### PR TITLE
feat(fleet): step 3 — Publisher interface, MqttPublisher, mosquitto CI harness

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -110,6 +110,29 @@ jobs:
           include-hidden-files: true
           if-no-files-found: warn
 
+  # MQTT round-trip integration tests against a real broker (spec §8). The
+  # broker is started as a step, not a `services:` container: GitHub starts
+  # service containers before `actions/checkout`, so a workspace-path config
+  # volume mount would be empty at container start, and service containers
+  # don't support command overrides either. Running mosquitto via `docker
+  # run` with its built-in /mosquitto-no-auth.conf sidesteps both problems
+  # and is the locally-verified route (test/sink/publish/test_mqtt_integration.py).
+  iot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.8.0"
+      - name: Install dependencies
+        run: uv sync --group fleet --group dev
+      - name: Start mosquitto
+        run: docker run -d --name mosq -p 1883:1883 eclipse-mosquitto:2 mosquitto -c /mosquitto-no-auth.conf
+      - name: Broker round-trip tests
+        env:
+          MQTT_TEST_BROKER: mqtt://localhost:1883
+        run: uv run pytest -q test/sink/publish/test_mqtt_integration.py -p no:cacheprovider
+
   coverage-gate:
     needs: [docker, host-tests]
     runs-on: ubuntu-latest

--- a/src/sink/publish/mqtt.py
+++ b/src/sink/publish/mqtt.py
@@ -10,6 +10,7 @@ import time
 import weakref
 from urllib.parse import urlparse
 
+from src.sink.publish import require_fleet
 from src.sink.publish.publisher import LWT_PAYLOAD, Publisher, PublishError, wire_topic
 
 _DEFAULT_PORTS = {"mqtts": 8883, "mqtt": 1883}
@@ -91,7 +92,16 @@ class MqttPublisher(Publisher):
         self._finalizer = weakref.finalize(self, _finalize, None)
 
     def connect(self) -> None:
-        """Build the paho client, arm the last-will, and connect."""
+        """Build the paho client, arm the last-will, and connect.
+
+        Enforces the fleet gate first, so a disabled or not-installed fleet
+        subsystem never imports paho or opens a socket. If already connected
+        to a prior client, tears it down before building the replacement
+        (connect() is idempotent-with-replacement).
+        """
+        require_fleet()
+        if self._client is not None:
+            _finalize(self._client)
         paho = _paho()
         client = paho.Client(
             callback_api_version=paho.CallbackAPIVersion.VERSION2,

--- a/src/sink/publish/mqtt.py
+++ b/src/sink/publish/mqtt.py
@@ -1,0 +1,159 @@
+"""MqttPublisher: one robot's QoS-1 MQTT session to a fleet broker.
+
+paho is imported lazily (via _paho) so this module never trips the
+package's no-eager-import invariant; require_fleet() remains the gate.
+"""
+
+import json
+import logging
+import time
+import weakref
+from urllib.parse import urlparse
+
+from src.sink.publish.publisher import LWT_PAYLOAD, Publisher, PublishError, wire_topic
+
+_DEFAULT_PORTS = {"mqtts": 8883, "mqtt": 1883}
+
+
+def _paho() -> object:
+    """Import and return the paho MQTT client module (lazy; test seam)."""
+    import paho.mqtt.client as paho_client
+
+    return paho_client
+
+
+def _dump(payload: dict) -> str:
+    """Serialize a payload dict to compact JSON."""
+    return json.dumps(payload, separators=(",", ":"))
+
+
+def _finalize(client: object) -> None:
+    """Best-effort teardown for a garbage-collected publisher's client."""
+    if client is None:
+        return
+    try:
+        client.loop_stop()
+        client.disconnect()
+    except Exception:
+        logging.debug("Best-effort teardown of an abandoned MQTT client failed")
+
+
+class MqttPublisher(Publisher):
+    """Publish fleet messages over MQTT with mTLS options and a retained last-will."""
+
+    def __init__(  # noqa: PLR0913
+        self,
+        broker_url: str,
+        tenant: str,
+        robot: str,
+        *,
+        tls_ca_certs: str | None = None,
+        tls_certfile: str | None = None,
+        tls_keyfile: str | None = None,
+        username: str | None = None,
+        password: str | None = None,
+        keepalive_s: int = 30,
+    ) -> None:
+        """Parse `broker_url` and stash connection options; does not connect.
+
+        Args:
+            broker_url: `mqtts://host[:port]` (TLS, default port 8883) or
+                `mqtt://host[:port]` (plain, default port 1883).
+            tenant: Tenant id used in the wire topic namespace.
+            robot: Robot id used in the wire topic namespace and client id.
+            tls_ca_certs: Path to a CA bundle for TLS.
+            tls_certfile: Path to a client certificate for mTLS.
+            tls_keyfile: Path to a client private key for mTLS.
+            username: Broker username, if auth is required.
+            password: Broker password, if auth is required.
+            keepalive_s: MQTT keepalive interval in seconds.
+
+        Raises:
+            ValueError: If `broker_url`'s scheme is not `mqtt` or `mqtts`, or it has
+                no host.
+
+        """
+        parsed = urlparse(broker_url)
+        if parsed.scheme not in _DEFAULT_PORTS or not parsed.hostname:
+            raise ValueError(
+                f"broker_url scheme must be mqtt:// or mqtts:// with a host: {broker_url!r}"
+            )
+        self._host = parsed.hostname
+        self._port = parsed.port or _DEFAULT_PORTS[parsed.scheme]
+        self._use_tls = parsed.scheme == "mqtts" or any((tls_ca_certs, tls_certfile, tls_keyfile))
+        self._tenant = tenant
+        self._robot = robot
+        self._tls = {"ca_certs": tls_ca_certs, "certfile": tls_certfile, "keyfile": tls_keyfile}
+        self._username = username
+        self._password = password
+        self._keepalive_s = keepalive_s
+        self._client: object = None
+        self._finalizer = weakref.finalize(self, _finalize, None)
+
+    def connect(self) -> None:
+        """Build the paho client, arm the last-will, and connect."""
+        paho = _paho()
+        client = paho.Client(
+            callback_api_version=paho.CallbackAPIVersion.VERSION2,
+            client_id=f"bagel-{self._tenant}-{self._robot}",
+            protocol=paho.MQTTv5,
+        )
+        client.will_set(
+            wire_topic(self._tenant, self._robot, "heartbeat"),
+            _dump(LWT_PAYLOAD),
+            qos=1,
+            retain=True,
+        )
+        if self._use_tls:
+            client.tls_set(**self._tls)
+        if self._username is not None:
+            client.username_pw_set(self._username, self._password)
+        client.connect(self._host, self._port, self._keepalive_s)
+        client.loop_start()
+        self._client = client
+        # Re-register the finalizer against the live client, holding no ref to self.
+        self._finalizer.detach()
+        self._finalizer = weakref.finalize(self, _finalize, client)
+
+    @property
+    def connected(self) -> bool:
+        """Return whether the underlying paho client reports itself connected."""
+        return bool(self._client is not None and self._client.is_connected())
+
+    def publish(
+        self, kind: str, payload: dict, *, retain: bool = False, timeout_s: float = 10.0
+    ) -> None:
+        """Publish `payload` as JSON at QoS 1 on the wire topic for `kind`."""
+        if self._client is None:
+            raise PublishError("publisher is not connected")
+        topic = wire_topic(self._tenant, self._robot, kind)
+        info = self._client.publish(topic, _dump(payload), qos=1, retain=retain)
+        try:
+            info.wait_for_publish(timeout=timeout_s)
+        except Exception as exc:
+            raise PublishError(f"{topic}: not acknowledged within {timeout_s}s: {exc}") from exc
+        if info.rc != 0 or not info.is_published():
+            raise PublishError(f"{topic}: publish failed (rc={info.rc})")
+
+    def close(self) -> None:
+        """Publish a clean-stop heartbeat (best-effort) then stop and disconnect.
+
+        Idempotent: safe to call more than once, and safe when never connected.
+        """
+        client, self._client = self._client, None
+        if client is None:
+            return
+        if client.is_connected():
+            stopped = {"v": 1, "t": time.time(), "online": False, "reason": "stopped"}
+            try:
+                info = client.publish(
+                    wire_topic(self._tenant, self._robot, "heartbeat"),
+                    _dump(stopped),
+                    qos=1,
+                    retain=True,
+                )
+                info.wait_for_publish(timeout=5.0)
+            except Exception:
+                logging.debug("Clean-stop heartbeat publish failed; closing anyway")
+        client.loop_stop()
+        client.disconnect()

--- a/src/sink/publish/publisher.py
+++ b/src/sink/publish/publisher.py
@@ -1,0 +1,66 @@
+"""Publisher interface for fleet streaming (spec §2/§3).
+
+Concrete implementations own the transport; the interface owns the wire
+contract: topic namespace, QoS-1 semantics, and which kinds are retained.
+Payloads arrive as ready dicts — batching and sequencing live upstream.
+"""
+
+import abc
+
+KINDS = ("schema", "channels", "events", "heartbeat", "cmd")
+LWT_PAYLOAD = {"v": 1, "online": False, "reason": "lwt"}
+
+
+class PublishError(Exception):
+    """Raised when a QoS-1 publish is not acknowledged."""
+
+
+def wire_topic(tenant: str, robot: str, kind: str) -> str:
+    """Return the v1 wire topic for one message kind of one robot."""
+    if kind not in KINDS:
+        raise ValueError(f"unknown kind '{kind}'; expected one of {KINDS}")
+    return f"bagel/v1/{tenant}/{robot}/{kind}"
+
+
+class Publisher(abc.ABC):
+    """One robot's session to a fleet broker."""
+
+    @abc.abstractmethod
+    def connect(self) -> None:
+        """Connect to the broker."""
+
+    @abc.abstractmethod
+    def publish(
+        self,
+        kind: str,
+        payload: dict,
+        *,
+        retain: bool = False,
+        timeout_s: float = 10.0,
+    ) -> None:
+        """Publish a message to the broker."""
+
+    @abc.abstractmethod
+    def close(self) -> None:
+        """Close the broker connection."""
+
+    @property
+    @abc.abstractmethod
+    def connected(self) -> bool:
+        """Return whether the broker is connected."""
+
+    def publish_schema(self, payload: dict) -> None:
+        """Publish a schema message (retained)."""
+        self.publish("schema", payload, retain=True)
+
+    def publish_heartbeat(self, payload: dict) -> None:
+        """Publish a heartbeat message (retained)."""
+        self.publish("heartbeat", payload, retain=True)
+
+    def publish_channels(self, payload: dict) -> None:
+        """Publish a channels message (not retained)."""
+        self.publish("channels", payload)
+
+    def publish_event(self, payload: dict) -> None:
+        """Publish an event message (not retained)."""
+        self.publish("events", payload)

--- a/test/sink/publish/test_mqtt_integration.py
+++ b/test/sink/publish/test_mqtt_integration.py
@@ -1,0 +1,145 @@
+"""Round-trip integration tests against a real MQTT broker (spec §8).
+
+Gated on MQTT_TEST_BROKER (e.g. mqtt://localhost:1883). In CI these run in
+the `iot` job against a mosquitto broker container; locally:
+    docker run -d -p 1883:1883 eclipse-mosquitto:2 mosquitto -c /mosquitto-no-auth.conf
+"""
+
+import json
+import os
+import queue
+import time
+import uuid
+from collections.abc import Iterator
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from src.sink.publish.mqtt import MqttPublisher
+
+BROKER = os.environ.get("MQTT_TEST_BROKER")
+pytestmark = pytest.mark.skipif(not BROKER, reason="MQTT_TEST_BROKER not set")
+
+
+@pytest.fixture()
+def subscriber() -> Iterator[tuple[object, "queue.Queue[tuple[str, bytes, bool]]"]]:
+    import paho.mqtt.client as paho
+
+    inbox: queue.Queue = queue.Queue()
+    client = paho.Client(
+        callback_api_version=paho.CallbackAPIVersion.VERSION2,
+        client_id=f"sub-{uuid.uuid4().hex[:8]}",
+        protocol=paho.MQTTv5,
+    )
+    client.on_message = lambda cl, ud, msg: inbox.put((msg.topic, msg.payload, msg.retain))
+    from urllib.parse import urlparse
+
+    parsed = urlparse(BROKER)
+    client.connect(parsed.hostname, parsed.port or 1883)
+    client.loop_start()
+    yield client, inbox
+    client.loop_stop()
+    client.disconnect()
+
+
+def _drain(
+    inbox: "queue.Queue[tuple[str, bytes, bool]]", topic: str, timeout: float = 5.0
+) -> tuple[str, bytes, bool] | None:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            got = inbox.get(timeout=deadline - time.time())
+        except queue.Empty:
+            return None
+        if got[0] == topic:
+            return got
+    return None
+
+
+def _publisher(tenant: str, robot: str) -> "MqttPublisher":
+    from src.sink.publish.mqtt import MqttPublisher
+
+    return MqttPublisher(BROKER, tenant, robot)
+
+
+def _subscribe_and_wait(client: object, topic: str) -> tuple[int, int]:
+    result = client.subscribe(topic, qos=1)
+    time.sleep(0.3)
+    return result
+
+
+def test_channels_round_trip(
+    subscriber: tuple[object, "queue.Queue[tuple[str, bytes, bool]]"],
+) -> None:
+    client, inbox = subscriber
+    tenant, robot = "it", uuid.uuid4().hex[:8]
+    topic = f"bagel/v1/{tenant}/{robot}/channels"
+    _subscribe_and_wait(client, topic)
+
+    p = _publisher(tenant, robot)
+    p.connect()
+    p.publish_channels({"v": 1, "seq": 1, "t_batch": time.time(), "samples": []})
+    got = _drain(inbox, topic)
+    p.close()
+    assert got is not None, "channels batch never arrived"
+    assert json.loads(got[1])["seq"] == 1
+
+
+def test_schema_is_retained_for_late_subscriber(
+    subscriber: tuple[object, "queue.Queue[tuple[str, bytes, bool]]"],
+) -> None:
+    client, inbox = subscriber
+    tenant, robot = "it", uuid.uuid4().hex[:8]
+    topic = f"bagel/v1/{tenant}/{robot}/schema"
+
+    p = _publisher(tenant, robot)
+    p.connect()
+    p.publish_schema({"v": 1, "channels": [{"c": "imu.ax", "type": "number"}]})
+    time.sleep(0.5)  # let the broker store the retained message
+    _subscribe_and_wait(client, topic)  # subscribe AFTER publish
+    got = _drain(inbox, topic)
+    p.close()
+    assert got is not None, "retained schema not delivered to late subscriber"
+    assert got[2] is True or json.loads(got[1])["v"] == 1  # paho v5 retain flag on stored delivery
+
+
+def test_clean_close_publishes_stopped_heartbeat(
+    subscriber: tuple[object, "queue.Queue[tuple[str, bytes, bool]]"],
+) -> None:
+    client, inbox = subscriber
+    tenant, robot = "it", uuid.uuid4().hex[:8]
+    topic = f"bagel/v1/{tenant}/{robot}/heartbeat"
+    _subscribe_and_wait(client, topic)
+
+    p = _publisher(tenant, robot)
+    p.connect()
+    p.publish_heartbeat({"v": 1, "t": time.time(), "online": True})
+    online = _drain(inbox, topic)
+    p.close()
+    stopped = _drain(inbox, topic)
+    assert online and json.loads(online[1])["online"] is True
+    assert stopped is not None, "clean close never published a stopped heartbeat"
+    body = json.loads(stopped[1])
+    assert body["online"] is False and body["reason"] == "stopped"
+
+
+def test_lwt_fires_on_unclean_disconnect(
+    subscriber: tuple[object, "queue.Queue[tuple[str, bytes, bool]]"],
+) -> None:
+    client, inbox = subscriber
+    tenant, robot = "it", uuid.uuid4().hex[:8]
+    topic = f"bagel/v1/{tenant}/{robot}/heartbeat"
+    _subscribe_and_wait(client, topic)
+
+    p = _publisher(tenant, robot)
+    p.connect()
+    # Simulate a crash: sever the socket without DISCONNECT so the broker
+    # publishes the will. paho's socket is reachable via the private client;
+    # loop_stop first so the loop doesn't race the reconnect.
+    p._client.loop_stop()
+    p._client._sock_close()  # deliberate unclean kill (private paho API)
+    got = _drain(inbox, topic, timeout=10.0)
+    assert got is not None, "LWT never fired"
+    body = json.loads(got[1])
+    assert body == {"v": 1, "online": False, "reason": "lwt"}

--- a/test/sink/publish/test_mqtt_publisher.py
+++ b/test/sink/publish/test_mqtt_publisher.py
@@ -1,0 +1,206 @@
+"""MqttPublisher unit tests over a fake paho client (no broker)."""
+
+import importlib
+import json
+import sys
+import types
+
+import pytest
+
+from src.sink.publish import mqtt as publish_mqtt
+from src.sink.publish.publisher import PublishError
+
+
+class FakeMsgInfo:
+    def __init__(
+        self, rc: int = 0, published: bool = True, raise_on_wait: Exception | None = None
+    ) -> None:
+        self.rc = rc
+        self._published = published
+        self._raise = raise_on_wait
+
+    def wait_for_publish(self, timeout: float | None = None) -> None:
+        if self._raise:
+            raise self._raise
+
+    def is_published(self) -> bool:
+        return self._published
+
+
+class FakeFleetPaho:
+    MQTT_ERR_SUCCESS = 0
+
+    def __init__(self, **kwargs: object) -> None:
+        self.kwargs = kwargs
+        self.calls: list[tuple[object, ...]] = []
+        self.will: tuple[str, str, int, bool] | None = None
+        self.tls: dict[str, object] | None = None
+        self.userpass: tuple[str, str | None] | None = None
+        self._connected = False
+        self.next_info = FakeMsgInfo()
+
+    def will_set(self, topic: str, payload: str, qos: int = 0, retain: bool = False) -> None:
+        self.will = (topic, payload, qos, retain)
+
+    def tls_set(self, **kwargs: object) -> None:
+        self.tls = kwargs
+
+    def username_pw_set(self, username: str, password: str | None = None) -> None:
+        self.userpass = (username, password)
+
+    def connect(self, host: str, port: int, keepalive: int = 60) -> None:
+        self.calls.append(("connect", host, port, keepalive))
+        self._connected = True
+
+    def loop_start(self) -> None:
+        self.calls.append(("loop_start",))
+
+    def loop_stop(self) -> None:
+        self.calls.append(("loop_stop",))
+
+    def disconnect(self) -> None:
+        self.calls.append(("disconnect",))
+        self._connected = False
+
+    def is_connected(self) -> bool:
+        return self._connected
+
+    def publish(self, topic: str, payload: str, qos: int = 0, retain: bool = False) -> FakeMsgInfo:
+        self.calls.append(("publish", topic, payload, qos, retain))
+        return self.next_info
+
+
+@pytest.fixture()
+def fake(monkeypatch: pytest.MonkeyPatch) -> dict[str, FakeFleetPaho]:
+    holder: dict[str, FakeFleetPaho] = {}
+
+    def fake_client(**kwargs: object) -> FakeFleetPaho:
+        holder["client"] = FakeFleetPaho(**kwargs)
+        return holder["client"]
+
+    fake_module = types.SimpleNamespace(
+        Client=fake_client,
+        CallbackAPIVersion=types.SimpleNamespace(VERSION2="v2"),
+        MQTTv5=5,
+        MQTT_ERR_SUCCESS=0,
+    )
+    monkeypatch.setattr(publish_mqtt, "_paho", lambda: fake_module)
+    return holder
+
+
+def _publisher(**kw: object) -> publish_mqtt.MqttPublisher:
+    defaults = dict(broker_url="mqtts://fleet.example.com", tenant="acme", robot="r7")
+    defaults.update(kw)
+    return publish_mqtt.MqttPublisher(**defaults)
+
+
+class TestConnect:
+    def test_will_is_set_before_connect_with_lwt_payload(
+        self, fake: dict[str, FakeFleetPaho]
+    ) -> None:
+        p = _publisher(tls_ca_certs="/ca.pem", tls_certfile="/c.pem", tls_keyfile="/k.pem")
+        p.connect()
+        client = fake["client"]
+        topic, payload, qos, retain = client.will
+        assert topic == "bagel/v1/acme/r7/heartbeat"
+        assert json.loads(payload) == {"v": 1, "online": False, "reason": "lwt"}
+        assert qos == 1 and retain is True
+        # will_set recorded before connect in the call ordering
+        # will/tls/userpass aren't in calls; connect is first *call*
+        assert client.calls[0][0] == "connect"
+        assert client.tls == {"ca_certs": "/ca.pem", "certfile": "/c.pem", "keyfile": "/k.pem"}
+
+    def test_mqtts_defaults_to_8883_and_mqtt_to_1883(self, fake: dict[str, FakeFleetPaho]) -> None:
+        p = _publisher(broker_url="mqtts://h")
+        p.connect()
+        assert fake["client"].calls[0] == ("connect", "h", 8883, 30)
+        p2 = _publisher(broker_url="mqtt://h2:1884")
+        p2.connect()
+        assert fake["client"].calls[0] == ("connect", "h2", 1884, 30)
+
+    def test_bad_scheme_raises_at_construction(self) -> None:
+        with pytest.raises(ValueError, match="scheme"):
+            _publisher(broker_url="http://h")
+
+    def test_plain_broker_sets_no_tls(self, fake: dict[str, FakeFleetPaho]) -> None:
+        _publisher(broker_url="mqtt://h").connect()
+        assert fake["client"].tls is None
+
+    def test_client_id_is_deterministic(self, fake: dict[str, FakeFleetPaho]) -> None:
+        _publisher().connect()
+        assert fake["client"].kwargs["client_id"] == "bagel-acme-r7"
+
+
+class TestPublish:
+    def test_publishes_json_qos1_on_wire_topic(self, fake: dict[str, FakeFleetPaho]) -> None:
+        p = _publisher()
+        p.connect()
+        p.publish_channels({"v": 1, "seq": 3})
+        call = next(c for c in fake["client"].calls if c[0] == "publish")
+        assert call[1] == "bagel/v1/acme/r7/channels"
+        assert json.loads(call[2]) == {"v": 1, "seq": 3}
+        assert call[3] == 1 and call[4] is False
+
+    def test_retained_kinds(self, fake: dict[str, FakeFleetPaho]) -> None:
+        p = _publisher()
+        p.connect()
+        p.publish_schema({"v": 1, "channels": []})
+        call = [c for c in fake["client"].calls if c[0] == "publish"][-1]
+        assert call[1].endswith("/schema") and call[4] is True
+
+    def test_unacked_publish_raises(self, fake: dict[str, FakeFleetPaho]) -> None:
+        p = _publisher()
+        p.connect()
+        fake["client"].next_info = FakeMsgInfo(published=False)
+        with pytest.raises(PublishError):
+            p.publish_event({"v": 1})
+
+    def test_bad_rc_raises(self, fake: dict[str, FakeFleetPaho]) -> None:
+        p = _publisher()
+        p.connect()
+        fake["client"].next_info = FakeMsgInfo(rc=4)
+        with pytest.raises(PublishError):
+            p.publish_channels({"v": 1})
+
+    def test_wait_timeout_wraps_into_publish_error(self, fake: dict[str, FakeFleetPaho]) -> None:
+        p = _publisher()
+        p.connect()
+        fake["client"].next_info = FakeMsgInfo(raise_on_wait=RuntimeError("timed out"))
+        with pytest.raises(PublishError, match="timed out|not acknowledged"):
+            p.publish_channels({"v": 1})
+
+
+class TestClose:
+    def test_close_publishes_stopped_heartbeat_then_disconnects(
+        self, fake: dict[str, FakeFleetPaho]
+    ) -> None:
+        p = _publisher()
+        p.connect()
+        p.close()
+        client = fake["client"]
+        stop = [c for c in client.calls if c[0] == "publish"][-1]
+        body = json.loads(stop[2])
+        assert body["online"] is False and body["reason"] == "stopped" and body["v"] == 1
+        assert "t" in body
+        assert ("loop_stop",) in client.calls and ("disconnect",) in client.calls
+        # ordering: stopped-heartbeat publish before disconnect
+        assert client.calls.index(stop) < client.calls.index(("disconnect",))
+
+    def test_close_is_idempotent_and_safe_unconnected(self, fake: dict[str, FakeFleetPaho]) -> None:
+        p = _publisher()
+        p.close()
+        p.close()
+
+    def test_close_swallows_publish_failure(self, fake: dict[str, FakeFleetPaho]) -> None:
+        p = _publisher()
+        p.connect()
+        fake["client"].next_info = FakeMsgInfo(published=False)
+        p.close()  # must not raise
+
+
+def test_mqtt_module_does_not_import_paho_eagerly(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in [m for m in sys.modules if m == "paho" or m.startswith("paho.")]:
+        monkeypatch.delitem(sys.modules, name)
+    monkeypatch.delitem(sys.modules, "src.sink.publish.mqtt", raising=False)
+    importlib.import_module("src.sink.publish.mqtt")
+    assert not any(m == "paho" or m.startswith("paho.") for m in sys.modules)

--- a/test/sink/publish/test_mqtt_publisher.py
+++ b/test/sink/publish/test_mqtt_publisher.py
@@ -7,6 +7,8 @@ import types
 
 import pytest
 
+from settings import settings
+from src.sink.publish import FleetDisabledError
 from src.sink.publish import mqtt as publish_mqtt
 from src.sink.publish.publisher import PublishError
 
@@ -129,6 +131,29 @@ class TestConnect:
     def test_client_id_is_deterministic(self, fake: dict[str, FakeFleetPaho]) -> None:
         _publisher().connect()
         assert fake["client"].kwargs["client_id"] == "bagel-acme-r7"
+
+    def test_connect_raises_when_fleet_disabled_before_touching_paho(
+        self, fake: dict[str, FakeFleetPaho], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(settings, "FLEET_ENABLED", False)
+        p = _publisher()
+        with pytest.raises(FleetDisabledError, match="FLEET_ENABLED"):
+            p.connect()
+        assert fake == {}
+
+    def test_reconnect_tears_down_prior_client_before_replacing_it(
+        self, fake: dict[str, FakeFleetPaho]
+    ) -> None:
+        p = _publisher()
+        p.connect()
+        first = fake["client"]
+        p.connect()
+        second = fake["client"]
+        assert first is not second
+        assert ("loop_stop",) in first.calls and ("disconnect",) in first.calls
+        assert not first.is_connected()
+        assert second.is_connected()
+        assert p.connected
 
 
 class TestPublish:

--- a/test/sink/publish/test_publisher.py
+++ b/test/sink/publish/test_publisher.py
@@ -1,0 +1,74 @@
+"""Publisher contract: wire topics, retain rules, and the lazy-import invariant."""
+
+import importlib
+import sys
+from typing import Any
+
+import pytest
+
+from src.sink.publish import publisher
+
+
+class TestWireTopic:
+    def test_builds_namespaced_topic(self) -> None:
+        assert publisher.wire_topic("acme", "r7", "channels") == "bagel/v1/acme/r7/channels"
+
+    @pytest.mark.parametrize("kind", ["schema", "channels", "events", "heartbeat", "cmd"])
+    def test_all_contract_kinds_accepted(self, kind: str) -> None:
+        assert publisher.wire_topic("t", "r", kind).endswith("/" + kind)
+
+    def test_unknown_kind_raises(self) -> None:
+        with pytest.raises(ValueError, match="unknown kind"):
+            publisher.wire_topic("t", "r", "video")
+
+
+class RecordingPublisher(publisher.Publisher):
+    """Minimal concrete Publisher recording publish calls."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any], bool]] = []
+        self._connected = False
+
+    def connect(self) -> None:
+        self._connected = True
+
+    def publish(
+        self,
+        kind: str,
+        payload: dict[str, Any],
+        *,
+        retain: bool = False,
+        timeout_s: float = 10.0,
+    ) -> None:
+        self.calls.append((kind, payload, retain))
+
+    def close(self) -> None:
+        self._connected = False
+
+    @property
+    def connected(self) -> bool:
+        return self._connected
+
+
+class TestRetainRules:
+    @pytest.mark.parametrize(
+        ("method", "kind", "retain"),
+        [
+            ("publish_schema", "schema", True),
+            ("publish_heartbeat", "heartbeat", True),
+            ("publish_channels", "channels", False),
+            ("publish_event", "events", False),
+        ],
+    )
+    def test_helper_sets_kind_and_retain(self, method: str, kind: str, retain: bool) -> None:
+        p = RecordingPublisher()
+        getattr(p, method)({"v": 1})
+        assert p.calls == [(kind, {"v": 1}, retain)]
+
+
+def test_publisher_module_does_not_import_paho_eagerly(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in [m for m in sys.modules if m == "paho" or m.startswith("paho.")]:
+        monkeypatch.delitem(sys.modules, name)
+    monkeypatch.delitem(sys.modules, "src.sink.publish.publisher", raising=False)
+    importlib.import_module("src.sink.publish.publisher")
+    assert not any(m == "paho" or m.startswith("paho.") for m in sys.modules)


### PR DESCRIPTION
Step 3 of the fleet streaming design (beta line).

- `Publisher` ABC: wire topics `bagel/v1/{tenant}/{robot}/…`, QoS-1 contract,
  retain rules (schema/heartbeat retained), typed `PublishError`.
- `MqttPublisher`: paho MQTTv5 (deliberate departure from the v3.1.1 sink
  default — the wire contract reserves v5 properties), lazy import, mTLS
  via flat tls_set params, deterministic client id (one session per robot),
  retained LWT set before connect, clean close publishes a stopped heartbeat.
- Integration: mosquitto round-trip tests (channels delivery, retained
  schema for late subscribers, clean-stop heartbeat, LWT on unclean
  disconnect), env-gated; new CI `iot` job runs them against a broker
  container.

No runtime wiring; nothing connects unless code constructs a publisher.
Router/spool/startup arrive in steps 4-5.

Stacked on #205; retarget to beta/fleet-streaming after it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)