### PR TITLE
release: 2.2.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bagel"
-version = "2.2.2"
+version = "2.2.3"
 description = "Bagel MCP Server"
 authors = []
 requires-python = ">=3.10,<3.13"

--- a/server.json
+++ b/server.json
@@ -12,7 +12,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/extelligence-ai/bagel/ros2-kilted:2.2.0",
+      "identifier": "ghcr.io/extelligence-ai/bagel/ros2-kilted:2.2.3",
       "transport": {
         "type": "sse",
         "url": "http://127.0.0.1:8000/sse"

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/Extelligence-ai/bagel",
     "source": "github"
   },
-  "version": "2.2.2",
+  "version": "2.2.3",
   "websiteUrl": "https://www.trybagel.com",
   "packages": [
     {

--- a/uv.lock
+++ b/uv.lock
@@ -222,7 +222,7 @@ wheels = [
 
 [[package]]
 name = "bagel"
-version = "2.2.2"
+version = "2.2.3"
 source = { virtual = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Patch release: ArduPilot dataflash logs report their real duration (#198) and `char[]` fields such as `MSG.Message` query as text (#199); Arrow cache keys now include the schema so type-mapping changes never serve stale files (#200).

Bumps `pyproject.toml`, `server.json`, `uv.lock` to 2.2.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Frad4zX5V73LvnypyggvkJ