### PR TITLE
feat(fleet): step 1 — opt-in group, kill switch, gate, beta image tags, boundary check

### DIFF
--- a/.github/workflows/dependency-audit.yaml
+++ b/.github/workflows/dependency-audit.yaml
@@ -15,6 +15,7 @@ on:
   pull_request:
     branches:
       - main
+      - "beta/**"
   schedule:
     - cron: "0 6 * * 1" # Monday 06:00 UTC
   workflow_dispatch:

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -46,3 +46,44 @@ jobs:
         run: sudo rm -rf /usr/share/dotnet /usr/local/lib/android /usr/lib/jvm
       - name: Build ${{ matrix.service }}
         run: docker compose build ${{ matrix.service }}
+
+  # Fleet streaming is opt-in per image (BAGEL_FLEET build arg). Build the
+  # opt-out variant of one image per Dockerfile and probe the gate inside the
+  # container, so the opt-out path cannot regress silently: the iot image must
+  # keep its MQTT client (the iot group ships it), while a ros2 image built
+  # without the fleet group must fail the gate with the typed error.
+  build-fleet-optout:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - service: iot
+            image: ghcr.io/extelligence-ai/bagel/iot:latest
+            paho: PAHO-PRESENT
+            gate: GATE-OPEN
+          - service: ros2-kilted
+            image: ghcr.io/extelligence-ai/bagel/ros2-kilted:latest
+            paho: PAHO-ABSENT
+            gate: FleetNotInstalledError
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Free disk space
+        run: sudo rm -rf /usr/share/dotnet /usr/local/lib/android /usr/lib/jvm
+      - name: Build ${{ matrix.service }} with BAGEL_FLEET=false
+        run: BAGEL_FLEET=false docker compose build ${{ matrix.service }}
+      - name: Probe MQTT client presence
+        run: |
+          out=$(docker run --rm --entrypoint uv "${{ matrix.image }}" run python -c \
+            "import importlib.util; print('PAHO-PRESENT' if importlib.util.find_spec('paho') else 'PAHO-ABSENT')")
+          echo "$out"
+          echo "$out" | grep -q "${{ matrix.paho }}"
+      - name: Probe the fleet gate
+        run: |
+          set +e
+          out=$(docker run --rm --entrypoint uv "${{ matrix.image }}" run python -c \
+            "from src.sink.publish import require_fleet; require_fleet(); print('GATE-OPEN')" 2>&1)
+          set -e
+          echo "$out"
+          echo "$out" | grep -q "${{ matrix.gate }}"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - "beta/**"
     types:
       - opened
       - synchronize

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -22,6 +22,8 @@ jobs:
       - uses: astral-sh/ruff-action@v3
         with:
           version-file: pyproject.toml
+      - name: Boundary rule (no vendor names in Bagel)
+        run: scripts/check_boundary.sh
 
   hadolint:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - "beta/**"
   # Manual re-run for dropped push events (2026-08-19: GitHub silently skipped
   # all workflows for a merge commit; images for that version never built).
   workflow_dispatch:
@@ -66,11 +67,20 @@ jobs:
             done
             docker push "$1"
           }
-          push_with_retry $IMAGE:latest
-          push_with_retry $IMAGE:$TAG
-          if docker manifest inspect "$IMAGE:$VERSION" >/dev/null 2>&1; then
-            echo "$IMAGE:$VERSION already published; leaving it untouched"
+          if [ "${GITHUB_REF_NAME}" = "main" ]; then
+            push_with_retry $IMAGE:latest
+            push_with_retry $IMAGE:$TAG
+            if docker manifest inspect "$IMAGE:$VERSION" >/dev/null 2>&1; then
+              echo "$IMAGE:$VERSION already published; leaving it untouched"
+            else
+              docker tag $IMAGE:latest $IMAGE:$VERSION
+              push_with_retry $IMAGE:$VERSION
+            fi
           else
-            docker tag $IMAGE:latest $IMAGE:$VERSION
-            push_with_retry $IMAGE:$VERSION
+            # Beta branches: pre-release tags only. Never touch latest or the
+            # immutable semver tag; each run gets its own beta number.
+            BETA="$IMAGE:${VERSION}-beta.${GITHUB_RUN_NUMBER}"
+            docker tag $IMAGE:latest "$BETA"
+            push_with_retry "$BETA"
+            push_with_retry $IMAGE:$TAG
           fi

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - "beta/**"
     types:
       - opened
       - synchronize
@@ -82,7 +83,7 @@ jobs:
       - name: Install dependencies
         # iot/automotive: hard imports in sink and message tests.
         # upload/viz: optional-dep tests skip without them; install so they run.
-        run: uv sync --group iot --group automotive --group upload --group viz
+        run: uv sync --group iot --group automotive --group upload --group viz --group fleet
       - name: Run host-side tests
         env:
           COVERAGE_FILE: .coverage.host

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,5 +40,7 @@ Instructions for AI agents asked to set up, use, or develop Bagel.
 - Every test file must be reachable by CI: `test/test_ci_reachability.py`
   fails the build otherwise (add new paths to `host-tests` or a Dockerfile).
 - Lint: `uv run ruff check` and `uv run ruff format` before committing.
+- Boundary rule: Bagel never names a specific fleet product; say "fleet
+  broker" / "fleet service". `scripts/check_boundary.sh` enforces it in CI.
 - Versioning: image tags and `server.json` follow `pyproject.toml`; published
   semver image tags are immutable (bump the version instead of retagging).

--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ control loop.
 - **Broad LLM support**: Claude Code, Gemini, Cursor, Codex, and more.
 - **Dockerized environments**: No local dependencies required.
 - **Extensible capabilities**: Bagel can learn [new tricks](#-teach-bagel-a-new-trick).
+- **Fleet streaming (beta)**: publish live channels, events, and heartbeats from the
+  edge to your own fleet broker. Landing incrementally on the `2.3.0-beta` image line;
+  opt out at build time with `BAGEL_FLEET=false`, or at runtime with `FLEET_ENABLED=0`.
 - **Wide format coverage**: Missing your data format? [Open a ticket](https://github.com/Extelligence-ai/bagel/issues).
 
 ## ⚡️ Quickstart

--- a/compose.yaml
+++ b/compose.yaml
@@ -14,6 +14,8 @@ services:
         JUPYTER_PORT: ${JUPYTER_PORT}
     environment:
       CONTAINER_MODE: true
+      # Runtime kill switch for fleet streaming (beta); build-time opt-out is BAGEL_FLEET.
+      FLEET_ENABLED: ${FLEET_ENABLED:-1}
       MCP_SERVER_PORT: ${MCP_SERVER_PORT}
       # Containers must listen on all container interfaces for Docker port
       # publishing; host-side exposure stays behind the 127.0.0.1 mapping.
@@ -53,6 +55,8 @@ services:
         JUPYTER_PORT: ${JUPYTER_PORT}
     environment:
       CONTAINER_MODE: true
+      # Runtime kill switch for fleet streaming (beta); build-time opt-out is BAGEL_FLEET.
+      FLEET_ENABLED: ${FLEET_ENABLED:-1}
       MCP_SERVER_PORT: ${MCP_SERVER_PORT}
       # Containers must listen on all container interfaces for Docker port
       # publishing; host-side exposure stays behind the 127.0.0.1 mapping.
@@ -92,6 +96,8 @@ services:
         JUPYTER_PORT: ${JUPYTER_PORT}
     environment:
       CONTAINER_MODE: true
+      # Runtime kill switch for fleet streaming (beta); build-time opt-out is BAGEL_FLEET.
+      FLEET_ENABLED: ${FLEET_ENABLED:-1}
       MCP_SERVER_PORT: ${MCP_SERVER_PORT}
       # Containers must listen on all container interfaces for Docker port
       # publishing; host-side exposure stays behind the 127.0.0.1 mapping.
@@ -131,6 +137,8 @@ services:
         JUPYTER_PORT: ${JUPYTER_PORT}
     environment:
       CONTAINER_MODE: true
+      # Runtime kill switch for fleet streaming (beta); build-time opt-out is BAGEL_FLEET.
+      FLEET_ENABLED: ${FLEET_ENABLED:-1}
       MCP_SERVER_PORT: ${MCP_SERVER_PORT}
       # Containers must listen on all container interfaces for Docker port
       # publishing; host-side exposure stays behind the 127.0.0.1 mapping.
@@ -169,6 +177,8 @@ services:
         JUPYTER_PORT: ${JUPYTER_PORT}
     environment:
       CONTAINER_MODE: true
+      # Runtime kill switch for fleet streaming (beta); build-time opt-out is BAGEL_FLEET.
+      FLEET_ENABLED: ${FLEET_ENABLED:-1}
       MCP_SERVER_PORT: ${MCP_SERVER_PORT}
       # Containers must listen on all container interfaces for Docker port
       # publishing; host-side exposure stays behind the 127.0.0.1 mapping.
@@ -205,6 +215,8 @@ services:
         JUPYTER_PORT: ${JUPYTER_PORT}
     environment:
       CONTAINER_MODE: true
+      # Runtime kill switch for fleet streaming (beta); build-time opt-out is BAGEL_FLEET.
+      FLEET_ENABLED: ${FLEET_ENABLED:-1}
       MCP_SERVER_PORT: ${MCP_SERVER_PORT}
       # Containers must listen on all container interfaces for Docker port
       # publishing; host-side exposure stays behind the 127.0.0.1 mapping.
@@ -240,6 +252,8 @@ services:
         JUPYTER_PORT: ${JUPYTER_PORT}
     environment:
       CONTAINER_MODE: true
+      # Runtime kill switch for fleet streaming (beta); build-time opt-out is BAGEL_FLEET.
+      FLEET_ENABLED: ${FLEET_ENABLED:-1}
       MCP_SERVER_PORT: ${MCP_SERVER_PORT}
       # Containers must listen on all container interfaces for Docker port
       # publishing; host-side exposure stays behind the 127.0.0.1 mapping.
@@ -275,6 +289,8 @@ services:
         JUPYTER_PORT: ${JUPYTER_PORT}
     environment:
       CONTAINER_MODE: true
+      # Runtime kill switch for fleet streaming (beta); build-time opt-out is BAGEL_FLEET.
+      FLEET_ENABLED: ${FLEET_ENABLED:-1}
       MCP_SERVER_PORT: ${MCP_SERVER_PORT}
       # Containers must listen on all container interfaces for Docker port
       # publishing; host-side exposure stays behind the 127.0.0.1 mapping.
@@ -310,6 +326,8 @@ services:
         JUPYTER_PORT: ${JUPYTER_PORT}
     environment:
       CONTAINER_MODE: true
+      # Runtime kill switch for fleet streaming (beta); build-time opt-out is BAGEL_FLEET.
+      FLEET_ENABLED: ${FLEET_ENABLED:-1}
       MCP_SERVER_PORT: ${MCP_SERVER_PORT}
       # Containers must listen on all container interfaces for Docker port
       # publishing; host-side exposure stays behind the 127.0.0.1 mapping.
@@ -345,6 +363,8 @@ services:
         JUPYTER_PORT: ${JUPYTER_PORT}
     environment:
       CONTAINER_MODE: true
+      # Runtime kill switch for fleet streaming (beta); build-time opt-out is BAGEL_FLEET.
+      FLEET_ENABLED: ${FLEET_ENABLED:-1}
       MCP_SERVER_PORT: ${MCP_SERVER_PORT}
       # Containers must listen on all container interfaces for Docker port
       # publishing; host-side exposure stays behind the 127.0.0.1 mapping.
@@ -381,6 +401,8 @@ services:
         JUPYTER_PORT: ${JUPYTER_PORT}
     environment:
       CONTAINER_MODE: true
+      # Runtime kill switch for fleet streaming (beta); build-time opt-out is BAGEL_FLEET.
+      FLEET_ENABLED: ${FLEET_ENABLED:-1}
       MCP_SERVER_PORT: ${MCP_SERVER_PORT}
       # Containers must listen on all container interfaces for Docker port
       # publishing; host-side exposure stays behind the 127.0.0.1 mapping.

--- a/compose.yaml
+++ b/compose.yaml
@@ -8,6 +8,7 @@ services:
         ROS_DISTRO: kilted
         UV_VERSION: 0.8.0
         DEV_MODE: false
+        BAGEL_FLEET: ${BAGEL_FLEET:-true}
         MCP_SERVER_PORT: ${MCP_SERVER_PORT}
         JUPYTER_HOST: ${JUPYTER_HOST}
         JUPYTER_PORT: ${JUPYTER_PORT}
@@ -46,6 +47,7 @@ services:
         ROS_DISTRO: jazzy
         UV_VERSION: 0.8.0
         DEV_MODE: false
+        BAGEL_FLEET: ${BAGEL_FLEET:-true}
         MCP_SERVER_PORT: ${MCP_SERVER_PORT}
         JUPYTER_HOST: ${JUPYTER_HOST}
         JUPYTER_PORT: ${JUPYTER_PORT}
@@ -84,6 +86,7 @@ services:
         ROS_DISTRO: iron
         UV_VERSION: 0.8.0
         DEV_MODE: false
+        BAGEL_FLEET: ${BAGEL_FLEET:-true}
         MCP_SERVER_PORT: ${MCP_SERVER_PORT}
         JUPYTER_HOST: ${JUPYTER_HOST}
         JUPYTER_PORT: ${JUPYTER_PORT}
@@ -122,6 +125,7 @@ services:
         ROS_DISTRO: humble
         UV_VERSION: 0.8.0
         DEV_MODE: false
+        BAGEL_FLEET: ${BAGEL_FLEET:-true}
         MCP_SERVER_PORT: ${MCP_SERVER_PORT}
         JUPYTER_HOST: ${JUPYTER_HOST}
         JUPYTER_PORT: ${JUPYTER_PORT}
@@ -371,6 +375,7 @@ services:
       args:
         UV_VERSION: 0.8.0
         DEV_MODE: false
+        BAGEL_FLEET: ${BAGEL_FLEET:-true}
         MCP_SERVER_PORT: ${MCP_SERVER_PORT}
         JUPYTER_HOST: ${JUPYTER_HOST}
         JUPYTER_PORT: ${JUPYTER_PORT}

--- a/docker/Dockerfile.iot
+++ b/docker/Dockerfile.iot
@@ -33,9 +33,10 @@ RUN /bin/bash -c "curl -LsSf https://astral.sh/uv/${UV_VERSION}/install.sh | sh 
 COPY --chown=${USERNAME}:${USERNAME} pyproject.toml ./
 COPY --chown=${USERNAME}:${USERNAME} uv.lock ./
 ARG DEV_MODE
-# Fleet streaming (beta) is opt-in per image: BAGEL_FLEET=false drops the
-# MQTT client from the container entirely.
+# Fleet streaming (beta) is opt-in per image: BAGEL_FLEET only controls the
+# fleet streaming extra -- the iot group already ships the MQTT client.
 ARG BAGEL_FLEET=true
+# hadolint ignore=SC2086
 RUN FLEET_GROUP=""; if [ "_${BAGEL_FLEET}" = "_true" ]; then FLEET_GROUP="--group fleet"; fi; \
     if [ "_${DEV_MODE}" = "_true" ]; then \
     uv sync --group iot ${FLEET_GROUP}; \

--- a/docker/Dockerfile.iot
+++ b/docker/Dockerfile.iot
@@ -33,10 +33,14 @@ RUN /bin/bash -c "curl -LsSf https://astral.sh/uv/${UV_VERSION}/install.sh | sh 
 COPY --chown=${USERNAME}:${USERNAME} pyproject.toml ./
 COPY --chown=${USERNAME}:${USERNAME} uv.lock ./
 ARG DEV_MODE
-RUN if [ "_${DEV_MODE}" = "_true" ]; then \
-    uv sync --group iot; \
+# Fleet streaming (beta) is opt-in per image: BAGEL_FLEET=false drops the
+# MQTT client from the container entirely.
+ARG BAGEL_FLEET=true
+RUN FLEET_GROUP=""; if [ "_${BAGEL_FLEET}" = "_true" ]; then FLEET_GROUP="--group fleet"; fi; \
+    if [ "_${DEV_MODE}" = "_true" ]; then \
+    uv sync --group iot ${FLEET_GROUP}; \
     else \
-    uv sync --no-dev --group iot; \
+    uv sync --no-dev --group iot ${FLEET_GROUP}; \
     fi
 
 # Pre-install the DuckDB postgres extension so TimescaleDB/Postgres sources

--- a/docker/Dockerfile.ros2
+++ b/docker/Dockerfile.ros2
@@ -45,6 +45,7 @@ ARG DEV_MODE
 # Fleet streaming (beta) is opt-in per image: BAGEL_FLEET=false drops the
 # MQTT client from the container entirely.
 ARG BAGEL_FLEET=true
+# hadolint ignore=SC2086
 RUN FLEET_GROUP=""; if [ "_${BAGEL_FLEET}" = "_true" ]; then FLEET_GROUP="--group fleet"; fi; \
     if [ "_${DEV_MODE}" = "_true" ]; then \
     uv sync --group ros2 ${FLEET_GROUP}; \

--- a/docker/Dockerfile.ros2
+++ b/docker/Dockerfile.ros2
@@ -42,10 +42,14 @@ RUN /bin/bash -c "curl -LsSf https://astral.sh/uv/${UV_VERSION}/install.sh | sh 
 COPY --chown=${USERNAME}:${USERNAME} pyproject.toml ./
 COPY --chown=${USERNAME}:${USERNAME} uv.lock ./
 ARG DEV_MODE
-RUN if [ "_${DEV_MODE}" = "_true" ]; then \
-    uv sync --group ros2; \
+# Fleet streaming (beta) is opt-in per image: BAGEL_FLEET=false drops the
+# MQTT client from the container entirely.
+ARG BAGEL_FLEET=true
+RUN FLEET_GROUP=""; if [ "_${BAGEL_FLEET}" = "_true" ]; then FLEET_GROUP="--group fleet"; fi; \
+    if [ "_${DEV_MODE}" = "_true" ]; then \
+    uv sync --group ros2 ${FLEET_GROUP}; \
     else \
-    uv sync --no-dev --group ros2; \
+    uv sync --no-dev --group ros2 ${FLEET_GROUP}; \
     fi
 
 # Expose MCP server port

--- a/plugin/references/settings-knobs.md
+++ b/plugin/references/settings-knobs.md
@@ -19,3 +19,5 @@ Defined in `settings.py`; set via the container environment or `.env`.
 | `MIN_ARROW_RECORD_BATCH_SIZE_COUNT` | 500 | Minimum records per arrow batch |
 | `ROSBRIDGE_QUEUE_LENGTH` | 1000 | Messages buffered in rosbridge before sending |
 | `CLOUDINI_ENABLED` | true | Cloudini pointcloud decompression in pipelines |
+| `FLEET_ENABLED` | 1 | Kill switch for fleet streaming (beta). `0` makes the publish subsystem inert: nothing connects, nothing leaves the box |
+| `BAGEL_FLEET` (build arg) | true | Compose build arg; `false` omits the MQTT client from the iot/ros2 images entirely |

--- a/plugin/references/settings-knobs.md
+++ b/plugin/references/settings-knobs.md
@@ -19,5 +19,5 @@ Defined in `settings.py`; set via the container environment or `.env`.
 | `MIN_ARROW_RECORD_BATCH_SIZE_COUNT` | 500 | Minimum records per arrow batch |
 | `ROSBRIDGE_QUEUE_LENGTH` | 1000 | Messages buffered in rosbridge before sending |
 | `CLOUDINI_ENABLED` | true | Cloudini pointcloud decompression in pipelines |
-| `FLEET_ENABLED` | 1 | Kill switch for fleet streaming (beta). `0` makes the publish subsystem inert: nothing connects, nothing leaves the box |
+| `FLEET_ENABLED` | true | Kill switch for fleet streaming (beta). `0` makes the publish subsystem inert: nothing connects, nothing leaves the box |
 | `BAGEL_FLEET` (build arg) | true | Compose build arg; `false` omits the MQTT client from the iot/ros2 images entirely |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ betaflight = ["orangebox >=0.4.0,<1.0.0"]
 cloudini = ["wasmtime >=26.0.0", "numpy >=1.24.0,<3.0.0"]
 iot = [
     "influxdb3-python>=0.10.0",
+    "paho-mqtt>=2.1.0,<3.0.0",
 ]
 fleet = [
     "paho-mqtt>=2.1.0,<3.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bagel"
-version = "2.2.3"
+version = "2.3.0"
 description = "Bagel MCP Server"
 authors = []
 requires-python = ">=3.10,<3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,8 @@ betaflight = ["orangebox >=0.4.0,<1.0.0"]
 cloudini = ["wasmtime >=26.0.0", "numpy >=1.24.0,<3.0.0"]
 iot = [
     "influxdb3-python>=0.10.0",
+]
+fleet = [
     "paho-mqtt>=2.1.0,<3.0.0",
 ]
 upload = [

--- a/scripts/check_boundary.sh
+++ b/scripts/check_boundary.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Boundary rule: Bagel speaks to a generic "fleet broker" / "fleet service" and
+# never names a specific fleet product in source, docs, settings or tool text.
+# Product-specific integration tests live in the product's own repo.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+# Case-insensitive; extend the alternation if a new vendor name must stay out.
+PATTERN='matcha'
+if hits=$(git grep -n -i -E "$PATTERN" -- ':!docs/**' ':!scripts/check_boundary.sh'); then
+  echo "Boundary rule violated (see AGENTS.md): vendor names are not allowed in Bagel." >&2
+  echo "$hits" >&2
+  exit 1
+fi
+echo "boundary check passed"

--- a/scripts/check_boundary.sh
+++ b/scripts/check_boundary.sh
@@ -5,7 +5,9 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 # Case-insensitive; extend the alternation if a new vendor name must stay out.
-PATTERN='matcha'
+# The term list is octal-encoded so the guarded names never appear in this
+# public tree (or its grep results) in plaintext.
+PATTERN="$(printf '\155\141\164\143\150\141')"
 if hits=$(git grep -n -i -E "$PATTERN" -- ':!docs/**' ':!scripts/check_boundary.sh'); then
   echo "Boundary rule violated (see AGENTS.md): vendor names are not allowed in Bagel." >&2
   echo "$hits" >&2

--- a/scripts/check_boundary.sh
+++ b/scripts/check_boundary.sh
@@ -8,7 +8,7 @@ cd "$(dirname "$0")/.."
 # The term list is octal-encoded so the guarded names never appear in this
 # public tree (or its grep results) in plaintext.
 PATTERN="$(printf '\155\141\164\143\150\141')"
-if hits=$(git grep -n -i -E "$PATTERN" -- ':!docs/**' ':!scripts/check_boundary.sh'); then
+if hits=$(git grep -n -i -E "$PATTERN" -- ':!scripts/check_boundary.sh'); then
   echo "Boundary rule violated (see AGENTS.md): vendor names are not allowed in Bagel." >&2
   echo "$hits" >&2
   exit 1

--- a/settings.py
+++ b/settings.py
@@ -80,6 +80,10 @@ class Settings(BaseSettings):
     # Whether to use cloudini for pointcloud compression/decompression by default
     CLOUDINI_ENABLED: bool = True
 
+    # Fleet streaming (beta). False makes the whole publish subsystem inert
+    # regardless of configuration: nothing connects, nothing leaves the box.
+    FLEET_ENABLED: bool = True
+
     # Default quantization resolution in meters for cloudini lossy compression
     CLOUDINI_DEFAULT_RESOLUTION: float = 0.001
     ###############################################

--- a/src/sink/publish/__init__.py
+++ b/src/sink/publish/__init__.py
@@ -1,0 +1,41 @@
+"""Fleet streaming: publish live channels, events and heartbeats to a fleet broker.
+
+This package is optional. ``require_fleet()`` is the single gate every fleet
+entry point calls first; it never imports the MQTT client at module import
+time so the rest of Bagel does not depend on it.
+"""
+
+from settings import settings
+
+INSTALL_HINT = (
+    "Fleet streaming is not installed in this image: the `fleet` dependency group "
+    "(paho-mqtt) is missing. Use an image built with `--group fleet`, or run "
+    "`uv sync --group fleet` in a source checkout."
+)
+
+
+class FleetNotInstalledError(Exception):
+    """Raised when the optional `fleet` dependency group is not installed."""
+
+
+class FleetDisabledError(Exception):
+    """Raised when FLEET_ENABLED=0 has switched the publish subsystem off."""
+
+
+def require_fleet() -> None:
+    """Check the kill switch, then that the MQTT client is importable.
+
+    Raises:
+        FleetDisabledError: if ``settings.FLEET_ENABLED`` is false.
+        FleetNotInstalledError: if ``paho`` cannot be imported.
+
+    """
+    if not settings.FLEET_ENABLED:
+        raise FleetDisabledError(
+            "Fleet streaming is disabled on this server (FLEET_ENABLED=0). "
+            "Set FLEET_ENABLED=1 and restart to use fleet tools."
+        )
+    try:
+        import paho.mqtt.client  # noqa: F401  (deferred: optional dependency)
+    except ImportError as exc:
+        raise FleetNotInstalledError(INSTALL_HINT) from exc

--- a/test/_fixtures/external.py
+++ b/test/_fixtures/external.py
@@ -1,4 +1,4 @@
-"""Locate optional external log fixtures (e.g. matcha-ext recordings).
+"""Locate optional external log fixtures (recordings kept outside this repo).
 
 Tests reach external recordings via ``BAGEL_EXTERNAL_FIXTURES`` and skip
 cleanly when it is unset or the path is missing — present locally, absent in CI.

--- a/test/e2e/test_known_anomalies.py
+++ b/test/e2e/test_known_anomalies.py
@@ -1,4 +1,4 @@
-"""Flows over external matcha-ext recordings with known anomalies."""
+"""Flows over external recordings with known anomalies."""
 
 import pathlib
 

--- a/test/sink/publish/test_gate.py
+++ b/test/sink/publish/test_gate.py
@@ -1,0 +1,57 @@
+"""The fleet gate: one function every fleet entry point calls first.
+
+It must never import paho at module import time (the rest of Bagel never pays
+for MQTT), must honor the FLEET_ENABLED kill switch, and must turn a missing
+optional dependency into a typed error with install guidance.
+"""
+
+import builtins
+import importlib
+import sys
+
+import pytest
+
+from settings import settings
+from src.sink import publish
+
+
+def test_disabled_wins_over_everything(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "FLEET_ENABLED", False)
+    with pytest.raises(publish.FleetDisabledError, match="FLEET_ENABLED"):
+        publish.require_fleet()
+
+
+def test_missing_paho_raises_typed_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "FLEET_ENABLED", True)
+    real_import = builtins.__import__
+
+    def fake_import(name: str, *args: object, **kwargs: object) -> object:
+        if name == "paho" or name.startswith("paho."):
+            raise ImportError("No module named 'paho'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.delitem(sys.modules, "paho", raising=False)
+    monkeypatch.delitem(sys.modules, "paho.mqtt", raising=False)
+    monkeypatch.delitem(sys.modules, "paho.mqtt.client", raising=False)
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    with pytest.raises(publish.FleetNotInstalledError, match="fleet"):
+        publish.require_fleet()
+
+
+def test_gate_passes_when_installed_and_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("paho")
+    monkeypatch.setattr(settings, "FLEET_ENABLED", True)
+    assert publish.require_fleet() is None
+
+
+def test_publish_package_does_not_import_paho_eagerly(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Importing src.sink.publish must not pull paho in; only require_fleet() does."""
+    for name in [m for m in sys.modules if m == "paho" or m.startswith("paho.")]:
+        monkeypatch.delitem(sys.modules, name)
+    monkeypatch.delitem(sys.modules, "src.sink.publish", raising=False)
+    importlib.import_module("src.sink.publish")
+    assert not any(m == "paho" or m.startswith("paho.") for m in sys.modules)
+
+
+def test_setting_default_is_enabled() -> None:
+    assert settings.model_fields["FLEET_ENABLED"].default is True

--- a/test/test_packaging.py
+++ b/test/test_packaging.py
@@ -1,0 +1,24 @@
+"""Packaging invariants for the optional fleet group."""
+
+import pathlib
+
+import tomllib
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+def _groups() -> dict[str, list[str]]:
+    return tomllib.loads((ROOT / "pyproject.toml").read_text())["dependency-groups"]
+
+
+def test_fleet_group_exists_with_only_the_mqtt_client() -> None:
+    fleet = _groups()["fleet"]
+    assert len(fleet) == 1
+    assert fleet[0].startswith("paho-mqtt")
+
+
+def test_fleet_group_is_opt_in_per_image() -> None:
+    for name in ("Dockerfile.iot", "Dockerfile.ros2"):
+        text = (ROOT / "docker" / name).read_text()
+        assert "ARG BAGEL_FLEET=true" in text, name
+        assert "--group fleet" in text, name

--- a/uv.lock
+++ b/uv.lock
@@ -284,6 +284,7 @@ fleet = [
 ]
 iot = [
     { name = "influxdb3-python" },
+    { name = "paho-mqtt" },
 ]
 px4 = [
     { name = "gitpython" },
@@ -360,7 +361,10 @@ dev = [
     { name = "ruff", specifier = "==0.12.4" },
 ]
 fleet = [{ name = "paho-mqtt", specifier = ">=2.1.0,<3.0.0" }]
-iot = [{ name = "influxdb3-python", specifier = ">=0.10.0" }]
+iot = [
+    { name = "influxdb3-python", specifier = ">=0.10.0" },
+    { name = "paho-mqtt", specifier = ">=2.1.0,<3.0.0" },
+]
 px4 = [
     { name = "gitpython", specifier = ">=3.1.0,<4.0.0" },
     { name = "pyulog", specifier = ">=1.2.0,<2.0.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -279,9 +279,11 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff" },
 ]
+fleet = [
+    { name = "paho-mqtt" },
+]
 iot = [
     { name = "influxdb3-python" },
-    { name = "paho-mqtt" },
 ]
 px4 = [
     { name = "gitpython" },
@@ -357,10 +359,8 @@ dev = [
     { name = "pytest-cov", specifier = ">=5.0.0,<7.0.0" },
     { name = "ruff", specifier = "==0.12.4" },
 ]
-iot = [
-    { name = "influxdb3-python", specifier = ">=0.10.0" },
-    { name = "paho-mqtt", specifier = ">=2.1.0,<3.0.0" },
-]
+fleet = [{ name = "paho-mqtt", specifier = ">=2.1.0,<3.0.0" }]
+iot = [{ name = "influxdb3-python", specifier = ">=0.10.0" }]
 px4 = [
     { name = "gitpython", specifier = ">=3.1.0,<4.0.0" },
     { name = "pyulog", specifier = ">=1.2.0,<2.0.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -222,7 +222,7 @@ wheels = [
 
 [[package]]
 name = "bagel"
-version = "2.2.3"
+version = "2.3.0"
 source = { virtual = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Step 1 of the fleet streaming design (beta branch).

- `fleet` dependency group (`paho-mqtt`), opt-in per image via `BAGEL_FLEET` build arg (iot, ros2 images).
- `FLEET_ENABLED` kill switch; `src/sink/publish/require_fleet()` gate raising typed `FleetDisabledError` / `FleetNotInstalledError`; the package never imports the MQTT client eagerly.
- `publish` workflow publishes `<version>-beta.<run>` images from `beta/**` (never `latest` or semver).
- `scripts/check_boundary.sh` in lint CI: no vendor names in Bagel.

No behavior change for anyone who does not use fleet tools; nothing connects anywhere yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Update (2026-08-31):** version on this line bumped to 2.3.0 (beta images publish as `2.3.0-beta.<run>`); fleet streaming is labeled beta in the README. Final-review fixes landed: paho-mqtt stays in the `iot` group per the design's optional-install rule, and the Dockerfiles carry hadolint SC2086 directives for the intentional word-splitting.