### PR TITLE
docs(test): describe external fixtures generically

### DIFF
--- a/test/_fixtures/external.py
+++ b/test/_fixtures/external.py
@@ -1,4 +1,4 @@
-"""Locate optional external log fixtures (e.g. matcha-ext recordings).
+"""Locate optional external log fixtures (recordings kept outside this repo).
 
 Tests reach external recordings via ``BAGEL_EXTERNAL_FIXTURES`` and skip
 cleanly when it is unset or the path is missing — present locally, absent in CI.

--- a/test/e2e/test_known_anomalies.py
+++ b/test/e2e/test_known_anomalies.py
@@ -1,4 +1,4 @@
-"""Flows over external matcha-ext recordings with known anomalies."""
+"""Flows over external recordings with known anomalies."""
 
 import pathlib
 


### PR DESCRIPTION
Rewords two test docstrings that named the private repo hosting optional
external recordings; the public tree now describes them generically
("external recordings"). No code or behavior change.

Same wording as the fleet branch (PR #203), so the eventual beta merge is
conflict-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
