### PR TITLE
feat(fleet): step 4 — store-and-forward spool with watermark, segments, lanes

### DIFF
--- a/plugin/references/settings-knobs.md
+++ b/plugin/references/settings-knobs.md
@@ -20,4 +20,5 @@ Defined in `settings.py`; set via the container environment or `.env`.
 | `ROSBRIDGE_QUEUE_LENGTH` | 1000 | Messages buffered in rosbridge before sending |
 | `CLOUDINI_ENABLED` | true | Cloudini pointcloud decompression in pipelines |
 | `FLEET_ENABLED` | true | Kill switch for fleet streaming (beta). `0` makes the publish subsystem inert: nothing connects, nothing leaves the box |
+| `FLEET_SPOOL_MAX_BYTES` | 256 MB | Disk cap for the fleet spool's channels lane; oldest segments evicted first. Events/heartbeats are never dropped and are exempt |
 | `BAGEL_FLEET` (build arg) | true | Compose build arg; `false` omits the MQTT client from the iot/ros2 images entirely |

--- a/settings.py
+++ b/settings.py
@@ -84,6 +84,13 @@ class Settings(BaseSettings):
     # regardless of configuration: nothing connects, nothing leaves the box.
     FLEET_ENABLED: bool = True
 
+    # Disk budget for the fleet spool's channels lane (store-and-forward
+    # outbox under CACHE_DIRECTORY/publish/). Oldest segments are dropped
+    # first when over budget; events and heartbeats are never dropped and
+    # don't count against this cap. Transient overshoot of one segment
+    # (~4 MB) is possible while rotating.
+    FLEET_SPOOL_MAX_BYTES: int = 268_435_456
+
     # Default quantization resolution in meters for cloudini lossy compression
     CLOUDINI_DEFAULT_RESOLUTION: float = 0.001
     ###############################################

--- a/src/sink/publish/spool.py
+++ b/src/sink/publish/spool.py
@@ -37,8 +37,40 @@ def _first_seq_of(path: pathlib.Path) -> int:
     return int(path.stem.split("-", 1)[1])
 
 
+def _parse_lines(segment: pathlib.Path, *, tolerate_torn_tail: bool = False) -> Iterator[dict]:
+    """Parse JSONL lines from a segment, optionally tolerating a torn final line.
+
+    Args:
+        segment: Path to segment file.
+        tolerate_torn_tail: If True, ignore JSONDecodeError on the final line only.
+            Corruption in any non-final line still raises.
+
+    Yields:
+        Parsed JSON objects.
+
+    Raises:
+        JSONDecodeError: If any non-final line fails to parse, or if any line fails
+            and tolerate_torn_tail is False.
+
+    """
+    lines = segment.read_text(encoding="utf-8").splitlines()
+    for i, line in enumerate(lines):
+        is_final = i == len(lines) - 1
+        try:
+            yield json.loads(line)
+        except json.JSONDecodeError:
+            if is_final and tolerate_torn_tail:
+                # Skip the torn final line; preceding lines win
+                continue
+            raise
+
+
 class Spool:
-    """One robot's outbox: lanes of segments plus an acked watermark."""
+    """One robot's outbox: lanes of segments plus an acked watermark.
+
+    Callers must maintain the single-writer invariant per lane: only one thread/process
+    appends to a lane at a time. Concurrent producers will collide with ValueError.
+    """
 
     def __init__(self, root: pathlib.Path, capped_lanes: dict[str, int] | None = None) -> None:
         """Initialize spool at root with optional per-lane size caps.
@@ -82,8 +114,8 @@ class Spool:
         if not segments:
             return self._watermark(lane)
         last = 0
-        for line in segments[-1].read_text(encoding="utf-8").splitlines():
-            last = json.loads(line)["seq"]
+        for record in _parse_lines(segments[-1], tolerate_torn_tail=True):
+            last = record["seq"]
         return max(last, self._watermark(lane))
 
     def next_seq(self, lane: str) -> int:
@@ -151,8 +183,9 @@ class Spool:
 
         """
         watermark = self._watermark(lane)
-        for segment in self._segments(lane):
-            for line in segment.read_text(encoding="utf-8").splitlines():
-                record = json.loads(line)
+        segments = self._segments(lane)
+        for i, segment in enumerate(segments):
+            is_final = i == len(segments) - 1
+            for record in _parse_lines(segment, tolerate_torn_tail=is_final):
                 if record["seq"] > watermark:
                     yield record["seq"], record["payload"]

--- a/src/sink/publish/spool.py
+++ b/src/sink/publish/spool.py
@@ -12,8 +12,11 @@ absorbs the replay. Concurrency: every mutator holds the spool's file
 lock (one lock per spool root, like the sink buffer's per-topic locks).
 """
 
+import dataclasses
 import json
+import os
 import pathlib
+import tempfile
 from collections.abc import Iterator
 
 import filelock
@@ -27,6 +30,17 @@ class SpoolError(Exception):
 
 class SpoolFullError(SpoolError):
     """Raised when a never-drop lane cannot write (disk full or failing)."""
+
+
+@dataclasses.dataclass
+class LaneStats:
+    """Per-lane counters for heartbeat/status reporting."""
+
+    bytes: int
+    pending: int
+    last_seq: int
+    acked_seq: int
+    evicted: int = 0
 
 
 def _segment_name(first_seq: int) -> str:
@@ -85,6 +99,7 @@ class Spool:
         self._capped = dict(capped_lanes or {})
         self._lock = filelock.FileLock(str(self._root / ".lock"))
         self._last_seq: dict[str, int] = {}
+        self._evicted: dict[str, int] = {}
 
     # -- paths ---------------------------------------------------------------
 
@@ -159,8 +174,10 @@ class Spool:
             line = json.dumps({"seq": seq, "payload": payload}) + "\n"
             segments = self._segments(lane)
             active = segments[-1] if segments else None
+            rolled = False
             if active is None or active.stat().st_size + len(line) > SEGMENT_MAX_BYTES:
                 active = self._lane_dir(lane) / _segment_name(seq)
+                rolled = True
             try:
                 with open(active, "a", encoding="utf-8") as handle:
                     handle.write(line)
@@ -169,6 +186,105 @@ class Spool:
                     raise SpoolFullError(f"lane '{lane}': {exc}") from exc
                 raise SpoolError(f"lane '{lane}': {exc}") from exc
             self._last_seq[lane] = seq
+            if rolled:
+                self._evict(lane)
+
+    # -- ack & watermark --------------------------------------------------------
+
+    def ack(self, lane: str, seq: int) -> None:
+        """Advance the lane's watermark to ``seq`` and prune acked segments.
+
+        Advance-to semantics: any ``seq`` above the watermark becomes the new
+        watermark (skipped seqs are treated as acked — the publisher sends and
+        acks in order); ``seq`` at or below it is an idempotent no-op.
+        """
+        with self._lock:
+            marks = self._watermarks()
+            if seq <= marks.get(lane, 0):
+                return
+            marks[lane] = seq
+            self._write_watermarks(marks)
+            self._prune(lane, seq)
+
+    def _write_watermarks(self, marks: dict[str, int]) -> None:
+        target = self._root / "watermark.json"
+        fd, tmp = tempfile.mkstemp(prefix=f".{target.name}.", dir=self._root)
+        tmp_path = pathlib.Path(tmp)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(marks, handle)
+            os.replace(tmp_path, target)
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+    def _prune(self, lane: str, watermark: int) -> None:
+        segments = self._segments(lane)
+        for index, segment in enumerate(segments):
+            if index + 1 < len(segments):
+                last_in_segment = _first_seq_of(segments[index + 1]) - 1
+            else:
+                break  # never prune the active (last) segment here
+            if last_in_segment <= watermark:
+                segment.unlink()
+
+    def _evict(self, lane: str) -> None:
+        cap = self._capped.get(lane)
+        if cap is None:
+            return
+        segments = self._segments(lane)
+        total = sum(p.stat().st_size for p in segments)
+        while total > cap and len(segments) > 1:
+            oldest = segments.pop(0)
+            watermark = self._watermark(lane)
+            if len(segments) >= 1:
+                last_in_oldest = _first_seq_of(segments[0]) - 1
+                if last_in_oldest > watermark:
+                    self._evicted[lane] = self._evicted.get(lane, 0) + (
+                        last_in_oldest - max(watermark, _first_seq_of(oldest) - 1)
+                    )
+            total -= oldest.stat().st_size
+            oldest.unlink()
+
+    def stats(self) -> dict[str, LaneStats]:
+        """Get per-lane statistics (bytes, pending, seqs, evicted count).
+
+        Returns:
+            Dict mapping lane name to LaneStats.
+
+        """
+        with self._lock:
+            marks = self._watermarks()
+            out: dict[str, LaneStats] = {}
+            lanes = {p.name for p in self._root.iterdir() if p.is_dir()}
+            for lane in sorted(lanes):
+                segments = self._segments(lane)
+                acked = marks.get(lane, 0)
+                last = self._last_seq.get(lane) or self._scan_last_seq(lane)
+                pending = sum(1 for _ in self.pending(lane))
+                out[lane] = LaneStats(
+                    bytes=sum(p.stat().st_size for p in segments),
+                    pending=pending,
+                    last_seq=last,
+                    acked_seq=acked,
+                    evicted=self._evicted.get(lane, 0),
+                )
+            return out
+
+    @classmethod
+    def for_robot(cls, robot: str) -> "Spool":
+        """Create a Spool for a robot with default caps.
+
+        Args:
+            robot: Robot identifier.
+
+        Returns:
+            Spool configured with default channels lane cap.
+
+        """
+        from settings import settings
+
+        root = pathlib.Path(settings.CACHE_DIRECTORY) / "publish" / robot
+        return cls(root, capped_lanes={"channels": settings.FLEET_SPOOL_MAX_BYTES})
 
     # -- replay ------------------------------------------------------------------
 

--- a/src/sink/publish/spool.py
+++ b/src/sink/publish/spool.py
@@ -1,0 +1,158 @@
+"""Store-and-forward disk spool for fleet streaming (spec §4).
+
+Per-lane append-only JSONL segments named by their first seq
+(``segment-{first_seq:016d}.jsonl``), a per-lane acked-seq watermark in
+``watermark.json`` (atomic replace), delete-only-on-ack, drop-oldest
+eviction for capped lanes, never-drop for the rest.
+
+Durability posture matches the repo: the watermark is rename-atomic;
+segment appends are plain writes (no fsync), so a crash may lose the
+active segment's tail — QoS-1 at-least-once plus cloud-side seq dedupe
+absorbs the replay. Concurrency: every mutator holds the spool's file
+lock (one lock per spool root, like the sink buffer's per-topic locks).
+"""
+
+import json
+import pathlib
+from collections.abc import Iterator
+
+import filelock
+
+SEGMENT_MAX_BYTES = 4 * 1024 * 1024
+
+
+class SpoolError(Exception):
+    """Raised when the spool cannot honor a request."""
+
+
+class SpoolFullError(SpoolError):
+    """Raised when a never-drop lane cannot write (disk full or failing)."""
+
+
+def _segment_name(first_seq: int) -> str:
+    return f"segment-{first_seq:016d}.jsonl"
+
+
+def _first_seq_of(path: pathlib.Path) -> int:
+    return int(path.stem.split("-", 1)[1])
+
+
+class Spool:
+    """One robot's outbox: lanes of segments plus an acked watermark."""
+
+    def __init__(self, root: pathlib.Path, capped_lanes: dict[str, int] | None = None) -> None:
+        """Initialize spool at root with optional per-lane size caps.
+
+        Args:
+            root: Path to spool root directory.
+            capped_lanes: Optional mapping of lane names to byte caps.
+
+        """
+        self._root = pathlib.Path(root)
+        self._root.mkdir(parents=True, exist_ok=True)
+        self._capped = dict(capped_lanes or {})
+        self._lock = filelock.FileLock(str(self._root / ".lock"))
+        self._last_seq: dict[str, int] = {}
+
+    # -- paths ---------------------------------------------------------------
+
+    def _lane_dir(self, lane: str) -> pathlib.Path:
+        path = self._root / lane
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+    def _segments(self, lane: str) -> list[pathlib.Path]:
+        return sorted(self._lane_dir(lane).glob("segment-*.jsonl"))
+
+    # -- watermark (read side; persistence arrives with ack()) ----------------
+
+    def _watermarks(self) -> dict[str, int]:
+        path = self._root / "watermark.json"
+        if not path.exists():
+            return {}
+        return {str(k): int(v) for k, v in json.loads(path.read_text()).items()}
+
+    def _watermark(self, lane: str) -> int:
+        return self._watermarks().get(lane, 0)
+
+    # -- seq allocation --------------------------------------------------------
+
+    def _scan_last_seq(self, lane: str) -> int:
+        segments = self._segments(lane)
+        if not segments:
+            return self._watermark(lane)
+        last = 0
+        for line in segments[-1].read_text(encoding="utf-8").splitlines():
+            last = json.loads(line)["seq"]
+        return max(last, self._watermark(lane))
+
+    def next_seq(self, lane: str) -> int:
+        """Get the next sequence number for a lane.
+
+        Args:
+            lane: Lane name.
+
+        Returns:
+            Next monotonic sequence number (1-based).
+
+        """
+        with self._lock:
+            if lane not in self._last_seq:
+                self._last_seq[lane] = self._scan_last_seq(lane)
+            return self._last_seq[lane] + 1
+
+    # -- append ----------------------------------------------------------------
+
+    def append(self, lane: str, seq: int, payload: dict) -> None:
+        """Append a record to a lane.
+
+        Args:
+            lane: Lane name.
+            seq: Sequence number (must be > last written seq).
+            payload: JSON-serializable record.
+
+        Raises:
+            ValueError: If seq is not monotonic.
+            SpoolFullError: If lane is never-capped and write fails.
+            SpoolError: If lane is capped and write fails.
+
+        """
+        with self._lock:
+            if lane not in self._last_seq:
+                self._last_seq[lane] = self._scan_last_seq(lane)
+            if seq <= self._last_seq[lane]:
+                raise ValueError(
+                    f"seq must be monotonic: got {seq}, last was {self._last_seq[lane]}"
+                )
+            line = json.dumps({"seq": seq, "payload": payload}) + "\n"
+            segments = self._segments(lane)
+            active = segments[-1] if segments else None
+            if active is None or active.stat().st_size + len(line) > SEGMENT_MAX_BYTES:
+                active = self._lane_dir(lane) / _segment_name(seq)
+            try:
+                with open(active, "a", encoding="utf-8") as handle:
+                    handle.write(line)
+            except OSError as exc:
+                if lane not in self._capped:
+                    raise SpoolFullError(f"lane '{lane}': {exc}") from exc
+                raise SpoolError(f"lane '{lane}': {exc}") from exc
+            self._last_seq[lane] = seq
+
+    # -- replay ------------------------------------------------------------------
+
+    def pending(self, lane: str) -> Iterator[tuple[int, dict]]:
+        """Iterate over all records in a lane with seq > watermark.
+
+        Args:
+            lane: Lane name.
+
+        Yields:
+            Tuples of (seq, payload) in ascending seq order.
+
+        """
+        watermark = self._watermark(lane)
+        for segment in self._segments(lane):
+            for line in segment.read_text(encoding="utf-8").splitlines():
+                record = json.loads(line)
+                if record["seq"] > watermark:
+                    yield record["seq"], record["payload"]

--- a/src/sink/publish/spool.py
+++ b/src/sink/publish/spool.py
@@ -40,7 +40,7 @@ class LaneStats:
     pending: int
     last_seq: int
     acked_seq: int
-    evicted: int = 0
+    evicted: int = 0  # Records discarded by eviction; exact if contiguous, may over-count if gapped
 
 
 def _segment_name(first_seq: int) -> str:
@@ -228,20 +228,25 @@ class Spool:
                 segment.unlink()
 
     def _evict(self, lane: str) -> None:
+        """Unlink oldest segments when lane bytes exceed cap.
+
+        Evicted-count tracking counts records above the watermark that were unlinked.
+        For contiguous seqs, the count is exact; with seq gaps, it may over-count (erring
+        toward reporting data loss). Seqs below the watermark are never counted as loss.
+        """
         cap = self._capped.get(lane)
         if cap is None:
             return
         segments = self._segments(lane)
         total = sum(p.stat().st_size for p in segments)
+        watermark = self._watermark(lane)
         while total > cap and len(segments) > 1:
             oldest = segments.pop(0)
-            watermark = self._watermark(lane)
-            if len(segments) >= 1:
-                last_in_oldest = _first_seq_of(segments[0]) - 1
-                if last_in_oldest > watermark:
-                    self._evicted[lane] = self._evicted.get(lane, 0) + (
-                        last_in_oldest - max(watermark, _first_seq_of(oldest) - 1)
-                    )
+            last_in_oldest = _first_seq_of(segments[0]) - 1
+            if last_in_oldest > watermark:
+                self._evicted[lane] = self._evicted.get(lane, 0) + (
+                    last_in_oldest - max(watermark, _first_seq_of(oldest) - 1)
+                )
             total -= oldest.stat().st_size
             oldest.unlink()
 
@@ -275,15 +280,37 @@ class Spool:
         """Create a Spool for a robot with default caps.
 
         Args:
-            robot: Robot identifier.
+            robot: Robot identifier in shape tenant/robot or robot (one `/` max).
+                   Must not contain `.`, `..`, or be empty. No leading `/`.
 
         Returns:
             Spool configured with default channels lane cap.
 
+        Raises:
+            ValueError: If robot contains path traversal or is malformed.
+
         """
         from settings import settings
 
-        root = pathlib.Path(settings.CACHE_DIRECTORY) / "publish" / robot
+        # Validate robot identifier to prevent path traversal
+        if not robot:
+            raise ValueError("robot must be non-empty")
+        if robot.startswith("/"):
+            raise ValueError("robot must not start with /")
+        segments = robot.split("/")
+        max_segments = 2  # tenant/robot or robot (0 vs 1 slash)
+        if len(segments) > max_segments:
+            raise ValueError("robot must have at most one / (format: robot or tenant/robot)")
+        for segment in segments:
+            if not segment or segment in (".", ".."):
+                raise ValueError("robot segments must be non-empty and not . or ..")
+
+        # Belt-and-braces: ensure resolved path is within publish directory
+        base = (pathlib.Path(settings.CACHE_DIRECTORY) / "publish").resolve()
+        root = (base / robot).resolve()
+        if not root.is_relative_to(base):
+            raise ValueError(f"robot path escapes base directory: {root}")
+
         return cls(root, capped_lanes={"channels": settings.FLEET_SPOOL_MAX_BYTES})
 
     # -- replay ------------------------------------------------------------------

--- a/src/sink/publish/spool.py
+++ b/src/sink/publish/spool.py
@@ -32,6 +32,10 @@ class SpoolFullError(SpoolError):
     """Raised when a never-drop lane cannot write (disk full or failing)."""
 
 
+class SpoolCorruptError(SpoolError):
+    """Raised when a segment has mid-file JSON corruption (not a crash-torn final line)."""
+
+
 @dataclasses.dataclass
 class LaneStats:
     """Per-lane counters for heartbeat/status reporting."""
@@ -51,32 +55,61 @@ def _first_seq_of(path: pathlib.Path) -> int:
     return int(path.stem.split("-", 1)[1])
 
 
-def _parse_lines(segment: pathlib.Path, *, tolerate_torn_tail: bool = False) -> Iterator[dict]:
-    """Parse JSONL lines from a segment, optionally tolerating a torn final line.
+def _scan_segment(
+    segment: pathlib.Path, *, lane: str, tolerate_torn_tail: bool = False
+) -> tuple[list[dict], int, bool]:
+    r"""Parse JSONL lines from a segment, tracking the good-data boundary.
+
+    Reads raw bytes (not text) so the returned offset is directly usable with
+    ``os.truncate``. A "line" is a chunk ending in ``b"\n"``; the final chunk of
+    a file that does not end in a newline is a crash-torn write in progress.
 
     Args:
         segment: Path to segment file.
-        tolerate_torn_tail: If True, ignore JSONDecodeError on the final line only.
-            Corruption in any non-final line still raises.
+        lane: Lane name, used only for the corruption error message.
+        tolerate_torn_tail: If True, a torn or unparseable *final* line is dropped
+            instead of raised. Corruption in any earlier line always raises.
 
-    Yields:
-        Parsed JSON objects.
+    Returns:
+        (records, good_end_offset, torn):
+            records: Parsed JSON objects, in file order, excluding a dropped torn tail.
+            good_end_offset: Byte offset immediately after the last good line's
+                trailing newline (0 if the segment has no good lines). Truncating
+                the file to this offset discards exactly the torn tail, if any.
+            torn: True if the final line was torn/unparseable and dropped.
 
     Raises:
-        JSONDecodeError: If any non-final line fails to parse, or if any line fails
-            and tolerate_torn_tail is False.
+        SpoolCorruptError: A non-final line fails to parse, or the final line fails
+            to parse and tolerate_torn_tail is False.
 
     """
-    lines = segment.read_text(encoding="utf-8").splitlines()
-    for i, line in enumerate(lines):
-        is_final = i == len(lines) - 1
-        try:
-            yield json.loads(line)
-        except json.JSONDecodeError:
+    data = segment.read_bytes()
+    chunks = data.splitlines(keepends=True)
+    records: list[dict] = []
+    good_end = 0
+    torn = False
+    for i, chunk in enumerate(chunks):
+        is_final = i == len(chunks) - 1
+        line_no = i + 1
+        if not chunk.endswith(b"\n"):
             if is_final and tolerate_torn_tail:
-                # Skip the torn final line; preceding lines win
-                continue
-            raise
+                torn = True
+                break
+            raise SpoolCorruptError(
+                f"lane '{lane}': segment '{segment.name}': truncated line {line_no} (no newline)"
+            )
+        try:
+            record = json.loads(chunk.decode("utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            if is_final and tolerate_torn_tail:
+                torn = True
+                break
+            raise SpoolCorruptError(
+                f"lane '{lane}': segment '{segment.name}': corrupt JSON at line {line_no}"
+            ) from exc
+        records.append(record)
+        good_end += len(chunk)
+    return records, good_end, torn
 
 
 class Spool:
@@ -103,13 +136,23 @@ class Spool:
 
     # -- paths ---------------------------------------------------------------
 
-    def _lane_dir(self, lane: str) -> pathlib.Path:
+    def _lane_dir(self, lane: str, *, create: bool = True) -> pathlib.Path:
         path = self._root / lane
-        path.mkdir(parents=True, exist_ok=True)
+        if create:
+            path.mkdir(parents=True, exist_ok=True)
         return path
 
-    def _segments(self, lane: str) -> list[pathlib.Path]:
-        return sorted(self._lane_dir(lane).glob("segment-*.jsonl"))
+    def _segments(self, lane: str, *, create: bool = True) -> list[pathlib.Path]:
+        """List a lane's segments in order.
+
+        Read paths (pending/stats/ack) must pass create=False: a never-written
+        lane has no directory, and a read must not conjure one into existence
+        (that would pollute stats with a phantom, permanently-empty lane).
+        """
+        lane_dir = self._lane_dir(lane, create=create)
+        if not lane_dir.exists():
+            return []
+        return sorted(lane_dir.glob("segment-*.jsonl"))
 
     # -- watermark (read side; persistence arrives with ack()) ----------------
 
@@ -125,13 +168,27 @@ class Spool:
     # -- seq allocation --------------------------------------------------------
 
     def _scan_last_seq(self, lane: str) -> int:
+        """Recover the last written seq for a lane and seal its active segment.
+
+        Segment file names encode history: even when the last segment is empty or
+        wholly torn by a crash, the previous segment's records prove seqs up to
+        ``_first_seq_of(last_segment) - 1`` were already written, so the recovered
+        seq must never fall below that floor (falling below it would let ``next_seq``
+        reissue already-used seqs). If the last segment has a crash-torn tail, this
+        also truncates the file to the last good line's end offset so the next
+        ``append`` starts from a clean line boundary instead of writing onto the
+        partial line.
+        """
         segments = self._segments(lane)
         if not segments:
             return self._watermark(lane)
-        last = 0
-        for record in _parse_lines(segments[-1], tolerate_torn_tail=True):
-            last = record["seq"]
-        return max(last, self._watermark(lane))
+        last_segment = segments[-1]
+        records, good_end, torn = _scan_segment(last_segment, lane=lane, tolerate_torn_tail=True)
+        if torn and good_end < last_segment.stat().st_size:
+            os.truncate(last_segment, good_end)
+        last = records[-1]["seq"] if records else 0
+        floor = _first_seq_of(last_segment) - 1
+        return max(last, floor, self._watermark(lane))
 
     def next_seq(self, lane: str) -> int:
         """Get the next sequence number for a lane.
@@ -141,6 +198,10 @@ class Spool:
 
         Returns:
             Next monotonic sequence number (1-based).
+
+        Raises:
+            SpoolCorruptError: The lane's active segment has mid-file corruption
+                (only on the first call for this lane in this process's lifetime).
 
         """
         with self._lock:
@@ -162,6 +223,8 @@ class Spool:
             ValueError: If seq is not monotonic.
             SpoolFullError: If lane is never-capped and write fails.
             SpoolError: If lane is capped and write fails.
+            SpoolCorruptError: The lane's active segment has mid-file corruption
+                (only on the first call for this lane in this process's lifetime).
 
         """
         with self._lock:
@@ -218,7 +281,7 @@ class Spool:
             tmp_path.unlink(missing_ok=True)
 
     def _prune(self, lane: str, watermark: int) -> None:
-        segments = self._segments(lane)
+        segments = self._segments(lane, create=False)
         for index, segment in enumerate(segments):
             if index + 1 < len(segments):
                 last_in_segment = _first_seq_of(segments[index + 1]) - 1
@@ -324,11 +387,23 @@ class Spool:
         Yields:
             Tuples of (seq, payload) in ascending seq order.
 
+        Raises:
+            SpoolCorruptError: A non-final segment line, or a non-final segment's
+                final line, fails to parse (mid-file corruption).
+
+        Note:
+            This is a read path: it never creates a lane directory. An ack for a
+            yielded record may arrive on the publisher's callback thread only after
+            that record has been yielded here; the segment list is captured once, at
+            the start of iteration, so segments rolled or pruned mid-iteration by a
+            concurrent ack do not change what this call sees.
+
         """
         watermark = self._watermark(lane)
-        segments = self._segments(lane)
+        segments = self._segments(lane, create=False)
         for i, segment in enumerate(segments):
             is_final = i == len(segments) - 1
-            for record in _parse_lines(segment, tolerate_torn_tail=is_final):
+            records, _, _ = _scan_segment(segment, lane=lane, tolerate_torn_tail=is_final)
+            for record in records:
                 if record["seq"] > watermark:
                     yield record["seq"], record["payload"]

--- a/test/sink/publish/test_spool.py
+++ b/test/sink/publish/test_spool.py
@@ -117,3 +117,96 @@ class TestCrashTolerance:
         s2 = Spool(root)
         with pytest.raises(json.JSONDecodeError):
             list(s2.pending("channels"))
+
+
+class TestAckAndWatermark:
+    def test_ack_prunes_fully_acked_segments(
+        self, root: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(spool_mod, "SEGMENT_MAX_BYTES", 120)
+        s = Spool(root)
+        for i in range(1, 10):
+            s.append("channels", i, {"pad": "x" * 40, "n": i})
+        segments_before = len(list((root / "channels").glob("segment-*.jsonl")))
+        assert segments_before >= 3
+        s.ack("channels", 8)
+        remaining = sorted((root / "channels").glob("segment-*.jsonl"))
+        assert len(remaining) < segments_before
+        assert [seq for seq, _ in s.pending("channels")] == [9]
+
+    def test_ack_is_idempotent_and_ignores_stale(self, root: pathlib.Path) -> None:
+        s = Spool(root)
+        for i in range(1, 4):
+            s.append("channels", i, {"n": i})
+        s.ack("channels", 2)
+        s.ack("channels", 2)
+        s.ack("channels", 1)  # stale: no-op
+        assert [seq for seq, _ in s.pending("channels")] == [3]
+
+    def test_watermark_survives_restart_exactly(self, root: pathlib.Path) -> None:
+        s = Spool(root)
+        for i in range(1, 6):
+            s.append("channels", i, {"n": i})
+        s.ack("channels", 3)
+        del s
+        s2 = Spool(root)
+        assert [seq for seq, _ in s2.pending("channels")] == [4, 5]
+        assert s2.next_seq("channels") == 6
+
+    def test_watermark_file_is_valid_json_after_ack(self, root: pathlib.Path) -> None:
+        s = Spool(root)
+        s.append("channels", 1, {"n": 1})
+        s.ack("channels", 1)
+        data = json.loads((root / "watermark.json").read_text())
+        assert data == {"channels": 1}
+
+
+class TestEvictionAndCaps:
+    def test_capped_lane_evicts_oldest_segments(
+        self, root: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(spool_mod, "SEGMENT_MAX_BYTES", 120)
+        s = Spool(root, capped_lanes={"channels": 300})
+        for i in range(1, 30):
+            s.append("channels", i, {"pad": "x" * 40, "n": i})
+        lane_bytes = sum(p.stat().st_size for p in (root / "channels").glob("*.jsonl"))
+        assert lane_bytes <= 300 + 120  # cap + one-segment slack
+        pending = [seq for seq, _ in s.pending("channels")]
+        assert pending == sorted(pending)
+        assert pending[-1] == 29  # newest survives
+        assert s.stats()["channels"].evicted > 0
+
+    def test_never_drop_lane_ignores_caps_and_grows(
+        self, root: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(spool_mod, "SEGMENT_MAX_BYTES", 120)
+        s = Spool(root, capped_lanes={"channels": 300})
+        for i in range(1, 30):
+            s.append("events", i, {"pad": "x" * 40, "n": i})
+        assert len([seq for seq, _ in s.pending("events")]) == 29
+
+    def test_write_failure_on_never_drop_lane_raises_spool_full(
+        self, root: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        s = Spool(root)
+        s.append("events", 1, {"n": 1})
+
+        def boom(*a: object, **k: object) -> object:
+            raise OSError(28, "No space left on device")
+
+        monkeypatch.setattr("builtins.open", boom)
+        with pytest.raises(spool_mod.SpoolFullError, match="events"):
+            s.append("events", 2, {"n": 2})
+
+
+class TestStats:
+    def test_stats_reports_bytes_pending_and_seqs(self, root: pathlib.Path) -> None:
+        s = Spool(root)
+        for i in range(1, 5):
+            s.append("channels", i, {"n": i})
+        s.ack("channels", 1)
+        st = s.stats()["channels"]
+        assert st.pending == 3
+        assert st.last_seq == 4
+        assert st.acked_seq == 1
+        assert st.bytes > 0

--- a/test/sink/publish/test_spool.py
+++ b/test/sink/publish/test_spool.py
@@ -76,3 +76,44 @@ class TestSegments:
         size_before = seg.stat().st_size
         s.append("channels", 2, {"n": 2})
         assert seg.stat().st_size > size_before  # appended, not rewritten
+
+
+class TestCrashTolerance:
+    def test_truncated_final_line_skipped_on_restart(self, root: pathlib.Path) -> None:
+        """Crash-truncated final line is skipped; restart recovers preceding records."""
+        s = Spool(root)
+        s.append("channels", 1, {"n": 1})
+        s.append("channels", 2, {"n": 2})
+        s.append("channels", 3, {"n": 3})
+        del s
+
+        # Truncate the final line of the segment mid-record (simulate crash).
+        seg = next((root / "channels").glob("segment-*.jsonl"))
+        text = seg.read_text()
+        # Remove last 15 characters to tear the final JSON record.
+        seg.write_text(text[:-15])
+
+        # Restart should not crash; next_seq skips torn line and resumes from seq 3.
+        s2 = Spool(root)
+        assert s2.next_seq("channels") == 3
+        # Pending yields only intact records, skipping the torn one.
+        assert [seq for seq, _ in s2.pending("channels")] == [1, 2]
+
+    def test_corrupted_middle_line_raises(self, root: pathlib.Path) -> None:
+        """Corruption in a middle line (real data corruption) raises on parse."""
+        s = Spool(root)
+        s.append("channels", 1, {"n": 1})
+        s.append("channels", 2, {"n": 2})
+        s.append("channels", 3, {"n": 3})
+        del s
+
+        # Corrupt a middle line by replacing it with garbage.
+        seg = next((root / "channels").glob("segment-*.jsonl"))
+        lines = seg.read_text().splitlines()
+        lines[1] = "corrupted garbage line"  # Corrupt the second line.
+        seg.write_text("\n".join(lines) + "\n")
+
+        # Restart fails because pending encounters corrupted line in the middle.
+        s2 = Spool(root)
+        with pytest.raises(json.JSONDecodeError):
+            list(s2.pending("channels"))

--- a/test/sink/publish/test_spool.py
+++ b/test/sink/publish/test_spool.py
@@ -260,3 +260,14 @@ class TestForRobot:
     def test_for_robot_rejects_dot_segment(self) -> None:
         with pytest.raises(ValueError, match="must be non-empty and not"):
             Spool.for_robot(".")
+
+
+def test_spool_module_does_not_import_paho_eagerly(monkeypatch: pytest.MonkeyPatch) -> None:
+    import importlib
+    import sys
+
+    for name in [m for m in sys.modules if m == "paho" or m.startswith("paho.")]:
+        monkeypatch.delitem(sys.modules, name)
+    monkeypatch.delitem(sys.modules, "src.sink.publish.spool", raising=False)
+    importlib.import_module("src.sink.publish.spool")
+    assert not any(m == "paho" or m.startswith("paho.") for m in sys.modules)

--- a/test/sink/publish/test_spool.py
+++ b/test/sink/publish/test_spool.py
@@ -1,0 +1,78 @@
+"""Disk spool: segments, watermark, lanes (fleet streaming spec §4)."""
+
+import json
+import pathlib
+
+import pytest
+
+from src.sink.publish import spool as spool_mod
+from src.sink.publish.spool import Spool
+
+
+@pytest.fixture()
+def root(tmp_path: pathlib.Path) -> pathlib.Path:
+    return tmp_path / "publish" / "robot-1"
+
+
+class TestAppendAndReplay:
+    def test_seq_allocation_starts_at_one_and_is_monotonic(self, root: pathlib.Path) -> None:
+        s = Spool(root)
+        assert s.next_seq("channels") == 1
+        s.append("channels", 1, {"v": 1})
+        assert s.next_seq("channels") == 2
+
+    def test_append_rejects_non_monotonic_seq(self, root: pathlib.Path) -> None:
+        s = Spool(root)
+        s.append("channels", 1, {"v": 1})
+        with pytest.raises(ValueError, match="monotonic"):
+            s.append("channels", 1, {"v": 1})
+
+    def test_pending_replays_in_order(self, root: pathlib.Path) -> None:
+        s = Spool(root)
+        for i in range(1, 6):
+            s.append("channels", i, {"n": i})
+        assert [(seq, p["n"]) for seq, p in s.pending("channels")] == [(i, i) for i in range(1, 6)]
+
+    def test_lanes_are_independent(self, root: pathlib.Path) -> None:
+        s = Spool(root)
+        s.append("channels", 1, {"c": 1})
+        s.append("events", 1, {"e": 1})
+        assert [p for _, p in s.pending("events")] == [{"e": 1}]
+
+    def test_restart_resumes_seq_and_replay(self, root: pathlib.Path) -> None:
+        s = Spool(root)
+        for i in range(1, 4):
+            s.append("channels", i, {"n": i})
+        del s
+        s2 = Spool(root)
+        assert s2.next_seq("channels") == 4
+        assert [seq for seq, _ in s2.pending("channels")] == [1, 2, 3]
+
+
+class TestSegments:
+    def test_segments_roll_at_size_cap(
+        self, root: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(spool_mod, "SEGMENT_MAX_BYTES", 200)
+        s = Spool(root)
+        big = {"pad": "x" * 80}
+        for i in range(1, 7):
+            s.append("channels", i, big)
+        segments = sorted((root / "channels").glob("segment-*.jsonl"))
+        assert len(segments) >= 3
+        # Named by first seq: the first segment starts at 1.
+        assert segments[0].name == f"segment-{1:016d}.jsonl"
+        # Every line in a segment parses and seqs ascend across segment order.
+        seqs = []
+        for seg in segments:
+            for line in seg.read_text().splitlines():
+                seqs.append(json.loads(line)["seq"])
+        assert seqs == sorted(seqs) == list(range(1, 7))
+
+    def test_active_segment_appends_dont_rewrite(self, root: pathlib.Path) -> None:
+        s = Spool(root)
+        s.append("channels", 1, {"n": 1})
+        seg = next((root / "channels").glob("segment-*.jsonl"))
+        size_before = seg.stat().st_size
+        s.append("channels", 2, {"n": 2})
+        assert seg.stat().st_size > size_before  # appended, not rewritten

--- a/test/sink/publish/test_spool.py
+++ b/test/sink/publish/test_spool.py
@@ -210,3 +210,53 @@ class TestStats:
         assert st.last_seq == 4
         assert st.acked_seq == 1
         assert st.bytes > 0
+
+
+class TestForRobot:
+    def test_for_robot_single_segment_nests_correctly(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """for_robot('r7') creates spool at CACHE_DIRECTORY/publish/r7 with channels cap."""
+        monkeypatch.setattr("settings.settings.CACHE_DIRECTORY", str(tmp_path))
+        monkeypatch.setattr("settings.settings.FLEET_SPOOL_MAX_BYTES", 500)
+        s = Spool.for_robot("r7")
+        s.append("channels", 1, {"n": 1})
+        assert (tmp_path / "publish" / "r7" / "channels").exists()
+        assert s._capped["channels"] == 500
+
+    def test_for_robot_two_segment_nests_correctly(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """for_robot('acme/r7') creates spool at CACHE_DIRECTORY/publish/acme/r7."""
+        monkeypatch.setattr("settings.settings.CACHE_DIRECTORY", str(tmp_path))
+        s = Spool.for_robot("acme/r7")
+        s.append("channels", 1, {"n": 1})
+        assert (tmp_path / "publish" / "acme" / "r7" / "channels").exists()
+
+    def test_for_robot_rejects_leading_slash(self) -> None:
+        with pytest.raises(ValueError, match="must not start with /"):
+            Spool.for_robot("/etc/passwd")
+
+    def test_for_robot_rejects_empty_string(self) -> None:
+        with pytest.raises(ValueError, match="must be non-empty"):
+            Spool.for_robot("")
+
+    def test_for_robot_rejects_dot_dot(self) -> None:
+        with pytest.raises(ValueError, match="at most one /"):
+            Spool.for_robot("../../evil")
+
+    def test_for_robot_rejects_dot_dot_in_path(self) -> None:
+        with pytest.raises(ValueError, match="at most one /"):
+            Spool.for_robot("a/../b")
+
+    def test_for_robot_rejects_too_many_segments(self) -> None:
+        with pytest.raises(ValueError, match="at most one /"):
+            Spool.for_robot("a/b/c")
+
+    def test_for_robot_rejects_empty_segment(self) -> None:
+        with pytest.raises(ValueError, match="must be non-empty"):
+            Spool.for_robot("acme/")
+
+    def test_for_robot_rejects_dot_segment(self) -> None:
+        with pytest.raises(ValueError, match="must be non-empty and not"):
+            Spool.for_robot(".")

--- a/test/sink/publish/test_spool.py
+++ b/test/sink/publish/test_spool.py
@@ -6,7 +6,7 @@ import pathlib
 import pytest
 
 from src.sink.publish import spool as spool_mod
-from src.sink.publish.spool import Spool
+from src.sink.publish.spool import Spool, SpoolCorruptError
 
 
 @pytest.fixture()
@@ -115,8 +115,135 @@ class TestCrashTolerance:
 
         # Restart fails because pending encounters corrupted line in the middle.
         s2 = Spool(root)
-        with pytest.raises(json.JSONDecodeError):
+        with pytest.raises(SpoolCorruptError, match="channels") as exc_info:
             list(s2.pending("channels"))
+        # Typed contract: message names the lane and the segment file, and chains
+        # the underlying parse failure.
+        assert seg.name in str(exc_info.value)
+        assert isinstance(exc_info.value.__cause__, json.JSONDecodeError)
+
+
+class TestRollBoundaryCrashRecovery:
+    """Final-review Critical 1: a crash exactly at a segment roll must not reset seq.
+
+    With SEGMENT_MAX_BYTES forced to 1, every append rolls into its own segment, so
+    each segment holds exactly one record and its name's first_seq equals that
+    record's seq. This makes "the last segment lost its only record" deterministic
+    to set up: whatever is left in segments[:-1] proves seqs up to
+    first_seq_of(segments[-1]) - 1 were durably written, even though the last
+    segment itself now looks empty (or wholly torn).
+    """
+
+    def test_empty_last_segment_floors_seq_at_segment_name_not_watermark(
+        self, root: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(spool_mod, "SEGMENT_MAX_BYTES", 1)
+        s = Spool(root)
+        for i in range(1, 4):
+            s.append("channels", i, {"n": i})
+        segments = sorted((root / "channels").glob("segment-*.jsonl"))
+        assert len(segments) == 3  # one record per segment, as designed above
+        last_first_seq = spool_mod._first_seq_of(segments[-1])
+        del s
+
+        # Crash landed after the roll created the file but before any bytes landed.
+        segments[-1].write_bytes(b"")
+
+        s2 = Spool(root)
+        assert s2.next_seq("channels") == last_first_seq  # floor, not a reset to 1
+        s2.append("channels", last_first_seq, {"n": last_first_seq})
+        assert [seq for seq, _ in s2.pending("channels")] == list(range(1, last_first_seq + 1))
+
+    def test_torn_only_line_of_last_segment_floors_seq_at_segment_name_not_watermark(
+        self, root: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(spool_mod, "SEGMENT_MAX_BYTES", 1)
+        s = Spool(root)
+        for i in range(1, 4):
+            s.append("channels", i, {"n": i})
+        segments = sorted((root / "channels").glob("segment-*.jsonl"))
+        assert len(segments) == 3
+        last_first_seq = spool_mod._first_seq_of(segments[-1])
+        del s
+
+        # Tear the segment's only line mid-record (simulate a crash mid-write).
+        text = segments[-1].read_text()
+        assert text
+        segments[-1].write_text(text[:-5])
+
+        s2 = Spool(root)
+        assert s2.next_seq("channels") == last_first_seq  # floor from the segment name
+        s2.append("channels", last_first_seq, {"n": last_first_seq})
+        assert [seq for seq, _ in s2.pending("channels")] == list(range(1, last_first_seq + 1))
+
+
+class TestTornTailSealedOnRestart:
+    """Final-review Critical 2: a torn tail must be repaired before the next append,
+    or the next append grafts onto the partial line and corrupts the segment.
+    """
+
+    def test_torn_tail_then_append_yields_prefix_plus_new_record_no_graft(
+        self, root: pathlib.Path
+    ) -> None:
+        s = Spool(root)
+        s.append("channels", 1, {"n": 1})
+        s.append("channels", 2, {"n": 2})
+        s.append("channels", 3, {"n": 3})
+        del s
+
+        seg = next((root / "channels").glob("segment-*.jsonl"))
+        text = seg.read_text()
+        seg.write_text(text[:-15])  # tear the final record mid-write
+
+        s2 = Spool(root)
+        # The torn tail is sealed (truncated away) before this first append lands,
+        # so the new record starts on a clean line boundary.
+        s2.append("channels", 3, {"n": 3, "resent": True})
+        assert [seq for seq, _ in s2.pending("channels")] == [1, 2, 3]
+
+        # A second append must still parse cleanly (no garbage mid-file to trip on).
+        s2.append("channels", 4, {"n": 4})
+        assert [seq for seq, _ in s2.pending("channels")] == [1, 2, 3, 4]
+
+        # Nothing grafted: every line in the segment is valid, standalone JSON.
+        for line in seg.read_text().splitlines():
+            json.loads(line)
+
+    def test_never_drop_lane_torn_tail_repaired_on_restart(self, root: pathlib.Path) -> None:
+        """Same repair, exercised explicitly on a never-drop lane ("events")."""
+        s = Spool(root)
+        s.append("events", 1, {"n": 1})
+        s.append("events", 2, {"n": 2})
+        s.append("events", 3, {"n": 3})
+        del s
+
+        seg = next((root / "events").glob("segment-*.jsonl"))
+        text = seg.read_text()
+        seg.write_text(text[:-15])
+
+        s2 = Spool(root)
+        s2.append("events", 3, {"n": 3, "resent": True})
+        assert [seq for seq, _ in s2.pending("events")] == [1, 2, 3]
+        s2.append("events", 4, {"n": 4})
+        assert [seq for seq, _ in s2.pending("events")] == [1, 2, 3, 4]
+        for line in seg.read_text().splitlines():
+            json.loads(line)
+
+
+class TestReadPathPurity:
+    def test_pending_and_stats_do_not_create_dirs_for_unknown_lane(
+        self, root: pathlib.Path
+    ) -> None:
+        s = Spool(root)
+        assert list(s.pending("ghost")) == []
+        assert not (root / "ghost").exists()
+
+        stats = s.stats()
+        assert "ghost" not in stats
+        assert not (root / "ghost").exists()
+
+        s.ack("ghost", 5)  # acking an unwritten lane must not conjure a dir either
+        assert not (root / "ghost").exists()
 
 
 class TestAckAndWatermark:

--- a/test/sink/publish/test_spool_properties.py
+++ b/test/sink/publish/test_spool_properties.py
@@ -1,0 +1,67 @@
+"""Spool invariants under arbitrary operation sequences (spec §8 property tests)."""
+
+import json
+
+import pytest
+from hypothesis import given
+from hypothesis import settings as hyp_settings
+from hypothesis import strategies as st
+
+from src.sink.publish import spool as spool_mod
+from src.sink.publish.spool import Spool
+
+
+@given(
+    n_records=st.integers(min_value=1, max_value=60),
+    ack_at=st.integers(min_value=0, max_value=60),
+    restart_at=st.integers(min_value=0, max_value=60),
+)
+@hyp_settings(max_examples=50, deadline=None)
+def test_replay_is_exactly_the_unacked_suffix(
+    tmp_path_factory: pytest.TempPathFactory,
+    n_records: int,
+    ack_at: int,
+    restart_at: int,
+) -> None:
+    root = tmp_path_factory.mktemp("spool")
+    s = Spool(root)
+    for i in range(1, n_records + 1):
+        s.append("events", i, {"n": i})
+        if i == restart_at:
+            s = Spool(root)  # simulated restart mid-stream
+    effective_ack = min(ack_at, n_records)
+    if effective_ack:
+        s.ack("events", effective_ack)
+    s = Spool(root)  # restart after ack
+    replayed = [seq for seq, _ in s.pending("events")]
+    assert replayed == list(range(effective_ack + 1, n_records + 1))
+    assert s.next_seq("events") == n_records + 1
+
+
+@given(
+    record_pad=st.integers(min_value=10, max_value=200),
+    n_records=st.integers(min_value=5, max_value=80),
+    cap=st.integers(min_value=200, max_value=1200),
+)
+@hyp_settings(max_examples=40, deadline=None)
+def test_capped_lane_bounded_and_ordered(
+    tmp_path_factory: pytest.TempPathFactory,
+    record_pad: int,
+    n_records: int,
+    cap: int,
+) -> None:
+    root = tmp_path_factory.mktemp("spool")
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(spool_mod, "SEGMENT_MAX_BYTES", 128)
+        s = Spool(root, capped_lanes={"channels": cap})
+        for i in range(1, n_records + 1):
+            s.append("channels", i, {"pad": "x" * record_pad, "n": i})
+        lane_bytes = sum(p.stat().st_size for p in (root / "channels").glob("*.jsonl"))
+        assert lane_bytes <= cap + spool_mod.SEGMENT_MAX_BYTES
+        pending = [seq for seq, _ in s.pending("channels")]
+        assert pending == sorted(pending)
+        assert pending[-1] == n_records  # newest always survives
+        # No parse damage anywhere.
+        for seg in (root / "channels").glob("*.jsonl"):
+            for line in seg.read_text().splitlines():
+                json.loads(line)


### PR DESCRIPTION
## Summary

Step 4 of fleet streaming: the store-and-forward disk spool that sits
between publish producers and the MQTT publisher (step 3), giving each
robot a crash-tolerant, per-lane outbox on disk.

- **Segments named by first seq** (`segment-{first_seq:016d}.jsonl`),
  append-only, rolled at `SEGMENT_MAX_BYTES` (4 MB).
- **Advance-to ack semantics**: `ack(lane, seq)` moves the watermark
  forward to `seq` (skipped seqs are treated as acked — the publisher
  sends and acks in order); `seq` at or below the current watermark is
  an idempotent no-op.
- **Rename-atomic watermark**: `watermark.json` is written via
  `mkstemp` + `os.replace`, so a crash mid-write never corrupts the
  watermark or rewinds it.
- **Drop-oldest capped lanes** (`channels`) vs **never-drop** lanes
  (`events`, `heartbeat`): capped lanes evict their oldest unacked
  segments to stay near the byte cap; never-drop lanes surface a typed
  `SpoolFullError` instead of silently discarding data.
- **`LaneStats`** (bytes, pending, last_seq, acked_seq, evicted) for
  heartbeat/status reporting.
- **Crash tolerance**: a torn final line (mid-write crash) is skipped
  on replay; corruption in a non-final line still raises, since that's
  real data corruption rather than a torn write.
- **Property-tested replay exactness** (this PR, spec §8): arbitrary
  interleavings of append/ack/restart always replay exactly the
  unacked suffix, and a capped lane always stays bounded, ordered, and
  parseable, across arbitrary record sizes/counts/caps.

### This PR (Task 3 of the spool work)

- `test/sink/publish/test_spool_properties.py` — two Hypothesis
  properties: replay-is-exactly-the-unacked-suffix under arbitrary
  append/ack/restart interleavings, and capped-lane bytes stay
  bounded/ordered/parseable under arbitrary record padding, counts,
  and caps. No counterexamples found — both properties held against
  the spool as delivered by Tasks 1–2.
- `test/sink/publish/test_spool.py` — appended the eager-import guard:
  importing `src.sink.publish.spool` must not pull in `paho`, so a
  robot with fleet streaming disabled never pays for the MQTT client.
- Fixture mechanics: `tmp_path_factory` (session-scoped, Hypothesis-safe)
  instead of function-scoped `tmp_path`; `SEGMENT_MAX_BYTES` patched via
  `pytest.MonkeyPatch.context()` inside the capped-lane test body
  instead of a module-level `monkeypatch_segment` fixture, since
  Hypothesis's `@given` re-invokes the test function per example and
  function-scoped fixtures don't compose with that.

### Deliberate posture

- **No fsync**: matches the rest of the repo's durability posture.
  Segment appends are plain writes; the watermark is rename-atomic.
  A crash may lose the active segment's tail, but QoS-1
  at-least-once delivery plus cloud-side seq dedupe absorbs the
  replay — this is a documented tradeoff, not an oversight.
- **`FLEET_QUEUE_MAX_SAMPLES` (in-memory queue cap) is deferred to
  step 5** — that's the controller/replay-orchestration layer's
  concern, not the disk spool's.

## Stacked on #206

This PR targets `feat/fleet-step3` (open, #206) rather than
`beta/fleet-streaming`, since step 3 hasn't merged yet. Rebase onto
`beta/fleet-streaming` once #206 lands.

## Test plan

- [x] `uv run pytest -q test/sink/publish/test_spool_properties.py test/sink/publish/test_spool.py -p no:cacheprovider` — 29 passed
- [x] `uv run pytest -q test/sink test/test_packaging.py -p no:cacheprovider` — 185 passed, 4 skipped (integration test skips without a broker)
- [x] `git grep -n "^import paho\|^from paho" -- 'src/sink/publish/'` — no output
- [x] `uv run ruff check && uv run ruff format` — clean
- [x] `scripts/check_boundary.sh` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
