### PR TITLE
feat(fleet): step 2 — streams manifest parsing with typed validation

### DIFF
--- a/.github/workflows/codex-gate.yaml
+++ b/.github/workflows/codex-gate.yaml
@@ -1,0 +1,62 @@
+name: codex-gate
+
+# Codex review is mandatory: this check passes only once the Codex cloud
+# reviewer has reviewed the PR's *current head commit*. When it hasn't, the
+# job posts the "@codex review" trigger (once per commit) and fails; Codex
+# submitting its review re-runs the gate via pull_request_review.
+#
+# Note: the auto-trigger comment is posted by github-actions[bot]; if the
+# Codex app ignores bot-authored triggers, comment "@codex review" manually
+# and the gate turns green when the review lands.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  codex-review-gate:
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require a Codex review of the head commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          reviewed_shas() {
+            {
+              gh api "repos/$REPO/pulls/$PR/reviews" --paginate \
+                --jq '.[] | select(.user.login == "chatgpt-codex-connector[bot]") | .body' || true
+              gh api "repos/$REPO/issues/$PR/comments" --paginate \
+                --jq '.[] | select(.user.login == "chatgpt-codex-connector[bot]") | .body' || true
+            } | grep -oE 'Reviewed commit:[^a-f0-9]*[a-f0-9]{7,40}' \
+              | grep -oE '[a-f0-9]{7,40}$' || true
+          }
+          for sha in $(reviewed_shas); do
+            case "$HEAD_SHA" in
+              "$sha"*)
+                echo "Codex reviewed the head commit ($sha)."
+                exit 0
+                ;;
+            esac
+          done
+          marker="<!-- codex-gate:$HEAD_SHA -->"
+          if gh api "repos/$REPO/issues/$PR/comments" --paginate --jq '.[].body' \
+               | grep -qF "$marker"; then
+            echo "Codex review already requested for $HEAD_SHA; waiting for it to land."
+          else
+            gh api -X POST "repos/$REPO/issues/$PR/comments" \
+              -f body="$(printf '@codex review\n\n%s' "$marker")" >/dev/null
+            echo "Requested a Codex review of $HEAD_SHA."
+          fi
+          echo "::error::Codex has not yet reviewed head commit $HEAD_SHA. The gate re-runs when its review is submitted."
+          exit 1

--- a/src/sink/publish/__init__.py
+++ b/src/sink/publish/__init__.py
@@ -22,6 +22,16 @@ class FleetDisabledError(Exception):
     """Raised when FLEET_ENABLED=0 has switched the publish subsystem off."""
 
 
+class StreamConfigError(Exception):
+    """Raised when the manifest's `streams:` section fails load-time validation."""
+
+    def __init__(self, field: str, reason: str) -> None:
+        """Initialize StreamConfigError with field and reason."""
+        self.field = field
+        self.reason = reason
+        super().__init__(f"streams config: {field}: {reason}")
+
+
 def require_fleet() -> None:
     """Check the kill switch, then that the MQTT client is importable.
 

--- a/src/sink/publish/config.py
+++ b/src/sink/publish/config.py
@@ -104,6 +104,9 @@ class ChannelRule(BaseModel):
                 f"{label}.as",
                 f"must map field paths to channel names: {renames}",
             )
+        unknown = set(config) - {"topic", "fields", "geo", "rate_hz", "as"}
+        if unknown:
+            raise StreamConfigError(label, f"unknown keys {sorted(unknown)}")
         return ChannelRule(
             topic=topic,
             fields=fields,
@@ -155,6 +158,17 @@ class EventRule(BaseModel):
                 f"{label}.artifact",
                 f"must be one of {ARTIFACT_KINDS}: {artifact!r}",
             )
+        unknown = set(config) - {
+            "name",
+            "topic",
+            "predicate",
+            "pre_seconds",
+            "post_seconds",
+            "debounce_seconds",
+            "artifact",
+        }
+        if unknown:
+            raise StreamConfigError(label, f"unknown keys {sorted(unknown)}")
         return EventRule(
             name=name,
             topic=topic,
@@ -174,6 +188,7 @@ class ResolvedChannel(BaseModel):
     unit: str | None = None
     source_topic: str
     source_field: str
+    rate_hz: float
     paths: dict[str, AccessPath]
 
 
@@ -181,11 +196,19 @@ def _stem(topic: str) -> str:
     return topic.rsplit("/", 1)[-1]
 
 
+def _check_renames(renames: dict[str, str], allowed: set[str], label: str) -> None:
+    """Reject a rename key that matches none of the rule's field paths."""
+    for key in renames:
+        if key not in allowed:
+            raise StreamConfigError(f"{label}.as", f"rename key '{key}' matches no field path")
+
+
 def _resolve_channel_rule(
     rule: ChannelRule, struct: pa.StructType, label: str
 ) -> list[ResolvedChannel]:
     resolved: list[ResolvedChannel] = []
     if rule.fields is not None:
+        _check_renames(rule.renames, set(rule.fields), label)
         for field_path in rule.fields:
             ap = resolve_path(struct, field_path, field_label=f"{label}.fields")
             try:
@@ -199,10 +222,12 @@ def _resolve_channel_rule(
                     type=type_name,
                     source_topic=rule.topic,
                     source_field=field_path,
+                    rate_hz=rule.rate_hz,
                     paths={"value": ap},
                 )
             )
     else:
+        _check_renames(rule.renames, {"geo"}, label)
         paths: dict[str, AccessPath] = {}
         for key, dotted in rule.geo.items():
             ap = resolve_path(struct, dotted, field_label=f"{label}.geo.{key}")
@@ -219,6 +244,7 @@ def _resolve_channel_rule(
                 type="geo",
                 source_topic=rule.topic,
                 source_field=",".join(f"{k}={v}" for k, v in sorted(rule.geo.items())),
+                rate_hz=rule.rate_hz,
                 paths=paths,
             )
         )
@@ -249,13 +275,20 @@ class StreamsConfig(BaseModel):
         flush = config.get("flush_interval_s", 1.0)
         if not isinstance(flush, int | float) or isinstance(flush, bool) or flush <= 0:
             raise StreamConfigError("streams.flush_interval_s", f"must be > 0: {flush!r}")
+        raw_channels = config.get("channels", [])
+        if raw_channels is None:
+            raw_channels = []
+        elif not isinstance(raw_channels, list):
+            raise StreamConfigError("streams.channels", f"must be a list: {raw_channels!r}")
         channels = [
-            ChannelRule.build(c, label=f"channels[{i}]")
-            for i, c in enumerate(config.get("channels", []))
+            ChannelRule.build(c, label=f"channels[{i}]") for i, c in enumerate(raw_channels)
         ]
-        events = [
-            EventRule.build(e, label=f"events[{i}]") for i, e in enumerate(config.get("events", []))
-        ]
+        raw_events = config.get("events", [])
+        if raw_events is None:
+            raw_events = []
+        elif not isinstance(raw_events, list):
+            raise StreamConfigError("streams.events", f"must be a list: {raw_events!r}")
+        events = [EventRule.build(e, label=f"events[{i}]") for i, e in enumerate(raw_events)]
         return StreamsConfig(
             broker=broker,
             flush_interval_s=float(flush),

--- a/src/sink/publish/config.py
+++ b/src/sink/publish/config.py
@@ -43,8 +43,50 @@ def resolve_path(struct: pa.StructType, dotted: str, *, field_label: str) -> Acc
     return AccessPath(path=walked, pa_type=current)
 
 
+def field_unit(struct: pa.StructType, dotted: str) -> str | None:
+    """Return the Arrow field metadata unit (key "unit") for a dotted path, if present.
+
+    Assumes ``dotted`` already resolves against ``struct`` (call after
+    ``resolve_path`` succeeds); an unresolvable path yields ``None`` rather
+    than raising, since unit metadata is decorative, not load-bearing.
+    """
+    current: pa.DataType = struct
+    field: pa.Field | None = None
+    for segment in dotted.split("."):
+        if not pat.is_struct(current):
+            return None
+        index = current.get_field_index(segment)
+        if index == -1:
+            return None
+        field = current.field(index)
+        current = field.type
+    if field is None or field.metadata is None:
+        return None
+    value = field.metadata.get(b"unit")
+    if value is None:
+        return None
+    return value.decode() if isinstance(value, bytes) else value
+
+
 MAX_RATE_HZ = 50.0
 ARTIFACT_KINDS = ("mcap",)
+
+
+def _validate_geo(geo: object, label: str) -> None:
+    """Validate a `geo:` mapping's keys and dotted-path string values."""
+    if not isinstance(geo, dict) or not {"lat", "lon"} <= set(geo):
+        raise StreamConfigError(
+            f"{label}.geo",
+            f"requires 'lat' and 'lon' dotted paths: {geo}",
+        )
+    unknown = set(geo) - {"lat", "lon", "alt"}
+    if unknown:
+        raise StreamConfigError(f"{label}.geo", f"unknown keys {sorted(unknown)}")
+    for key, value in geo.items():
+        if not isinstance(value, str) or not value:
+            raise StreamConfigError(
+                f"{label}.geo", f"path for '{key}' must be a dotted string: {value!r}"
+            )
 
 
 class ChannelRule(BaseModel):
@@ -78,14 +120,7 @@ class ChannelRule(BaseModel):
                 f"must be a non-empty list of strings: {fields}",
             )
         if geo is not None:
-            if not isinstance(geo, dict) or not {"lat", "lon"} <= set(geo):
-                raise StreamConfigError(
-                    f"{label}.geo",
-                    f"requires 'lat' and 'lon' dotted paths: {geo}",
-                )
-            unknown = set(geo) - {"lat", "lon", "alt"}
-            if unknown:
-                raise StreamConfigError(f"{label}.geo", f"unknown keys {sorted(unknown)}")
+            _validate_geo(geo, label)
         rate = rest.get("rate_hz")
         if (
             not isinstance(rate, int | float)
@@ -220,6 +255,7 @@ def _resolve_channel_rule(
                 ResolvedChannel(
                     name=name,
                     type=type_name,
+                    unit=field_unit(struct, field_path),
                     source_topic=rule.topic,
                     source_field=field_path,
                     rate_hz=rule.rate_hz,

--- a/src/sink/publish/config.py
+++ b/src/sink/publish/config.py
@@ -5,8 +5,11 @@ Two phases: `load_streams` turns raw YAML into models (shape validation);
 (field existence, scalar-ness, wire types). No runtime behavior lives here.
 """
 
+from urllib.parse import urlparse
+
 import pyarrow as pa
 import pyarrow.types as pat
+from pydantic import BaseModel
 
 from src.message.base import AccessPath
 from src.sink.publish import StreamConfigError
@@ -38,3 +41,163 @@ def resolve_path(struct: pa.StructType, dotted: str, *, field_label: str) -> Acc
         current = current.field(index).type
         walked.append(segment)
     return AccessPath(path=walked, pa_type=current)
+
+
+MAX_RATE_HZ = 50.0
+ARTIFACT_KINDS = ("mcap",)
+
+
+class ChannelRule(BaseModel):
+    """One `channels:` entry: project fields of a topic at a capped rate."""
+
+    topic: str
+    fields: list[str] | None = None
+    geo: dict[str, str] | None = None
+    rate_hz: float
+    renames: dict[str, str] = {}
+
+    @staticmethod
+    def build(config: dict, label: str = "channels[]") -> "ChannelRule":
+        """Build and validate a channel rule from config dict."""
+        match config:
+            case {"topic": str(topic), **rest}:
+                pass
+            case _:
+                raise StreamConfigError(f"{label}.topic", f"missing or non-string topic: {config}")
+        fields = rest.get("fields")
+        geo = rest.get("geo")
+        if (fields is None) == (geo is None):
+            raise StreamConfigError(label, "exactly one of 'fields' or 'geo' is required")
+        if fields is not None and (
+            not isinstance(fields, list)
+            or not fields
+            or not all(isinstance(f, str) for f in fields)
+        ):
+            raise StreamConfigError(
+                f"{label}.fields",
+                f"must be a non-empty list of strings: {fields}",
+            )
+        if geo is not None:
+            if not isinstance(geo, dict) or not {"lat", "lon"} <= set(geo):
+                raise StreamConfigError(
+                    f"{label}.geo",
+                    f"requires 'lat' and 'lon' dotted paths: {geo}",
+                )
+            unknown = set(geo) - {"lat", "lon", "alt"}
+            if unknown:
+                raise StreamConfigError(f"{label}.geo", f"unknown keys {sorted(unknown)}")
+        rate = rest.get("rate_hz")
+        if (
+            not isinstance(rate, int | float)
+            or isinstance(rate, bool)
+            or not 0 < rate <= MAX_RATE_HZ
+        ):
+            raise StreamConfigError(
+                f"{label}.rate_hz",
+                f"must be in (0, {MAX_RATE_HZ:g}]: {rate!r}",
+            )
+        renames = rest.get("as", {})
+        if not isinstance(renames, dict) or not all(
+            isinstance(k, str) and isinstance(v, str) for k, v in renames.items()
+        ):
+            raise StreamConfigError(
+                f"{label}.as",
+                f"must map field paths to channel names: {renames}",
+            )
+        return ChannelRule(
+            topic=topic,
+            fields=fields,
+            geo=geo,
+            rate_hz=float(rate),
+            renames=renames,
+        )
+
+
+class EventRule(BaseModel):
+    """One `events:` entry: a named predicate with capture windows."""
+
+    name: str
+    topic: str
+    predicate: str
+    pre_seconds: float = 0.0
+    post_seconds: float = 0.0
+    debounce_seconds: float = 0.0
+    artifact: str | None = None
+
+    @staticmethod
+    def build(config: dict, label: str = "events[]") -> "EventRule":
+        """Build and validate an event rule from config dict."""
+        match config:
+            case {
+                "name": str(name),
+                "topic": str(topic),
+                "predicate": str(predicate),
+                **rest,
+            }:
+                pass
+            case _:
+                raise StreamConfigError(
+                    label,
+                    f"requires string 'name', 'topic' and 'predicate': {config}",
+                )
+        windows = {}
+        for key in ("pre_seconds", "post_seconds", "debounce_seconds"):
+            value = rest.get(key, 0.0)
+            if not isinstance(value, int | float) or isinstance(value, bool) or value < 0:
+                raise StreamConfigError(
+                    f"{label}.{key}",
+                    f"must be a non-negative number: {value!r}",
+                )
+            windows[key] = float(value)
+        artifact = rest.get("artifact")
+        if artifact is not None and artifact not in ARTIFACT_KINDS:
+            raise StreamConfigError(
+                f"{label}.artifact",
+                f"must be one of {ARTIFACT_KINDS}: {artifact!r}",
+            )
+        return EventRule(
+            name=name,
+            topic=topic,
+            predicate=predicate,
+            artifact=artifact,
+            **windows,
+        )
+
+
+class StreamsConfig(BaseModel):
+    """The whole `streams:` manifest section, shape-validated."""
+
+    broker: str | None = None
+    flush_interval_s: float = 1.0
+    channels: list[ChannelRule] = []
+    events: list[EventRule] = []
+
+    @staticmethod
+    def build(config: dict) -> "StreamsConfig":
+        """Build and validate streams config from dict."""
+        if not isinstance(config, dict):
+            raise StreamConfigError("streams", f"must be a mapping: {config!r}")
+        broker = config.get("broker")
+        if broker is not None:
+            parsed = urlparse(str(broker))
+            if parsed.scheme not in ("mqtt", "mqtts") or not parsed.hostname:
+                raise StreamConfigError(
+                    "streams.broker",
+                    f"must be an mqtt:// or mqtts:// URL with a host: {broker!r}",
+                )
+        flush = config.get("flush_interval_s", 1.0)
+        if not isinstance(flush, int | float) or isinstance(flush, bool) or flush <= 0:
+            raise StreamConfigError("streams.flush_interval_s", f"must be > 0: {flush!r}")
+        channels = [
+            ChannelRule.build(c, label=f"channels[{i}]")
+            for i, c in enumerate(config.get("channels", []))
+        ]
+        events = [
+            EventRule.build(e, label=f"events[{i}]") for i, e in enumerate(config.get("events", []))
+        ]
+        return StreamsConfig(
+            broker=broker,
+            flush_interval_s=float(flush),
+            channels=channels,
+            events=events,
+        )

--- a/src/sink/publish/config.py
+++ b/src/sink/publish/config.py
@@ -9,7 +9,7 @@ from urllib.parse import urlparse
 
 import pyarrow as pa
 import pyarrow.types as pat
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from src.message.base import AccessPath
 from src.sink.publish import StreamConfigError
@@ -164,6 +164,67 @@ class EventRule(BaseModel):
         )
 
 
+class ResolvedChannel(BaseModel):
+    """A channel rule bound to a topic's Arrow schema — schema-payload-ready."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    name: str
+    type: str
+    unit: str | None = None
+    source_topic: str
+    source_field: str
+    paths: dict[str, AccessPath]
+
+
+def _stem(topic: str) -> str:
+    return topic.rsplit("/", 1)[-1]
+
+
+def _resolve_channel_rule(
+    rule: ChannelRule, struct: pa.StructType, label: str
+) -> list[ResolvedChannel]:
+    resolved: list[ResolvedChannel] = []
+    if rule.fields is not None:
+        for field_path in rule.fields:
+            ap = resolve_path(struct, field_path, field_label=f"{label}.fields")
+            try:
+                type_name = classify(ap.pa_type)
+            except ValueError as exc:
+                raise StreamConfigError(f"{label}.fields", str(exc)) from exc
+            name = rule.renames.get(field_path, f"{_stem(rule.topic)}.{field_path}")
+            resolved.append(
+                ResolvedChannel(
+                    name=name,
+                    type=type_name,
+                    source_topic=rule.topic,
+                    source_field=field_path,
+                    paths={"value": ap},
+                )
+            )
+    else:
+        paths: dict[str, AccessPath] = {}
+        for key, dotted in rule.geo.items():
+            ap = resolve_path(struct, dotted, field_label=f"{label}.geo.{key}")
+            try:
+                if classify(ap.pa_type) != "number":
+                    raise ValueError(f"geo '{key}' must resolve to a number, got {ap.pa_type}")
+            except ValueError as exc:
+                raise StreamConfigError(f"{label}.geo.{key}", str(exc)) from exc
+            paths[key] = ap
+        name = rule.renames.get("geo", f"{_stem(rule.topic)}.geo")
+        resolved.append(
+            ResolvedChannel(
+                name=name,
+                type="geo",
+                source_topic=rule.topic,
+                source_field=",".join(f"{k}={v}" for k, v in sorted(rule.geo.items())),
+                paths=paths,
+            )
+        )
+    return resolved
+
+
 class StreamsConfig(BaseModel):
     """The whole `streams:` manifest section, shape-validated."""
 
@@ -201,3 +262,25 @@ class StreamsConfig(BaseModel):
             channels=channels,
             events=events,
         )
+
+    def resolve(self, structs: dict[str, pa.StructType]) -> list[ResolvedChannel]:
+        """Resolve channel rules against topic schemas."""
+        out: list[ResolvedChannel] = []
+        for i, rule in enumerate(self.channels):
+            label = f"channels[{i}]"
+            if rule.topic not in structs:
+                raise StreamConfigError(f"{label}.topic", f"unknown topic '{rule.topic}'")
+            out.extend(_resolve_channel_rule(rule, structs[rule.topic], label))
+        seen: set[str] = set()
+        for channel in out:
+            if channel.name in seen:
+                raise StreamConfigError("channels", f"duplicate channel name '{channel.name}'")
+            seen.add(channel.name)
+        return out
+
+
+def load_streams(manifest: dict) -> StreamsConfig | None:
+    """Parse the `streams:` section of the startup manifest, if present."""
+    if not isinstance(manifest, dict) or "streams" not in manifest:
+        return None
+    return StreamsConfig.build(manifest["streams"])

--- a/src/sink/publish/config.py
+++ b/src/sink/publish/config.py
@@ -1,0 +1,40 @@
+"""Parse and validate the manifest's `streams:` section (fleet streaming).
+
+Two phases: `load_streams` turns raw YAML into models (shape validation);
+`StreamsConfig.resolve` binds channel rules to a topic's Arrow schema
+(field existence, scalar-ness, wire types). No runtime behavior lives here.
+"""
+
+import pyarrow as pa
+import pyarrow.types as pat
+
+from src.message.base import AccessPath
+from src.sink.publish import StreamConfigError
+
+
+def classify(pa_type: pa.DataType) -> str:
+    """Wire-contract type name for a scalar Arrow type (spec §3)."""
+    if pat.is_integer(pa_type) or pat.is_floating(pa_type):
+        return "number"
+    if pat.is_boolean(pa_type):
+        return "bool"
+    if pat.is_string(pa_type) or pat.is_large_string(pa_type):
+        return "string"
+    raise ValueError(f"{pa_type} is not a streamable scalar")
+
+
+def resolve_path(struct: pa.StructType, dotted: str, *, field_label: str) -> AccessPath:
+    """Walk a dotted path through nested structs to its leaf type."""
+    current: pa.DataType = struct
+    walked: list[str] = []
+    for segment in dotted.split("."):
+        if not pat.is_struct(current):
+            raise StreamConfigError(
+                field_label, f"'{'.'.join(walked)}' is not a struct; cannot descend to '{segment}'"
+            )
+        index = current.get_field_index(segment)
+        if index == -1:
+            raise StreamConfigError(field_label, f"unknown field '{segment}' in '{dotted}'")
+        current = current.field(index).type
+        walked.append(segment)
+    return AccessPath(path=walked, pa_type=current)

--- a/test/sink/conftest.py
+++ b/test/sink/conftest.py
@@ -6,89 +6,99 @@ from types import SimpleNamespace
 
 import pytest
 
-pytest.importorskip("paho")
-
-from settings import settings
-from src.sink import base as sink_base
-from src.sink import mqtt
-
-
-class FakePahoClient:
-    """A stand-in for paho.Client that delivers configured retained messages."""
-
-    def __init__(self, callback_api_version: object = None, client_id: str | None = None) -> None:
-        self.on_message = None
-        self.retained: dict[str, list[bytes]] = {}
-        self.subscriptions: list[str] = []
-        self.topic_callbacks: dict[str, object] = {}
-        self._connected = False
-
-    # -- connection ------------------------------------------------------------
-    def username_pw_set(self, username: str, password: str | None = None) -> None:
-        pass
-
-    def is_connected(self) -> bool:
-        return self._connected
-
-    def connect(self, host: str, port: int, keepalive: int = 60) -> None:
-        self._connected = True
-
-    def loop_start(self) -> None:
-        pass
-
-    def loop_stop(self) -> None:
-        pass
-
-    def disconnect(self) -> None:
-        self._connected = False
-
-    # -- pub/sub ----------------------------------------------------------------
-    def subscribe(self, topic: str) -> None:
-        self.subscriptions.append(topic)
-        # Deliver retained messages synchronously, like a broker on subscribe.
-        for retained_topic, payloads in self.retained.items():
-            if topic in (mqtt.DISCOVERY_WILDCARD, retained_topic):
-                for payload in payloads:
-                    self.deliver(retained_topic, payload)
-
-    def unsubscribe(self, topic: str) -> None:
-        self.subscriptions = [s for s in self.subscriptions if s != topic]
-
-    def message_callback_add(self, topic: str, callback: object) -> None:
-        self.topic_callbacks[topic] = callback
-
-    def message_callback_remove(self, topic: str) -> None:
-        self.topic_callbacks.pop(topic, None)
-
-    def deliver(self, topic: str, payload: bytes) -> None:
-        """Simulate a message arriving from the broker."""
-        message = SimpleNamespace(topic=topic, payload=payload)
-        if topic in self.topic_callbacks:
-            self.topic_callbacks[topic](self, None, message)
-        elif self.on_message is not None:
-            self.on_message(self, None, message)
+try:
+    import paho.mqtt.client
+except ImportError:
+    paho = None
+else:
+    from settings import settings
+    from src.sink import base as sink_base
+    from src.sink import mqtt
 
 
-_PORT_COUNTER = iter(range(20000, 30000))
+if paho is not None:
 
-MakeSink = Callable[..., "mqtt.TopicSink"]
+    class FakePahoClient:
+        """A stand-in for paho.Client that delivers configured retained messages."""
 
+        def __init__(
+            self, callback_api_version: object = None, client_id: str | None = None
+        ) -> None:
+            self.on_message = None
+            self.retained: dict[str, list[bytes]] = {}
+            self.subscriptions: list[str] = []
+            self.topic_callbacks: dict[str, object] = {}
+            self._connected = False
 
-@pytest.fixture
-def make_sink(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[MakeSink]:
-    """Build an MQTT sink wired to a FakePahoClient, isolated per test."""
-    monkeypatch.setattr(settings, "CACHE_DIRECTORY", str(tmp_path / "cache"))
-    sink_base._global_sink_singletons.clear()
+        # -- connection --------------------------------------------------------
+        def username_pw_set(self, username: str, password: str | None = None) -> None:
+            pass
 
-    def _make(retained: dict[str, list[bytes]] | None = None, **kwargs: object) -> mqtt.TopicSink:
-        fake = FakePahoClient()
-        fake.retained = retained or {}
-        monkeypatch.setattr(mqtt.paho, "Client", lambda **_: fake)
-        sink = mqtt.TopicSink(
-            host="broker.test", port=next(_PORT_COUNTER), discovery_seconds=0.0, **kwargs
-        )
-        sink._fake = fake  # expose for assertions/injection
-        return sink
+        def is_connected(self) -> bool:
+            return self._connected
 
-    yield _make
-    sink_base._global_sink_singletons.clear()
+        def connect(self, host: str, port: int, keepalive: int = 60) -> None:
+            self._connected = True
+
+        def loop_start(self) -> None:
+            pass
+
+        def loop_stop(self) -> None:
+            pass
+
+        def disconnect(self) -> None:
+            self._connected = False
+
+        # -- pub/sub -------------------------------------------------------
+        def subscribe(self, topic: str) -> None:
+            self.subscriptions.append(topic)
+            # Deliver retained messages synchronously, like a broker on subscribe.
+            for retained_topic, payloads in self.retained.items():
+                if topic in (mqtt.DISCOVERY_WILDCARD, retained_topic):
+                    for payload in payloads:
+                        self.deliver(retained_topic, payload)
+
+        def unsubscribe(self, topic: str) -> None:
+            self.subscriptions = [s for s in self.subscriptions if s != topic]
+
+        def message_callback_add(self, topic: str, callback: object) -> None:
+            self.topic_callbacks[topic] = callback
+
+        def message_callback_remove(self, topic: str) -> None:
+            self.topic_callbacks.pop(topic, None)
+
+        def deliver(self, topic: str, payload: bytes) -> None:
+            """Simulate a message arriving from the broker."""
+            message = SimpleNamespace(topic=topic, payload=payload)
+            if topic in self.topic_callbacks:
+                self.topic_callbacks[topic](self, None, message)
+            elif self.on_message is not None:
+                self.on_message(self, None, message)
+
+    _PORT_COUNTER = iter(range(20000, 30000))
+
+    MakeSink = Callable[..., "mqtt.TopicSink"]
+
+    @pytest.fixture
+    def make_sink(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[MakeSink]:
+        """Build an MQTT sink wired to a FakePahoClient, isolated per test."""
+        monkeypatch.setattr(settings, "CACHE_DIRECTORY", str(tmp_path / "cache"))
+        sink_base._global_sink_singletons.clear()
+
+        def _make(
+            retained: dict[str, list[bytes]] | None = None, **kwargs: object
+        ) -> mqtt.TopicSink:
+            fake = FakePahoClient()
+            fake.retained = retained or {}
+            monkeypatch.setattr(mqtt.paho, "Client", lambda **_: fake)
+            sink = mqtt.TopicSink(
+                host="broker.test",
+                port=next(_PORT_COUNTER),
+                discovery_seconds=0.0,
+                **kwargs,
+            )
+            sink._fake = fake  # expose for assertions/injection
+            return sink
+
+        yield _make
+        sink_base._global_sink_singletons.clear()

--- a/test/sink/publish/test_config.py
+++ b/test/sink/publish/test_config.py
@@ -1,0 +1,81 @@
+"""Streams config: typed validation of the manifest's `streams:` section.
+
+Load-time failures are StreamConfigError(field, reason). Predicate strings
+are deliberately NOT validated here (SQL predicates surface errors at first
+evaluation, matching src/pipeline/gates/sql.py convention).
+"""
+
+import pyarrow as pa
+import pytest
+
+from src.sink.publish import StreamConfigError, config
+
+IMU = pa.struct(
+    [
+        pa.field(
+            "linear_acceleration",
+            pa.struct([pa.field("x", pa.float64()), pa.field("y", pa.float64())]),
+        ),
+        pa.field("frame_id", pa.string()),
+        pa.field("calibrated", pa.bool_()),
+        pa.field("readings", pa.list_(pa.float64())),
+    ]
+)
+
+
+class TestStreamConfigError:
+    def test_carries_field_and_reason(self) -> None:
+        e = StreamConfigError("channels[0].fields", "unknown field 'z'")
+        assert e.field == "channels[0].fields"
+        assert e.reason == "unknown field 'z'"
+        assert str(e) == "streams config: channels[0].fields: unknown field 'z'"
+
+
+class TestResolvePath:
+    def test_nested_scalar_resolves(self) -> None:
+        ap = config.resolve_path(IMU, "linear_acceleration.x", field_label="f")
+        assert ap.path == ["linear_acceleration", "x"]
+        assert ap.pa_type == pa.float64()
+
+    def test_top_level_scalar_resolves(self) -> None:
+        ap = config.resolve_path(IMU, "frame_id", field_label="f")
+        assert ap.path == ["frame_id"]
+        assert ap.pa_type == pa.string()
+
+    def test_unknown_segment_raises(self) -> None:
+        with pytest.raises(StreamConfigError, match="unknown field 'z'"):
+            config.resolve_path(IMU, "linear_acceleration.z", field_label="channels[0].fields")
+
+    def test_traversing_through_scalar_raises(self) -> None:
+        with pytest.raises(StreamConfigError, match="not a struct"):
+            config.resolve_path(IMU, "frame_id.sub", field_label="f")
+
+
+class TestClassify:
+    @pytest.mark.parametrize(
+        ("pa_type", "expected"),
+        [
+            (pa.float64(), "number"),
+            (pa.float32(), "number"),
+            (pa.int32(), "number"),
+            (pa.uint8(), "number"),
+            (pa.bool_(), "bool"),
+            (pa.string(), "string"),
+            (pa.large_string(), "string"),
+        ],
+    )
+    def test_scalars(self, pa_type: pa.DataType, expected: str) -> None:
+        assert config.classify(pa_type) == expected
+
+    @pytest.mark.parametrize(
+        "pa_type",
+        [
+            pa.list_(pa.float64()),
+            pa.struct([pa.field("a", pa.int8())]),
+            pa.binary(),
+            pa.timestamp("us"),
+        ],
+    )
+    def test_non_scalars_raise(self, pa_type: pa.DataType) -> None:
+        with pytest.raises(ValueError, match="not a streamable scalar"):
+            config.classify(pa_type)

--- a/test/sink/publish/test_config.py
+++ b/test/sink/publish/test_config.py
@@ -79,3 +79,140 @@ class TestClassify:
     def test_non_scalars_raise(self, pa_type: pa.DataType) -> None:
         with pytest.raises(ValueError, match="not a streamable scalar"):
             config.classify(pa_type)
+
+
+class TestChannelRule:
+    def test_fields_rule_builds(self) -> None:
+        r = config.ChannelRule.build(
+            {"topic": "/imu", "fields": ["linear_acceleration.x"], "rate_hz": 5}
+        )
+        assert r.topic == "/imu"
+        assert r.fields == ["linear_acceleration.x"]
+        assert r.rate_hz == 5.0
+        assert r.renames == {}
+
+    def test_geo_rule_builds_with_rename(self) -> None:
+        r = config.ChannelRule.build(
+            {
+                "topic": "/odom",
+                "geo": {"lat": "pose.x", "lon": "pose.y"},
+                "rate_hz": 1,
+                "as": {"geo": "position"},
+            }
+        )
+        assert r.geo == {"lat": "pose.x", "lon": "pose.y"}
+        assert r.renames == {"geo": "position"}
+
+    @pytest.mark.parametrize("rate", [0, -1, 50.001, 1000])
+    def test_rate_out_of_range_raises(self, rate: int | float) -> None:
+        with pytest.raises(StreamConfigError, match="rate_hz"):
+            config.ChannelRule.build({"topic": "/imu", "fields": ["a"], "rate_hz": rate})
+
+    def test_rate_of_exactly_50_is_allowed(self) -> None:
+        assert (
+            config.ChannelRule.build({"topic": "/t", "fields": ["a"], "rate_hz": 50}).rate_hz
+            == 50.0
+        )
+
+    def test_fields_and_geo_together_raise(self) -> None:
+        with pytest.raises(StreamConfigError, match="exactly one of"):
+            config.ChannelRule.build(
+                {"topic": "/t", "fields": ["a"], "geo": {"lat": "a", "lon": "b"}, "rate_hz": 1}
+            )
+
+    def test_neither_fields_nor_geo_raises(self) -> None:
+        with pytest.raises(StreamConfigError, match="exactly one of"):
+            config.ChannelRule.build({"topic": "/t", "rate_hz": 1})
+
+    def test_geo_missing_lon_raises(self) -> None:
+        with pytest.raises(StreamConfigError, match="lat.*lon|lon"):
+            config.ChannelRule.build({"topic": "/t", "geo": {"lat": "a"}, "rate_hz": 1})
+
+    def test_missing_topic_raises(self) -> None:
+        with pytest.raises(StreamConfigError, match="topic"):
+            config.ChannelRule.build({"fields": ["a"], "rate_hz": 1})
+
+
+class TestEventRule:
+    def test_full_event_builds(self) -> None:
+        e = config.EventRule.build(
+            {
+                "name": "hard_decel",
+                "topic": "/imu",
+                "predicate": "\"/imu\"['linear_acceleration']['x'] < -10",
+                "pre_seconds": 10,
+                "post_seconds": 10,
+                "debounce_seconds": 2,
+                "artifact": "mcap",
+            }
+        )
+        assert e.name == "hard_decel"
+        assert e.artifact == "mcap"
+
+    def test_minimal_event_builds(self) -> None:
+        e = config.EventRule.build({"name": "n", "topic": "/t", "predicate": "true"})
+        assert e.pre_seconds == 0.0 and e.artifact is None
+
+    def test_unknown_artifact_kind_raises(self) -> None:
+        with pytest.raises(StreamConfigError, match="artifact"):
+            config.EventRule.build(
+                {"name": "n", "topic": "/t", "predicate": "true", "artifact": "avi"}
+            )
+
+    def test_negative_window_raises(self) -> None:
+        with pytest.raises(StreamConfigError, match="pre_seconds"):
+            config.EventRule.build(
+                {"name": "n", "topic": "/t", "predicate": "true", "pre_seconds": -1}
+            )
+
+    def test_missing_predicate_raises(self) -> None:
+        with pytest.raises(StreamConfigError, match="predicate"):
+            config.EventRule.build({"name": "n", "topic": "/t"})
+
+
+class TestStreamsConfigBuild:
+    def test_full_manifest_section_builds(self) -> None:
+        cfg = config.StreamsConfig.build(
+            {
+                "broker": "mqtts://fleet.example.com:8883",
+                "flush_interval_s": 2,
+                "channels": [{"topic": "/imu", "fields": ["linear_acceleration.x"], "rate_hz": 5}],
+                "events": [{"name": "n", "topic": "/imu", "predicate": "true"}],
+            }
+        )
+        assert cfg.broker == "mqtts://fleet.example.com:8883"
+        assert cfg.flush_interval_s == 2.0
+        assert len(cfg.channels) == 1 and len(cfg.events) == 1
+
+    def test_defaults(self) -> None:
+        cfg = config.StreamsConfig.build(
+            {"channels": [{"topic": "/t", "fields": ["a"], "rate_hz": 1}]}
+        )
+        assert cfg.broker is None and cfg.flush_interval_s == 1.0 and cfg.events == []
+
+    @pytest.mark.parametrize("url", ["http://x", "ftp://x:1", "not a url", "mqtts://"])
+    def test_bad_broker_url_raises(self, url: str) -> None:
+        with pytest.raises(StreamConfigError, match="broker"):
+            config.StreamsConfig.build({"broker": url, "channels": []})
+
+    def test_plain_mqtt_scheme_is_syntactically_ok(self) -> None:
+        # Whether mqtt:// is *allowed* is enrollment's dev-mode rule (step 6);
+        # here it only has to parse.
+        assert config.StreamsConfig.build(
+            {"broker": "mqtt://localhost:1883", "channels": []}
+        ).broker
+
+    def test_zero_flush_interval_raises(self) -> None:
+        with pytest.raises(StreamConfigError, match="flush_interval_s"):
+            config.StreamsConfig.build({"flush_interval_s": 0, "channels": []})
+
+    def test_error_labels_carry_list_index(self) -> None:
+        with pytest.raises(StreamConfigError, match=r"channels\[1\]"):
+            config.StreamsConfig.build(
+                {
+                    "channels": [
+                        {"topic": "/a", "fields": ["x"], "rate_hz": 1},
+                        {"topic": "/b", "fields": ["y"], "rate_hz": 99},
+                    ]
+                }
+            )

--- a/test/sink/publish/test_config.py
+++ b/test/sink/publish/test_config.py
@@ -22,6 +22,21 @@ IMU = pa.struct(
     ]
 )
 
+ODOM = pa.struct(
+    [
+        pa.field(
+            "pose",
+            pa.struct(
+                [
+                    pa.field("x", pa.float64()),
+                    pa.field("y", pa.float64()),
+                    pa.field("z", pa.float64()),
+                ]
+            ),
+        )
+    ]
+)
+
 
 class TestStreamConfigError:
     def test_carries_field_and_reason(self) -> None:
@@ -216,3 +231,130 @@ class TestStreamsConfigBuild:
                     ]
                 }
             )
+
+    def test_event_error_labels_carry_list_index(self) -> None:
+        with pytest.raises(StreamConfigError, match=r"events\[1\]"):
+            config.StreamsConfig.build(
+                {
+                    "channels": [],
+                    "events": [
+                        {"name": "a", "topic": "/t", "predicate": "true"},
+                        {"name": "b", "topic": "/t", "predicate": "true", "pre_seconds": -1},
+                    ],
+                }
+            )
+
+
+class TestResolve:
+    def _cfg(self, channels: list) -> config.StreamsConfig:
+        return config.StreamsConfig.build({"channels": channels})
+
+    def test_scalar_channels_resolve_with_default_names(self) -> None:
+        cfg = self._cfg(
+            [{"topic": "/imu", "fields": ["linear_acceleration.x", "frame_id"], "rate_hz": 5}]
+        )
+        out = cfg.resolve({"/imu": IMU})
+        assert [(c.name, c.type) for c in out] == [
+            ("imu.linear_acceleration.x", "number"),
+            ("imu.frame_id", "string"),
+        ]
+        assert out[0].source_topic == "/imu"
+        assert out[0].source_field == "linear_acceleration.x"
+        assert out[0].paths["value"].path == ["linear_acceleration", "x"]
+
+    def test_rename_overrides_default(self) -> None:
+        cfg = self._cfg(
+            [
+                {
+                    "topic": "/imu",
+                    "fields": ["linear_acceleration.x"],
+                    "rate_hz": 5,
+                    "as": {"linear_acceleration.x": "accel.x"},
+                }
+            ]
+        )
+        assert cfg.resolve({"/imu": IMU})[0].name == "accel.x"
+
+    def test_geo_channel_resolves(self) -> None:
+        cfg = self._cfg(
+            [{"topic": "/nav/odom", "geo": {"lat": "pose.x", "lon": "pose.y"}, "rate_hz": 1}]
+        )
+        (c,) = cfg.resolve({"/nav/odom": ODOM})
+        assert c.name == "odom.geo" and c.type == "geo"
+        assert set(c.paths) == {"lat", "lon"}
+
+    def test_geo_path_to_non_number_raises(self) -> None:
+        cfg = self._cfg(
+            [{"topic": "/imu", "geo": {"lat": "frame_id", "lon": "calibrated"}, "rate_hz": 1}]
+        )
+        with pytest.raises(StreamConfigError, match="geo.*number|number"):
+            cfg.resolve({"/imu": IMU})
+
+    def test_non_scalar_field_raises(self) -> None:
+        cfg = self._cfg([{"topic": "/imu", "fields": ["readings"], "rate_hz": 1}])
+        with pytest.raises(StreamConfigError, match="not a streamable scalar"):
+            cfg.resolve({"/imu": IMU})
+
+    def test_unknown_topic_raises(self) -> None:
+        cfg = self._cfg([{"topic": "/nope", "fields": ["a"], "rate_hz": 1}])
+        with pytest.raises(StreamConfigError, match="unknown topic"):
+            cfg.resolve({"/imu": IMU})
+
+    def test_duplicate_channel_names_raise(self) -> None:
+        cfg = self._cfg(
+            [
+                {"topic": "/imu", "fields": ["frame_id"], "rate_hz": 1},
+                {
+                    "topic": "/imu",
+                    "fields": ["linear_acceleration.x"],
+                    "rate_hz": 1,
+                    "as": {"linear_acceleration.x": "imu.frame_id"},
+                },
+            ]
+        )
+        with pytest.raises(StreamConfigError, match="duplicate channel name"):
+            cfg.resolve({"/imu": IMU})
+
+
+class TestLoadStreams:
+    def test_manifest_without_streams_returns_none(self) -> None:
+        assert config.load_streams({"subscriptions": []}) is None
+
+    def test_manifest_with_streams_builds(self) -> None:
+        manifest = {
+            "subscriptions": [],
+            "streams": {"channels": [{"topic": "/imu", "fields": ["frame_id"], "rate_hz": 1}]},
+        }
+        cfg = config.load_streams(manifest)
+        assert isinstance(cfg, config.StreamsConfig) and len(cfg.channels) == 1
+
+    def test_yaml_round_trip(self, tmp_path: object) -> None:
+        import yaml
+
+        text = """
+streams:
+  broker: mqtts://fleet.example.com:8883
+  flush_interval_s: 1
+  channels:
+    - topic: /imu
+      fields: [linear_acceleration.x, linear_acceleration.y]
+      rate_hz: 5
+  events:
+    - name: hard_decel
+      topic: /imu
+      predicate: '"/imu"[''linear_acceleration''][''x''] < -10'
+      pre_seconds: 10
+      post_seconds: 10
+      debounce_seconds: 2
+      artifact: mcap
+"""
+        f = tmp_path / "startup.yaml"
+        f.write_text(text)
+        cfg = config.load_streams(yaml.safe_load(f.read_text()))
+        assert cfg.broker.startswith("mqtts://")
+        assert cfg.channels[0].rate_hz == 5.0
+        assert cfg.events[0].name == "hard_decel"
+
+    def test_invalid_streams_raises_not_swallows(self) -> None:
+        with pytest.raises(StreamConfigError):
+            config.load_streams({"streams": {"channels": [{"topic": "/t", "rate_hz": 1}]}})

--- a/test/sink/publish/test_config.py
+++ b/test/sink/publish/test_config.py
@@ -147,6 +147,12 @@ class TestChannelRule:
         with pytest.raises(StreamConfigError, match="topic"):
             config.ChannelRule.build({"fields": ["a"], "rate_hz": 1})
 
+    def test_unknown_top_level_key_raises(self) -> None:
+        with pytest.raises(StreamConfigError, match=r"unknown keys \['az'\]"):
+            config.ChannelRule.build(
+                {"topic": "/t", "fields": ["a"], "rate_hz": 1, "az": {"lat": "a", "lon": "b"}}
+            )
+
 
 class TestEventRule:
     def test_full_event_builds(self) -> None:
@@ -183,6 +189,12 @@ class TestEventRule:
     def test_missing_predicate_raises(self) -> None:
         with pytest.raises(StreamConfigError, match="predicate"):
             config.EventRule.build({"name": "n", "topic": "/t"})
+
+    def test_unknown_top_level_key_raises(self) -> None:
+        with pytest.raises(StreamConfigError, match=r"unknown keys \['severity'\]"):
+            config.EventRule.build(
+                {"name": "n", "topic": "/t", "predicate": "true", "severity": "high"}
+            )
 
 
 class TestStreamsConfigBuild:
@@ -244,6 +256,22 @@ class TestStreamsConfigBuild:
                 }
             )
 
+    def test_null_channels_is_treated_as_empty(self) -> None:
+        cfg = config.StreamsConfig.build({"channels": None})
+        assert cfg.channels == []
+
+    def test_null_events_is_treated_as_empty(self) -> None:
+        cfg = config.StreamsConfig.build({"channels": [], "events": None})
+        assert cfg.events == []
+
+    def test_non_list_channels_raises_typed(self) -> None:
+        with pytest.raises(StreamConfigError, match="streams.channels"):
+            config.StreamsConfig.build({"channels": "x"})
+
+    def test_non_list_events_raises_typed(self) -> None:
+        with pytest.raises(StreamConfigError, match="streams.events"):
+            config.StreamsConfig.build({"channels": [], "events": {"a": 1}})
+
 
 class TestResolve:
     def _cfg(self, channels: list) -> config.StreamsConfig:
@@ -261,6 +289,7 @@ class TestResolve:
         assert out[0].source_topic == "/imu"
         assert out[0].source_field == "linear_acceleration.x"
         assert out[0].paths["value"].path == ["linear_acceleration", "x"]
+        assert out[0].rate_hz == 5.0
 
     def test_rename_overrides_default(self) -> None:
         cfg = self._cfg(
@@ -282,6 +311,21 @@ class TestResolve:
         (c,) = cfg.resolve({"/nav/odom": ODOM})
         assert c.name == "odom.geo" and c.type == "geo"
         assert set(c.paths) == {"lat", "lon"}
+        assert c.rate_hz == 1.0
+
+    def test_geo_channel_with_alt_resolves(self) -> None:
+        cfg = self._cfg(
+            [
+                {
+                    "topic": "/nav/odom",
+                    "geo": {"lat": "pose.x", "lon": "pose.y", "alt": "pose.z"},
+                    "rate_hz": 1,
+                }
+            ]
+        )
+        (c,) = cfg.resolve({"/nav/odom": ODOM})
+        assert set(c.paths) == {"lat", "lon", "alt"}
+        assert c.type == "geo"
 
     def test_geo_path_to_non_number_raises(self) -> None:
         cfg = self._cfg(
@@ -314,6 +358,44 @@ class TestResolve:
         )
         with pytest.raises(StreamConfigError, match="duplicate channel name"):
             cfg.resolve({"/imu": IMU})
+
+    def test_duplicate_default_names_raise(self) -> None:
+        cfg = self._cfg(
+            [
+                {"topic": "/imu", "fields": ["frame_id"], "rate_hz": 1},
+                {"topic": "/imu", "fields": ["frame_id"], "rate_hz": 2},
+            ]
+        )
+        with pytest.raises(StreamConfigError, match="duplicate channel name"):
+            cfg.resolve({"/imu": IMU})
+
+    def test_typo_rename_key_raises(self) -> None:
+        cfg = self._cfg(
+            [
+                {
+                    "topic": "/imu",
+                    "fields": ["frame_id"],
+                    "rate_hz": 1,
+                    "as": {"frme_id": "n"},
+                }
+            ]
+        )
+        with pytest.raises(StreamConfigError, match="matches no field path"):
+            cfg.resolve({"/imu": IMU})
+
+    def test_typo_geo_rename_key_raises(self) -> None:
+        cfg = self._cfg(
+            [
+                {
+                    "topic": "/nav/odom",
+                    "geo": {"lat": "pose.x", "lon": "pose.y"},
+                    "rate_hz": 1,
+                    "as": {"gep": "position"},
+                }
+            ]
+        )
+        with pytest.raises(StreamConfigError, match="matches no field path"):
+            cfg.resolve({"/nav/odom": ODOM})
 
 
 class TestLoadStreams:

--- a/test/sink/publish/test_config.py
+++ b/test/sink/publish/test_config.py
@@ -66,6 +66,29 @@ class TestResolvePath:
             config.resolve_path(IMU, "frame_id.sub", field_label="f")
 
 
+class TestFieldUnit:
+    def test_metadata_unit_is_returned(self) -> None:
+        struct = pa.struct([pa.field("temp", pa.float64(), metadata={"unit": "celsius"})])
+        assert config.field_unit(struct, "temp") == "celsius"
+
+    def test_nested_metadata_unit_is_returned(self) -> None:
+        struct = pa.struct(
+            [
+                pa.field(
+                    "outer",
+                    pa.struct([pa.field("temp", pa.float64(), metadata={"unit": "celsius"})]),
+                )
+            ]
+        )
+        assert config.field_unit(struct, "outer.temp") == "celsius"
+
+    def test_absent_metadata_is_none(self) -> None:
+        assert config.field_unit(IMU, "frame_id") is None
+
+    def test_unresolvable_path_is_none(self) -> None:
+        assert config.field_unit(IMU, "nope") is None
+
+
 class TestClassify:
     @pytest.mark.parametrize(
         ("pa_type", "expected"),
@@ -146,6 +169,18 @@ class TestChannelRule:
     def test_missing_topic_raises(self) -> None:
         with pytest.raises(StreamConfigError, match="topic"):
             config.ChannelRule.build({"fields": ["a"], "rate_hz": 1})
+
+    def test_non_string_geo_value_raises_typed(self) -> None:
+        with pytest.raises(StreamConfigError, match=r"channels\[\]\.geo"):
+            config.ChannelRule.build(
+                {"topic": "/odom", "geo": {"lat": 1, "lon": "pose.y"}, "rate_hz": 1}
+            )
+
+    def test_empty_string_geo_value_raises_typed(self) -> None:
+        with pytest.raises(StreamConfigError, match=r"channels\[\]\.geo"):
+            config.ChannelRule.build(
+                {"topic": "/odom", "geo": {"lat": "", "lon": "pose.y"}, "rate_hz": 1}
+            )
 
     def test_unknown_top_level_key_raises(self) -> None:
         with pytest.raises(StreamConfigError, match=r"unknown keys \['az'\]"):
@@ -312,6 +347,18 @@ class TestResolve:
         assert c.name == "odom.geo" and c.type == "geo"
         assert set(c.paths) == {"lat", "lon"}
         assert c.rate_hz == 1.0
+        assert c.unit is None
+
+    def test_scalar_channel_picks_up_arrow_unit_metadata(self) -> None:
+        struct = pa.struct([pa.field("temp", pa.float64(), metadata={"unit": "celsius"})])
+        cfg = self._cfg([{"topic": "/env", "fields": ["temp"], "rate_hz": 1}])
+        (c,) = cfg.resolve({"/env": struct})
+        assert c.unit == "celsius"
+
+    def test_scalar_channel_without_metadata_has_no_unit(self) -> None:
+        cfg = self._cfg([{"topic": "/imu", "fields": ["frame_id"], "rate_hz": 1}])
+        (c,) = cfg.resolve({"/imu": IMU})
+        assert c.unit is None
 
     def test_geo_channel_with_alt_resolves(self) -> None:
         cfg = self._cfg(


### PR DESCRIPTION
Step 2 of the fleet streaming design (beta branch): `streams:` manifest
parsing, no runtime.

- `StreamConfigError(field, reason)` joins the typed error family.
- `src/sink/publish/config.py`: ChannelRule/EventRule/StreamsConfig with
  match-case `build()` validation (house style), rate_hz capped to (0, 50],
  broker URL scheme check, exactly-one-of fields/geo.
- Dotted field paths resolve against per-topic Arrow StructTypes (reusing
  `AccessPath`); channels classify to the wire contract's number/string/
  bool/geo; duplicate channel names rejected.
- `load_streams(manifest)` entry point; startup wiring lands with the
  router in step 5.

No behavior change for anyone without a `streams:` section; nothing
connects anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
