### PR TITLE
feat(fleet): step 5 — router, tap, heartbeat, service lifecycle

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -117,6 +117,12 @@ jobs:
   # don't support command overrides either. Running mosquitto via `docker
   # run` with its built-in /mosquitto-no-auth.conf sidesteps both problems
   # and is the locally-verified route (test/sink/publish/test_mqtt_integration.py).
+  #
+  # test_stream_e2e.py's chaos test manages its OWN mosquitto container on
+  # MQTT_CHAOS_PORT (default 1884, set in that test file) -- never this
+  # job's `mosq` container on 1883 -- so MQTT_TEST_BROKER_MANAGED=1 is safe
+  # to set here: it only tells that one test its broker (a container IT
+  # starts) is safe to kill and restart.
   iot:
     runs-on: ubuntu-latest
     steps:
@@ -131,7 +137,11 @@ jobs:
       - name: Broker round-trip tests
         env:
           MQTT_TEST_BROKER: mqtt://localhost:1883
-        run: uv run pytest -q test/sink/publish/test_mqtt_integration.py -p no:cacheprovider
+          MQTT_TEST_BROKER_MANAGED: "1"
+        run: |
+          uv run pytest -q -p no:cacheprovider \
+            test/sink/publish/test_mqtt_integration.py \
+            test/sink/publish/test_stream_e2e.py
 
   coverage-gate:
     needs: [docker, host-tests]

--- a/plugin/references/settings-knobs.md
+++ b/plugin/references/settings-knobs.md
@@ -21,4 +21,5 @@ Defined in `settings.py`; set via the container environment or `.env`.
 | `CLOUDINI_ENABLED` | true | Cloudini pointcloud decompression in pipelines |
 | `FLEET_ENABLED` | true | Kill switch for fleet streaming (beta). `0` makes the publish subsystem inert: nothing connects, nothing leaves the box |
 | `FLEET_SPOOL_MAX_BYTES` | 256 MB | Disk cap for the fleet spool's channels lane; oldest segments evicted first. Events/heartbeats are never dropped and are exempt |
+| `FLEET_QUEUE_MAX_SAMPLES` | 10000 | Max samples in the router's bounded queue between the buffer tap and the router thread; oldest sample dropped on overflow, queue never blocks the tap |
 | `BAGEL_FLEET` (build arg) | true | Compose build arg; `false` omits the MQTT client from the iot/ros2 images entirely |

--- a/settings.py
+++ b/settings.py
@@ -91,6 +91,11 @@ class Settings(BaseSettings):
     # (~4 MB) is possible while rotating.
     FLEET_SPOOL_MAX_BYTES: int = 268_435_456
 
+    # Max samples held in the router's bounded queue between the buffer tap
+    # and the router thread. On overflow the oldest sample is dropped to make
+    # room for the newest; the queue never blocks the tap.
+    FLEET_QUEUE_MAX_SAMPLES: int = 10_000
+
     # Default quantization resolution in meters for cloudini lossy compression
     CLOUDINI_DEFAULT_RESOLUTION: float = 0.001
     ###############################################

--- a/src/sink/buffer.py
+++ b/src/sink/buffer.py
@@ -148,6 +148,11 @@ class TopicBufferWriter:
         return self._topic
 
     @property
+    def struct(self) -> pa.StructType:
+        """PyArrow StructType for the topic (read-only; used to resolve fleet-stream channels)."""
+        return self._struct
+
+    @property
     def pipeline(self) -> Pipeline | None:
         """The callback pipeline associated with this buffer, if any."""
         return self._pipeline

--- a/src/sink/buffer.py
+++ b/src/sink/buffer.py
@@ -1,6 +1,7 @@
 """File-backed topic buffer writer and reader."""
 
 import json
+import logging
 import pathlib
 import pickle
 import shutil
@@ -123,6 +124,7 @@ class TopicBufferWriter:
         self._message_count = 0
         self._last_run_at = None
         self._last_timestamp_seconds = None
+        self._tap: Callable[[str, float, dict[str, Any]], None] | None = None
 
         # For an OnEvent cadence, edge-record the live stream: fire the pipeline on each
         # rising edge of the predicate, delayed by the cadence's forward window so the
@@ -173,6 +175,15 @@ class TopicBufferWriter:
         """
         return self._last_timestamp_seconds
 
+    def set_tap(self, tap: Callable[[str, float, dict[str, Any]], None] | None) -> None:
+        """Set (or clear, with None) an opaque callback fed every appended message.
+
+        The tap fires after this buffer's own pipeline dispatch, with the raw
+        message dict as passed to `append()`. It must never block or raise:
+        exceptions are caught and logged, never propagated.
+        """
+        self._tap = tap
+
     def append(self, msg: dict[str, Any]) -> None:
         """Append a message to the buffer."""
         timestamp_seconds = self._extract_timestamp(msg) if self._extract_timestamp else time.time()
@@ -208,6 +219,12 @@ class TopicBufferWriter:
         ):
             self.pipeline.run_at(timestamp_seconds)
             self._last_run_at = timestamp_seconds
+
+        if self._tap is not None:
+            try:
+                self._tap(self._topic, timestamp_seconds, msg)
+            except Exception:  # the tap is opaque; it must never break append
+                logging.getLogger(__name__).debug("buffer tap raised", exc_info=True)
 
         self._message_count += 1
         self._last_timestamp_seconds = timestamp_seconds

--- a/src/sink/publish/heartbeat.py
+++ b/src/sink/publish/heartbeat.py
@@ -128,6 +128,7 @@ class HeartbeatThread(threading.Thread):
         self._interval_s = interval_s
         self._spool = spool
         self._stop_event = threading.Event()
+        self._spool_failures = 0
 
     def run(self) -> None:
         """Tick immediately on start, then every `interval_s`, until stop() is called."""
@@ -136,21 +137,39 @@ class HeartbeatThread(threading.Thread):
             self._stop_event.wait(self._interval_s)
 
     def _tick(self) -> None:
-        """One heartbeat: build the payload, publish it, spool it on failure."""
+        """One heartbeat: build the payload, publish it, spool it on failure.
+
+        A `PublishError` (the broker is unreachable) is normal, expected
+        offline behavior -- logged at DEBUG. A failure spooling the payload
+        to the never-drop "heartbeat" lane afterward is not: per spec §4
+        that lane must never silently drop, so a `SpoolError` (e.g.
+        `SpoolFullError` -- disk full) or any other exception from the spool
+        path logs at WARNING (with the lane and reason) and increments
+        `spool_failures` so it is visible to an operator via
+        `FleetService.status()`, instead of vanishing at DEBUG. Either way
+        the thread never dies and no exception escapes this method.
+        """
         payload = self._payload_factory()
         try:
             self._publisher.publish_heartbeat(payload)
         except PublishError:
+            logging.getLogger(__name__).debug("heartbeat publish failed", exc_info=True)
             if self._spool is not None:
                 try:
                     seq = self._spool.next_seq("heartbeat")
                     self._spool.append("heartbeat", seq, payload)
-                except Exception:
-                    logging.getLogger(__name__).debug(
-                        "heartbeat spool append failed", exc_info=True
+                except Exception as exc:
+                    self._spool_failures += 1
+                    logging.getLogger(__name__).warning(
+                        "heartbeat spool append failed on lane 'heartbeat': %s", exc, exc_info=True
                     )
 
     def stop(self) -> None:
         """Signal the loop to stop and join with a bounded timeout."""
         self._stop_event.set()
         self.join(timeout=5)
+
+    @property
+    def spool_failures(self) -> int:
+        """Count of failed attempts to spool a heartbeat payload after a publish failure."""
+        return self._spool_failures

--- a/src/sink/publish/heartbeat.py
+++ b/src/sink/publish/heartbeat.py
@@ -1,0 +1,156 @@
+"""Heartbeat: liveness payload building and the wall-clock publishing thread.
+
+Spec §3. `bagel_version()` probes `importlib.metadata` for the installed
+distribution first (works for a `uv sync`/pip-installed image); when that
+distribution metadata is absent -- as in a source checkout run via `uv run`
+without `uv sync --package/-e` having registered it, which is the live path
+in this worktree -- it falls back to parsing `pyproject.toml`'s
+`[project].version` directly. Either miss returns `"unknown"` rather than
+raising: a heartbeat must go out even if its own version string is a mystery.
+"""
+
+import importlib.metadata
+import logging
+import pathlib
+import shutil
+import threading
+import time
+from collections.abc import Callable
+
+import tomllib
+
+from src.sink.publish.publisher import Publisher, PublishError
+from src.sink.publish.spool import Spool
+
+HEARTBEAT_INTERVAL_S = 30.0
+
+_DISTRIBUTION_NAME = "bagel"
+
+
+def _pyproject_version() -> str:
+    """Read `[project].version` from the repo's pyproject.toml (fallback path)."""
+    root = pathlib.Path(__file__).resolve().parents[3]
+    data = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
+    return str(data["project"]["version"])
+
+
+def bagel_version() -> str:
+    """Return the running Bagel version, or "unknown" if neither source works."""
+    try:
+        return importlib.metadata.version(_DISTRIBUTION_NAME)
+    except importlib.metadata.PackageNotFoundError:
+        pass
+    try:
+        return _pyproject_version()
+    except Exception:
+        return "unknown"
+
+
+def disk_free(path: str | pathlib.Path) -> int:
+    """Free bytes on the filesystem containing `path`."""
+    return shutil.disk_usage(path).free
+
+
+def _lane_field(stat: object, field: str) -> int:
+    """Read one numeric field off a lane-stats value that may be a dict or an object."""
+    if isinstance(stat, dict):
+        return stat.get(field, 0)
+    return getattr(stat, field, 0)
+
+
+def build_heartbeat(  # noqa: PLR0913
+    *,
+    started_at: float,
+    subscriptions: list[str],
+    channels_active: int,
+    queue_depth: int,
+    queue_dropped: int,
+    spool_stats: dict,
+    disk_free_bytes: int,
+    reconnects: int,
+    now: float | None = None,
+) -> dict:
+    """Build the §3 heartbeat payload.
+
+    `spool_stats` maps lane name -> a value exposing `bytes`/`pending`/
+    `evicted` (either as dict keys or attributes, e.g. `Spool.stats()`'s
+    `LaneStats`); this aggregates the channels/events/heartbeat lanes into
+    one `spool` object by summing each field. `cert_expires_at` is always
+    `None` here -- identity/enrollment lands in step 6.
+    """
+    t = now if now is not None else time.time()
+    return {
+        "v": 1,
+        "t": t,
+        "online": True,
+        "bagel_version": bagel_version(),
+        "uptime_s": t - started_at,
+        "subscriptions": list(subscriptions),
+        "channels_active": channels_active,
+        "queue": {"depth": queue_depth, "dropped": queue_dropped},
+        "spool": {
+            "bytes": sum(_lane_field(s, "bytes") for s in spool_stats.values()),
+            "pending": sum(_lane_field(s, "pending") for s in spool_stats.values()),
+            "evicted": sum(_lane_field(s, "evicted") for s in spool_stats.values()),
+        },
+        "disk_free_bytes": disk_free_bytes,
+        "cert_expires_at": None,
+        "reconnects": reconnects,
+    }
+
+
+class HeartbeatThread(threading.Thread):
+    """Publishes a fresh heartbeat payload on a fixed interval.
+
+    Follows the thread-lifecycle precedent documented in `service.py`:
+    daemon=True, a `threading.Event` waited on with the tick interval as its
+    timeout (so `stop()` returns as soon as the event is set rather than
+    after a full interval elapses), and a bounded `join()` in `stop()`.
+
+    A publish failure never kills the thread: heartbeat is the never-drop
+    lane (spec §4), so on `PublishError` the payload is appended to the
+    spool's "heartbeat" lane instead (best-effort -- a spool failure here is
+    swallowed too, since a heartbeat thread that dies is worse than one that
+    occasionally fails to record a missed beat).
+    """
+
+    def __init__(
+        self,
+        publisher: Publisher,
+        payload_factory: Callable[[], dict],
+        interval_s: float = HEARTBEAT_INTERVAL_S,
+        spool: Spool | None = None,
+    ) -> None:
+        """Wire the publisher, payload builder, and optional spool; does not start the thread."""
+        super().__init__(daemon=True)
+        self._publisher = publisher
+        self._payload_factory = payload_factory
+        self._interval_s = interval_s
+        self._spool = spool
+        self._stop_event = threading.Event()
+
+    def run(self) -> None:
+        """Tick immediately on start, then every `interval_s`, until stop() is called."""
+        while not self._stop_event.is_set():
+            self._tick()
+            self._stop_event.wait(self._interval_s)
+
+    def _tick(self) -> None:
+        """One heartbeat: build the payload, publish it, spool it on failure."""
+        payload = self._payload_factory()
+        try:
+            self._publisher.publish_heartbeat(payload)
+        except PublishError:
+            if self._spool is not None:
+                try:
+                    seq = self._spool.next_seq("heartbeat")
+                    self._spool.append("heartbeat", seq, payload)
+                except Exception:
+                    logging.getLogger(__name__).debug(
+                        "heartbeat spool append failed", exc_info=True
+                    )
+
+    def stop(self) -> None:
+        """Signal the loop to stop and join with a bounded timeout."""
+        self._stop_event.set()
+        self.join(timeout=5)

--- a/src/sink/publish/heartbeat.py
+++ b/src/sink/publish/heartbeat.py
@@ -129,6 +129,7 @@ class HeartbeatThread(threading.Thread):
         self._spool = spool
         self._stop_event = threading.Event()
         self._spool_failures = 0
+        self._last_error: str | None = None
 
     def run(self) -> None:
         """Tick immediately on start, then every `interval_s`, until stop() is called."""
@@ -138,6 +139,17 @@ class HeartbeatThread(threading.Thread):
 
     def _tick(self) -> None:
         """One heartbeat: build the payload, publish it, spool it on failure.
+
+        The `payload_factory()` call is its own try/except: it can raise
+        (e.g. `Spool.stats()` -> `SpoolCorruptError`, `disk_free()` on a
+        missing directory) and an uncaught exception here would unwind
+        `run()`'s loop and silently kill the liveness thread with no
+        visibility anywhere. So a factory exception logs at WARNING (with
+        the error) and skips this beat entirely -- `last_error` is set and
+        the thread lives to try again next interval. `last_error` is
+        cleared as soon as a beat's payload is built successfully; it does
+        not track publish failures, which are the separate, normal
+        offline path below.
 
         A `PublishError` (the broker is unreachable) is normal, expected
         offline behavior -- logged at DEBUG. A failure spooling the payload
@@ -149,7 +161,15 @@ class HeartbeatThread(threading.Thread):
         `FleetService.status()`, instead of vanishing at DEBUG. Either way
         the thread never dies and no exception escapes this method.
         """
-        payload = self._payload_factory()
+        try:
+            payload = self._payload_factory()
+        except Exception as exc:
+            self._last_error = f"heartbeat payload factory failed: {exc!r}"
+            logging.getLogger(__name__).warning(
+                "heartbeat payload factory failed; skipping this beat: %s", exc, exc_info=True
+            )
+            return
+        self._last_error = None
         try:
             self._publisher.publish_heartbeat(payload)
         except PublishError:
@@ -173,3 +193,25 @@ class HeartbeatThread(threading.Thread):
     def spool_failures(self) -> int:
         """Count of failed attempts to spool a heartbeat payload after a publish failure."""
         return self._spool_failures
+
+    @property
+    def alive(self) -> bool:
+        """Whether the thread is running and has hit no fatal state.
+
+        Mirrors `StreamRouter.alive`'s visibility pattern, but the payload
+        factory fix above means `_tick` has no remaining fatal path -- a
+        factory failure is now caught and skipped rather than escaping
+        `run()`'s loop -- so this is simply `is_alive()`.
+        """
+        return self.is_alive()
+
+    @property
+    def last_error(self) -> str | None:
+        """The most recent payload-factory failure, if the last beat skipped one.
+
+        Set when a beat's `payload_factory()` call raises (that beat is
+        skipped); cleared as soon as a later beat builds its payload
+        successfully. Independent of publish/spool outcomes -- those are
+        tracked separately (see `spool_failures`).
+        """
+        return self._last_error

--- a/src/sink/publish/mqtt.py
+++ b/src/sink/publish/mqtt.py
@@ -89,6 +89,11 @@ class MqttPublisher(Publisher):
         self._password = password
         self._keepalive_s = keepalive_s
         self._client: object = None
+        # Set while our own close() is tearing the client down, so the
+        # synchronous on_disconnect fire that a clean disconnect() triggers
+        # (see _on_disconnect docstring) doesn't count as a reconnect event.
+        self._closing = False
+        self.reconnects = 0
         self._finalizer = weakref.finalize(self, _finalize, None)
 
     def connect(self) -> None:
@@ -118,12 +123,46 @@ class MqttPublisher(Publisher):
             client.tls_set(**self._tls)
         if self._username is not None:
             client.username_pw_set(self._username, self._password)
+        client.on_disconnect = self._on_disconnect
         client.connect(self._host, self._port, self._keepalive_s)
         client.loop_start()
         self._client = client
         # Re-register the finalizer against the live client, holding no ref to self.
         self._finalizer.detach()
         self._finalizer = weakref.finalize(self, _finalize, client)
+
+    def _on_disconnect(
+        self,
+        client: object,
+        userdata: object,
+        disconnect_flags: object,
+        reason_code: object,
+        properties: object = None,
+    ) -> None:
+        """Paho VERSION2 on_disconnect hook: `(client, userdata, flags, reason, props)`.
+
+        Verified against the installed paho 2.1.0 source
+        (paho/mqtt/client.py, CallbackOnDisconnect_v2 / _do_on_disconnect):
+        the VERSION2 callback always receives exactly these five positional
+        args. Confirmed paho fires this callback even for a deliberate,
+        clean close() -- our close() calls loop_stop() (which nulls the
+        client's background thread) then disconnect(); with no background
+        thread running, disconnect()'s outgoing DISCONNECT packet is written
+        synchronously on the calling thread, and paho's packet-write path
+        invokes on_disconnect right there. So a clean close is
+        indistinguishable from an unexpected drop unless we gate on it
+        ourselves: self._closing (set for the duration of our close()) is
+        that gate, so `reconnects` counts only disconnects we didn't ask for.
+
+        Never raises: a broker-thread callback that raises would only get
+        logged and swallowed by paho itself, so any exception here is
+        caught rather than relying on that.
+        """
+        try:
+            if not self._closing:
+                self.reconnects += 1
+        except Exception:
+            logging.debug("on_disconnect handler failed", exc_info=True)
 
     @property
     def connected(self) -> bool:
@@ -153,17 +192,21 @@ class MqttPublisher(Publisher):
         client, self._client = self._client, None
         if client is None:
             return
-        if client.is_connected():
-            stopped = {"v": 1, "t": time.time(), "online": False, "reason": "stopped"}
-            try:
-                info = client.publish(
-                    wire_topic(self._tenant, self._robot, "heartbeat"),
-                    _dump(stopped),
-                    qos=1,
-                    retain=True,
-                )
-                info.wait_for_publish(timeout=5.0)
-            except Exception:
-                logging.debug("Clean-stop heartbeat publish failed; closing anyway")
-        client.loop_stop()
-        client.disconnect()
+        self._closing = True
+        try:
+            if client.is_connected():
+                stopped = {"v": 1, "t": time.time(), "online": False, "reason": "stopped"}
+                try:
+                    info = client.publish(
+                        wire_topic(self._tenant, self._robot, "heartbeat"),
+                        _dump(stopped),
+                        qos=1,
+                        retain=True,
+                    )
+                    info.wait_for_publish(timeout=5.0)
+                except Exception:
+                    logging.debug("Clean-stop heartbeat publish failed; closing anyway")
+            client.loop_stop()
+            client.disconnect()
+        finally:
+            self._closing = False

--- a/src/sink/publish/mqtt.py
+++ b/src/sink/publish/mqtt.py
@@ -106,7 +106,17 @@ class MqttPublisher(Publisher):
         """
         require_fleet()
         if self._client is not None:
-            _finalize(self._client)
+            # Same _closing gate as close(): tearing down the prior client
+            # here is our own doing, not an unexpected drop. If the prior
+            # client's socket is still live (e.g. we are replacing it after
+            # a wait_for_publish timeout, not a broker-side drop), paho can
+            # fire on_disconnect synchronously from this teardown, and it
+            # must not count as a reconnect.
+            self._closing = True
+            try:
+                _finalize(self._client)
+            finally:
+                self._closing = False
         paho = _paho()
         client = paho.Client(
             callback_api_version=paho.CallbackAPIVersion.VERSION2,

--- a/src/sink/publish/router.py
+++ b/src/sink/publish/router.py
@@ -8,6 +8,8 @@ spools and publishes. Spec §2/§4.
 import queue as queue_mod
 from collections.abc import Callable
 
+from src.sink.publish.config import ResolvedChannel
+
 Sample = tuple[str, float, dict]
 
 
@@ -60,3 +62,110 @@ class SampleQueue:
             self.put((topic, t, msg))
 
         return tap
+
+
+def extract_value(msg: dict, path: list[str]) -> object:
+    """Walk nested dict `msg` by `path`. Raises KeyError passthrough on missing."""
+    value: object = msg
+    for key in path:
+        value = value[key]  # type: ignore[index]  # path walks nested dicts by contract
+    return value
+
+
+def _extract_channel_value(chan: ResolvedChannel, msg: dict) -> object:
+    """Extract a channel's sample value from `msg` per its resolved paths.
+
+    A scalar/bool channel has a single "value" path. A geo channel has "lat"
+    and "lon" paths (required) and an optional "alt" path -- the "alt" key is
+    included in the returned dict only when that path was resolved for this
+    channel.
+    """
+    paths = chan.paths
+    if "value" in paths:
+        return extract_value(msg, paths["value"].path)
+    geo: dict[str, object] = {
+        "lat": extract_value(msg, paths["lat"].path),
+        "lon": extract_value(msg, paths["lon"].path),
+    }
+    if "alt" in paths:
+        geo["alt"] = extract_value(msg, paths["alt"].path)
+    return geo
+
+
+class RouterCore:
+    """Pure extraction, rate-capping, and batch-building logic.
+
+    No I/O, no spool, no seq -- the router thread (Task 3) drives offer()/
+    flush()/should_flush() and owns sequencing and publishing.
+
+    Slot-survival rule: `offer()` computes a per-channel slot index
+    `int(t * rate_hz)` and keeps the later-`t` sample as that slot's winner
+    (`_pending`, keyed by `(channel_name, slot)`). Once `flush()` pops a
+    slot's winner into a batch, that slot is retired into
+    `_last_emitted_slot[channel_name]` (a per-channel high-water mark). Any
+    later `offer()` whose slot is <= that high-water mark is dropped instead
+    of being stored -- otherwise a reordered/late sample could resurrect and
+    re-emit a slot a subscriber already received in an earlier batch. This is
+    simpler than re-deriving "already emitted" from history at flush time
+    and keeps the check on the hot `offer()` path a single dict lookup.
+    """
+
+    def __init__(
+        self,
+        resolved: list[ResolvedChannel],
+        flush_interval_s: float,
+        max_samples: int = 500,
+    ) -> None:
+        """Index `resolved` channels by source topic and set batching limits."""
+        self._channels_by_topic: dict[str, list[ResolvedChannel]] = {}
+        for chan in resolved:
+            self._channels_by_topic.setdefault(chan.source_topic, []).append(chan)
+        self.flush_interval_s = flush_interval_s
+        self.max_samples = max_samples
+        self.skipped = 0
+        self._pending: dict[tuple[str, int], tuple[float, object]] = {}
+        self._last_emitted_slot: dict[str, int] = {}
+        self._last_flush = 0.0
+
+    def offer(self, topic: str, t: float, msg: dict) -> None:
+        """Extract+rate-cap `msg` into each channel sourced from `topic`."""
+        for chan in self._channels_by_topic.get(topic, []):
+            try:
+                value = _extract_channel_value(chan, msg)
+            except (KeyError, TypeError):
+                self.skipped += 1
+                continue
+            slot = int(t * chan.rate_hz)
+            last_emitted = self._last_emitted_slot.get(chan.name)
+            if last_emitted is not None and slot <= last_emitted:
+                continue  # stale sample for a slot already flushed out
+            key = (chan.name, slot)
+            existing = self._pending.get(key)
+            if existing is None or t >= existing[0]:
+                self._pending[key] = (t, value)
+
+    def flush(self, t_batch: float) -> dict | None:
+        """Pop all pending slot-winners, ordered by t, into a batch (or None)."""
+        self._last_flush = t_batch
+        if not self._pending:
+            return None
+        items = sorted(
+            ((chan_name, slot, t, v) for (chan_name, slot), (t, v) in self._pending.items()),
+            key=lambda item: item[2],
+        )
+        for chan_name, slot, _t, _v in items:
+            prev = self._last_emitted_slot.get(chan_name)
+            if prev is None or slot > prev:
+                self._last_emitted_slot[chan_name] = slot
+        self._pending.clear()
+        samples = [{"c": chan_name, "t": t, "v": v} for chan_name, _slot, t, v in items]
+        return {"v": 1, "t_batch": t_batch, "samples": samples}
+
+    def should_flush(self, now: float, pending_count: int) -> bool:
+        """Return True if the batch is big enough or the flush interval has elapsed."""
+        return pending_count >= self.max_samples or now - self._last_flush >= self.flush_interval_s
+
+    @property
+    def pending_count(self) -> int:
+        """Number of stored slot-winners awaiting the next flush."""
+        return len(self._pending)

--- a/src/sink/publish/router.py
+++ b/src/sink/publish/router.py
@@ -242,6 +242,13 @@ class StreamRouter(threading.Thread):
 
         Always starts from `spool.pending("channels")` -- see class
         docstring for why that alone makes replay-then-live emergent.
+
+        Checks `self._stop_event` between iterations: a post-outage backlog
+        (the channels lane is capped but can still hold thousands of
+        records) can take longer to drain than stop()'s join(timeout=5)
+        bound. Breaking early leaves the remaining records spooled and
+        unacked, which is correct -- they replay on the next start, in the
+        same seq order, exactly like any other still-unacked backlog.
         """
         if not self._online:
             if now < self._next_attempt:
@@ -250,6 +257,8 @@ class StreamRouter(threading.Thread):
             if not self._online:
                 return
         for seq, payload in self._spool.pending("channels"):
+            if self._stop_event.is_set():
+                return
             try:
                 self._publisher.publish_channels(payload)
             except PublishError:

--- a/src/sink/publish/router.py
+++ b/src/sink/publish/router.py
@@ -6,9 +6,14 @@ spools and publishes. Spec §2/§4.
 """
 
 import queue as queue_mod
+import random
+import threading
+import time
 from collections.abc import Callable
 
 from src.sink.publish.config import ResolvedChannel
+from src.sink.publish.publisher import Publisher, PublishError
+from src.sink.publish.spool import Spool
 
 Sample = tuple[str, float, dict]
 
@@ -169,3 +174,117 @@ class RouterCore:
     def pending_count(self) -> int:
         """Number of stored slot-winners awaiting the next flush."""
         return len(self._pending)
+
+
+class StreamRouter(threading.Thread):
+    """Drains the sample queue into RouterCore, spools batches, and publishes.
+
+    Replay-then-live is emergent, not a separate code path: `_pump` always
+    starts from `spool.pending("channels")`, and a freshly-flushed live
+    batch is appended to the spool (with its seq) before `_pump` runs in the
+    same tick. So a batch built from this tick's live samples is published
+    only after every older, still-unacked spooled batch -- the spool is the
+    single source of publish order, whether its records arrived from a prior
+    offline period or from this tick.
+    """
+
+    INITIAL_BACKOFF_S = 1.0
+    MAX_BACKOFF_S = 60.0
+
+    def __init__(
+        self,
+        core: RouterCore,
+        queue: SampleQueue,
+        spool: Spool,
+        publisher: Publisher,
+        schema_payload: dict,
+    ) -> None:
+        """Wire the core, queue, spool and publisher together; does not start the thread."""
+        super().__init__(daemon=True)
+        self._core = core
+        self._queue = queue
+        self._spool = spool
+        self._publisher = publisher
+        self._schema_payload = schema_payload
+        # Named _stop_event (not _stop) because threading.Thread already owns
+        # a private _stop() method; shadowing it breaks Thread's own join().
+        self._stop_event = threading.Event()
+        self._online = False
+        self._backoff = self.INITIAL_BACKOFF_S
+        self._next_attempt = 0.0
+
+    def run(self) -> None:
+        """Thin loop: tick until stop() is called. All logic lives in `_tick`."""
+        while not self._stop_event.is_set():
+            self._tick(time.time())
+
+    def _tick(self, now: float) -> None:
+        """One iteration: drain+offer+maybe-flush-to-spool, then publish.
+
+        Unit tests drive this directly with controlled `now` values instead
+        of sleeping; `queue.drain`'s bounded timeout is what paces the real
+        thread loop in `run()`.
+        """
+        timeout_s = min(0.2, self._core.flush_interval_s)
+        samples = self._queue.drain(max_items=500, timeout_s=timeout_s)
+        for topic, t, msg in samples:
+            self._core.offer(topic, t, msg)
+        if self._core.should_flush(now, self._core.pending_count):
+            batch = self._core.flush(now)
+            if batch is not None:
+                seq = self._spool.next_seq("channels")
+                batch["seq"] = seq
+                self._spool.append("channels", seq, batch)
+        self._pump(now)
+
+    def _pump(self, now: float) -> None:
+        """Publish the spool's backlog in seq order; go offline on the first failure.
+
+        Always starts from `spool.pending("channels")` -- see class
+        docstring for why that alone makes replay-then-live emergent.
+        """
+        if not self._online:
+            if now < self._next_attempt:
+                return
+            self._reconnect(now)
+            if not self._online:
+                return
+        for seq, payload in self._spool.pending("channels"):
+            try:
+                self._publisher.publish_channels(payload)
+            except PublishError:
+                self._online = False
+                self._schedule_retry(now)
+                return
+            self._spool.ack("channels", seq)
+
+    def _reconnect(self, now: float) -> None:
+        """Attempt one (re)connect + schema republish; stay offline on failure."""
+        try:
+            self._publisher.connect()
+            self._publisher.publish_schema(self._schema_payload)
+        except Exception:  # connect()/publish_schema() may raise broadly (transport, TLS, ...)
+            self._schedule_retry(now)
+            return
+        self._backoff = self.INITIAL_BACKOFF_S
+        self._online = True
+
+    def _schedule_retry(self, now: float) -> None:
+        """Double (capped) the backoff, then pick the next attempt with full jitter."""
+        self._backoff = min(self.MAX_BACKOFF_S, self._backoff * 2)
+        self._next_attempt = now + random.uniform(0, self._backoff)  # noqa: S311 -- jitter, not crypto
+
+    def stop(self) -> None:
+        """Signal the loop to stop and join with a bounded timeout."""
+        self._stop_event.set()
+        self.join(timeout=5)
+
+    @property
+    def online(self) -> bool:
+        """Whether the router currently believes it has a live publisher session."""
+        return self._online
+
+    @property
+    def backoff(self) -> float:
+        """Current backoff ceiling (seconds) used for the next reconnect's full jitter."""
+        return self._backoff

--- a/src/sink/publish/router.py
+++ b/src/sink/publish/router.py
@@ -1,0 +1,62 @@
+"""Fleet streaming runtime: bounded sample queue and the stream router.
+
+The tap side (SampleQueue.put) is called from source callback threads and
+must never block or raise; the router thread drains, rate-caps, batches,
+spools and publishes. Spec §2/§4.
+"""
+
+import queue as queue_mod
+from collections.abc import Callable
+
+Sample = tuple[str, float, dict]
+
+
+class SampleQueue:
+    """Bounded drop-oldest queue between the buffer tap and the router."""
+
+    def __init__(self, maxsize: int) -> None:
+        """Initialize a SampleQueue with the given maximum depth."""
+        self._q: queue_mod.Queue[Sample] = queue_mod.Queue(maxsize=maxsize)
+        self.dropped = 0
+
+    def put(self, sample: Sample) -> None:
+        """Enqueue a sample, non-blocking. On Full, drop the oldest and count it."""
+        try:
+            self._q.put_nowait(sample)
+        except queue_mod.Full:
+            try:
+                self._q.get_nowait()
+                self.dropped += 1
+            except queue_mod.Empty:
+                pass
+            try:
+                self._q.put_nowait(sample)
+            except queue_mod.Full:
+                self.dropped += 1
+
+    def drain(self, max_items: int, timeout_s: float) -> list[Sample]:
+        """Block up to timeout_s for the first item, then greedily drain up to max_items."""
+        out: list[Sample] = []
+        try:
+            out.append(self._q.get(timeout=timeout_s))
+        except queue_mod.Empty:
+            return out
+        while len(out) < max_items:
+            try:
+                out.append(self._q.get_nowait())
+            except queue_mod.Empty:
+                break
+        return out
+
+    @property
+    def depth(self) -> int:
+        """Current number of samples waiting in the queue."""
+        return self._q.qsize()
+
+    def as_tap(self) -> Callable[[str, float, dict], None]:
+        """Return a bound callback suitable for TopicBufferWriter.set_tap()."""
+
+        def tap(topic: str, t: float, msg: dict) -> None:
+            self.put((topic, t, msg))
+
+        return tap

--- a/src/sink/publish/router.py
+++ b/src/sink/publish/router.py
@@ -5,6 +5,7 @@ must never block or raise; the router thread drains, rate-caps, batches,
 spools and publishes. Spec §2/§4.
 """
 
+import logging
 import queue as queue_mod
 import random
 import threading
@@ -212,11 +213,25 @@ class StreamRouter(threading.Thread):
         self._online = False
         self._backoff = self.INITIAL_BACKOFF_S
         self._next_attempt = 0.0
+        self._fatal_error: str | None = None
 
     def run(self) -> None:
-        """Thin loop: tick until stop() is called. All logic lives in `_tick`."""
+        """Thin loop: tick until stop() is called. All logic lives in `_tick`.
+
+        A `_tick` failure that is not a `PublishError` (already handled inside
+        `_pump`) means a bug in `RouterCore` or `Spool`, not an offline
+        broker. Rather than dying silently -- indistinguishable from a router
+        that is merely still offline -- log it, record it as `_fatal_error`,
+        and exit the loop so `alive`/`last_error` surface it to
+        `FleetService.status()`.
+        """
         while not self._stop_event.is_set():
-            self._tick(time.time())
+            try:
+                self._tick(time.time())
+            except Exception as exc:
+                logging.getLogger(__name__).exception("StreamRouter thread died")
+                self._fatal_error = repr(exc)
+                return
 
     def _tick(self, now: float) -> None:
         """One iteration: drain+offer+maybe-flush-to-spool, then publish.
@@ -297,3 +312,18 @@ class StreamRouter(threading.Thread):
     def backoff(self) -> float:
         """Current backoff ceiling (seconds) used for the next reconnect's full jitter."""
         return self._backoff
+
+    @property
+    def alive(self) -> bool:
+        """Whether the thread is running AND has not died on an unhandled `_tick` error.
+
+        Distinct from `online`: `online` tracks the broker session (false
+        while offline-but-retrying, which is normal); `alive` tracks whether
+        the router thread itself is still doing its job at all.
+        """
+        return self.is_alive() and self._fatal_error is None
+
+    @property
+    def last_error(self) -> str | None:
+        """The `repr()` of the exception that killed the thread, if any."""
+        return self._fatal_error

--- a/src/sink/publish/router.py
+++ b/src/sink/publish/router.py
@@ -264,7 +264,16 @@ class StreamRouter(threading.Thread):
         bound. Breaking early leaves the remaining records spooled and
         unacked, which is correct -- they replay on the next start, in the
         same seq order, exactly like any other still-unacked backlog.
+
+        Also checks `self._stop_event` first thing: without this, a
+        `stop()` landing while `_reconnect()`'s blocking `connect()` call is
+        in flight could still let this call fall through into a full
+        publish pass on a connection that only just came up, past
+        `join(5)`'s deadline -- this closes that stop/reconnect race at its
+        narrowest point.
         """
+        if self._stop_event.is_set():
+            return
         if not self._online:
             if now < self._next_attempt:
                 return

--- a/src/sink/publish/service.py
+++ b/src/sink/publish/service.py
@@ -184,6 +184,9 @@ class FleetService:
             "channels_active": len(self._resolved),
             "router_alive": self._router.alive if self._router is not None else False,
             "router_error": self._router.last_error if self._router is not None else None,
+            "heartbeat_spool_failures": (
+                self._heartbeat.spool_failures if self._heartbeat is not None else 0
+            ),
         }
 
     # -- internals ---------------------------------------------------------------

--- a/src/sink/publish/service.py
+++ b/src/sink/publish/service.py
@@ -1,0 +1,225 @@
+"""FleetService: composes the tap/queue/router/heartbeat pieces into one lifecycle.
+
+Spec §2/§5. `start()` resolves the manifest's `streams:` channels against the
+sink's already-subscribed topic buffers, wires a tap on each referenced
+buffer into a fresh `SampleQueue`, and starts the `StreamRouter` and
+`HeartbeatThread` threads that drain it. `stop()`/`pause()`/`resume()` manage
+that pair of daemon threads; `status()` returns the plain-JSON shape step 7's
+`describe_stream_status` tool hands back directly.
+
+This module (with `router.StreamRouter` before it) sets this repo's
+thread-lifecycle precedent: every long-running fleet thread is
+`daemon=True`, stops via a `threading.Event` (so `stop()`/`join()` never
+requires a sleep-based poll and returns as soon as the event is observed),
+and its `stop()` joins with a bounded timeout (5s) so a slow or stuck thread
+can never hang the caller -- mirrored from `TopicSink.close()`
+(`src/sink/base.py:323`)'s try/finally shape: `stop()`/`pause()` do their
+teardown in a `try` and always release the publisher session in a `finally`,
+so a failure partway through still leaves the service in a consistent,
+re-enterable state.
+
+Startup/manifest wiring (deciding *when* to call `start()`) is explicitly
+out of scope here -- step 6 ruling, since it's conditioned on identity
+existing, which step 6 delivers. `startup.py` is not touched by this module.
+"""
+
+import dataclasses
+import time
+
+from settings import settings
+from src.sink.publish import require_fleet
+from src.sink.publish.config import StreamsConfig
+from src.sink.publish.heartbeat import HeartbeatThread, build_heartbeat, disk_free
+from src.sink.publish.publisher import Publisher
+from src.sink.publish.router import RouterCore, SampleQueue, StreamRouter
+from src.sink.publish.spool import Spool
+
+
+class FleetService:
+    """Owns one robot's fleet-streaming runtime: tap wiring + router + heartbeat."""
+
+    def __init__(
+        self, *, sink: object, streams: StreamsConfig, publisher: Publisher, spool: Spool
+    ) -> None:
+        """Store the collaborators; does not touch the sink, publisher, or spool yet."""
+        self._sink = sink
+        self._streams = streams
+        self._publisher = publisher
+        self._spool = spool
+
+        self._resolved: list = []
+        self._schema_payload: dict = {"v": 1, "channels": []}
+        self._writers: dict[str, object] = {}  # topic -> writer, for taps
+
+        self._queue: SampleQueue | None = None
+        self._core: RouterCore | None = None
+        self._router: StreamRouter | None = None
+        self._heartbeat: HeartbeatThread | None = None
+        self._started_at: float | None = None
+
+        self._started = False
+        self._paused = False
+
+    # -- lifecycle -------------------------------------------------------------
+
+    def start(self) -> None:
+        """Resolve channels against the sink's subscribed buffers, then run.
+
+        Raises:
+            FleetDisabledError | FleetNotInstalledError: via `require_fleet()`.
+            StreamConfigError: a configured `channels[].topic` is not
+                currently subscribed on the sink (reused from
+                `StreamsConfig.resolve`, which raises exactly this when a
+                topic is missing from the `structs` mapping -- a topic not
+                subscribed on the sink is simply absent from it here).
+
+        """
+        require_fleet()
+        configured_topics = {rule.topic for rule in self._streams.channels}
+        # TopicSink exposes no public per-topic buffer accessor (only the
+        # aggregate `subscribed_topics` list), so this reaches into `_buffers`
+        # directly -- same attribute name a real TopicSink and this module's
+        # FakeSink test doubles both use.
+        structs = {
+            topic: self._sink._buffers[topic].struct
+            for topic in configured_topics
+            if topic in self._sink.subscribed_topics
+        }
+        resolved = self._streams.resolve(structs)
+
+        self._resolved = resolved
+        self._schema_payload = {
+            "v": 1,
+            "channels": [
+                {
+                    "c": channel.name,
+                    "type": channel.type,
+                    "unit": channel.unit,
+                    "source_topic": channel.source_topic,
+                    "source_field": channel.source_field,
+                }
+                for channel in resolved
+            ],
+        }
+        self._writers = {
+            topic: self._sink._buffers[topic]
+            for topic in sorted({channel.source_topic for channel in resolved})
+        }
+
+        self._launch_runtime()
+        self._started = True
+        self._paused = False
+
+    def stop(self) -> None:
+        """Idempotent: clear taps, stop heartbeat, stop router, then release the publisher.
+
+        Heartbeat stops BEFORE `publisher.close()` so the clean-stop
+        heartbeat that `close()` itself publishes (per step 3's
+        `MqttPublisher.close`) is the last one anyone sees -- a still-running
+        heartbeat thread ticking after that could otherwise republish
+        `online: true` right behind it.
+        """
+        if not self._started:
+            return
+        try:
+            self._clear_taps()
+            if self._heartbeat is not None:
+                self._heartbeat.stop()
+            if self._router is not None:
+                self._router.stop()
+        finally:
+            self._publisher.close()
+            self._started = False
+            self._paused = False
+
+    def pause(self, discard: bool = False) -> None:
+        """Go offline, keeping the resolved config so `resume()` needs no re-resolve.
+
+        Idempotent: a no-op if not started or already paused. `discard=True`
+        additionally acks the channels lane up to its last written seq,
+        dropping any still-unacked backlog (events/heartbeat are never-drop
+        lanes and are left untouched).
+        """
+        if not self._started or self._paused:
+            return
+        self._clear_taps()
+        if self._heartbeat is not None:
+            self._heartbeat.stop()
+        if self._router is not None:
+            self._router.stop()
+        self._publisher.close()
+        if discard:
+            last_seq = self._spool.next_seq("channels") - 1
+            self._spool.ack("channels", last_seq)
+        self._paused = True
+
+    def resume(self) -> None:
+        """Restart threads (fresh queue/core/router/heartbeat) and reconnect.
+
+        Idempotent: a no-op if not started or not paused. Router/heartbeat
+        threads cannot be restarted once stopped (`threading.Thread` runs
+        once), so this builds fresh instances rather than reusing the paused
+        ones; the resolved config and writer set from `start()` carry over
+        unchanged.
+        """
+        if not self._started or not self._paused:
+            return
+        self._launch_runtime()
+        self._paused = False
+
+    def status(self) -> dict:
+        """Plain JSON-able snapshot: connection, counters, and per-lane spool stats."""
+        spool_stats = self._spool.stats()
+        return {
+            "online": self._router.online if self._router is not None else False,
+            "backoff": self._router.backoff if self._router is not None else None,
+            "queue": {
+                "depth": self._queue.depth if self._queue is not None else 0,
+                "dropped": self._queue.dropped if self._queue is not None else 0,
+            },
+            "skipped": self._core.skipped if self._core is not None else 0,
+            "spool": {lane: dataclasses.asdict(stats) for lane, stats in spool_stats.items()},
+            "reconnects": getattr(self._publisher, "reconnects", 0),
+            "subscriptions": self._subscriptions(),
+            "channels_active": len(self._resolved),
+            "router_alive": self._router.alive if self._router is not None else False,
+            "router_error": self._router.last_error if self._router is not None else None,
+        }
+
+    # -- internals ---------------------------------------------------------------
+
+    def _launch_runtime(self) -> None:
+        """Build fresh queue/core/router/heartbeat, wire taps, and start both threads."""
+        self._queue = SampleQueue(settings.FLEET_QUEUE_MAX_SAMPLES)
+        self._core = RouterCore(self._resolved, self._streams.flush_interval_s)
+        self._router = StreamRouter(
+            self._core, self._queue, self._spool, self._publisher, self._schema_payload
+        )
+        tap = self._queue.as_tap()
+        for writer in self._writers.values():
+            writer.set_tap(tap)
+        self._started_at = time.time()
+        self._heartbeat = HeartbeatThread(
+            self._publisher, self._heartbeat_payload, spool=self._spool
+        )
+        self._router.start()
+        self._heartbeat.start()
+
+    def _clear_taps(self) -> None:
+        for writer in self._writers.values():
+            writer.set_tap(None)
+
+    def _subscriptions(self) -> list[str]:
+        return sorted(self._writers)
+
+    def _heartbeat_payload(self) -> dict:
+        return build_heartbeat(
+            started_at=self._started_at if self._started_at is not None else time.time(),
+            subscriptions=self._subscriptions(),
+            channels_active=len(self._resolved),
+            queue_depth=self._queue.depth if self._queue is not None else 0,
+            queue_dropped=self._queue.dropped if self._queue is not None else 0,
+            spool_stats=self._spool.stats(),
+            disk_free_bytes=disk_free(settings.CACHE_DIRECTORY),
+            reconnects=getattr(self._publisher, "reconnects", 0),
+        )

--- a/src/sink/publish/service.py
+++ b/src/sink/publish/service.py
@@ -66,6 +66,9 @@ class FleetService:
         """Resolve channels against the sink's subscribed buffers, then run.
 
         Raises:
+            RuntimeError: `start()` called while already started -- a
+                double start is a programming error, not something to
+                silently ignore or silently restart.
             FleetDisabledError | FleetNotInstalledError: via `require_fleet()`.
             StreamConfigError: a configured `channels[].topic` is not
                 currently subscribed on the sink (reused from
@@ -74,6 +77,8 @@ class FleetService:
                 subscribed on the sink is simply absent from it here).
 
         """
+        if self._started:
+            raise RuntimeError("FleetService already started")
         require_fleet()
         configured_topics = {rule.topic for rule in self._streams.channels}
         # TopicSink exposes no public per-topic buffer accessor (only the
@@ -187,6 +192,8 @@ class FleetService:
             "heartbeat_spool_failures": (
                 self._heartbeat.spool_failures if self._heartbeat is not None else 0
             ),
+            "heartbeat_alive": self._heartbeat.alive if self._heartbeat is not None else False,
+            "heartbeat_error": self._heartbeat.last_error if self._heartbeat is not None else None,
         }
 
     # -- internals ---------------------------------------------------------------

--- a/test/sink/publish/test_heartbeat.py
+++ b/test/sink/publish/test_heartbeat.py
@@ -273,6 +273,78 @@ class TestHeartbeatThread:
         assert warnings
         assert any("heartbeat" in r.getMessage() for r in warnings)
 
+    def test_factory_failure_skips_beat_logs_warning_and_stays_alive(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        pub = FakePublisher()
+
+        def boom() -> dict:
+            raise RuntimeError("spool corrupt")
+
+        thread = HeartbeatThread(pub, boom, interval_s=0.01)
+
+        with caplog.at_level(logging.WARNING):
+            thread.start()
+            deadline = time.monotonic() + 2.0
+            while thread.last_error is None and time.monotonic() < deadline:
+                time.sleep(0.01)
+            assert thread.alive is True  # the factory failure never escaped run()'s loop
+            thread.stop()
+
+        assert pub.heartbeat_calls == []
+        assert thread.alive is False  # stopped and joined
+        assert thread.last_error is not None
+        assert "spool corrupt" in thread.last_error
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert warnings
+        assert any("payload factory" in r.getMessage() for r in warnings)
+
+    def test_factory_failure_synchronous_tick_skips_and_sets_last_error(self) -> None:
+        pub = FakePublisher()
+
+        def boom() -> dict:
+            raise RuntimeError("spool corrupt")
+
+        thread = HeartbeatThread(pub, boom, interval_s=HEARTBEAT_INTERVAL_S)
+
+        thread._tick()  # drive synchronously; no sleeping needed
+
+        assert pub.heartbeat_calls == []
+        assert thread.last_error is not None
+        assert "spool corrupt" in thread.last_error
+
+    def test_factory_recovery_clears_last_error(self) -> None:
+        pub = FakePublisher()
+        calls = {"n": 0}
+
+        def flaky() -> dict:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("disk missing")
+            return {"v": 1}
+
+        thread = HeartbeatThread(pub, flaky, interval_s=HEARTBEAT_INTERVAL_S)
+
+        thread._tick()
+        assert thread.last_error is not None
+
+        thread._tick()
+        assert thread.last_error is None
+        assert pub.heartbeat_calls == [{"v": 1}]
+
+    def test_thread_alive_running(self) -> None:
+        pub = FakePublisher()
+        thread = HeartbeatThread(pub, lambda: {"v": 1}, interval_s=0.01)
+        thread.start()
+        try:
+            deadline = time.monotonic() + 2.0
+            while not thread.alive and time.monotonic() < deadline:
+                time.sleep(0.01)
+            assert thread.alive is True
+        finally:
+            thread.stop()
+        assert thread.alive is False
+
     def test_stop_joins_promptly(self) -> None:
         pub = FakePublisher()
         thread = HeartbeatThread(pub, lambda: {"v": 1}, interval_s=HEARTBEAT_INTERVAL_S)

--- a/test/sink/publish/test_heartbeat.py
+++ b/test/sink/publish/test_heartbeat.py
@@ -1,0 +1,252 @@
+"""Heartbeat payload building and HeartbeatThread lifecycle (fleet streaming spec §3)."""
+
+import importlib
+import pathlib
+import sys
+import time
+
+import pytest
+
+from src.sink.publish import heartbeat as heartbeat_mod
+from src.sink.publish.heartbeat import HEARTBEAT_INTERVAL_S, HeartbeatThread, build_heartbeat
+from src.sink.publish.publisher import Publisher, PublishError
+from src.sink.publish.spool import Spool
+
+
+def test_heartbeat_module_does_not_import_paho_eagerly(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in [m for m in sys.modules if m == "paho" or m.startswith("paho.")]:
+        monkeypatch.delitem(sys.modules, name)
+    monkeypatch.delitem(sys.modules, "src.sink.publish.heartbeat", raising=False)
+    importlib.import_module("src.sink.publish.heartbeat")
+    assert not any(m == "paho" or m.startswith("paho.") for m in sys.modules)
+
+
+class TestBuildHeartbeat:
+    def test_golden_shape_and_exact_keys(self) -> None:
+        payload = build_heartbeat(
+            started_at=100.0,
+            subscriptions=["/imu", "/odom"],
+            channels_active=3,
+            queue_depth=5,
+            queue_dropped=2,
+            spool_stats={
+                "channels": {"bytes": 10, "pending": 1, "evicted": 0},
+                "events": {"bytes": 20, "pending": 2, "evicted": 1},
+                "heartbeat": {"bytes": 30, "pending": 0, "evicted": 0},
+            },
+            disk_free_bytes=1_000_000,
+            reconnects=4,
+            now=130.0,
+        )
+        assert payload == {
+            "v": 1,
+            "t": 130.0,
+            "online": True,
+            "bagel_version": payload["bagel_version"],  # asserted separately below
+            "uptime_s": 30.0,
+            "subscriptions": ["/imu", "/odom"],
+            "channels_active": 3,
+            "queue": {"depth": 5, "dropped": 2},
+            "spool": {"bytes": 60, "pending": 3, "evicted": 1},
+            "disk_free_bytes": 1_000_000,
+            "cert_expires_at": None,
+            "reconnects": 4,
+        }
+        assert isinstance(payload["bagel_version"], str) and payload["bagel_version"]
+        assert set(payload) == {
+            "v",
+            "t",
+            "online",
+            "bagel_version",
+            "uptime_s",
+            "subscriptions",
+            "channels_active",
+            "queue",
+            "spool",
+            "disk_free_bytes",
+            "cert_expires_at",
+            "reconnects",
+        }
+
+    def test_now_defaults_to_wall_clock(self) -> None:
+        before = time.time()
+        payload = build_heartbeat(
+            started_at=0.0,
+            subscriptions=[],
+            channels_active=0,
+            queue_depth=0,
+            queue_dropped=0,
+            spool_stats={},
+            disk_free_bytes=0,
+            reconnects=0,
+        )
+        after = time.time()
+        assert before <= payload["t"] <= after
+
+    def test_empty_spool_stats_aggregate_to_zero(self) -> None:
+        payload = build_heartbeat(
+            started_at=0.0,
+            subscriptions=[],
+            channels_active=0,
+            queue_depth=0,
+            queue_dropped=0,
+            spool_stats={},
+            disk_free_bytes=0,
+            reconnects=0,
+            now=1.0,
+        )
+        assert payload["spool"] == {"bytes": 0, "pending": 0, "evicted": 0}
+
+    def test_accepts_lanestats_like_objects_with_attributes(self) -> None:
+        class FakeLaneStats:
+            def __init__(self, bytes_: int, pending: int, evicted: int) -> None:
+                self.bytes = bytes_
+                self.pending = pending
+                self.evicted = evicted
+
+        payload = build_heartbeat(
+            started_at=0.0,
+            subscriptions=[],
+            channels_active=0,
+            queue_depth=0,
+            queue_dropped=0,
+            spool_stats={"channels": FakeLaneStats(5, 1, 0)},
+            disk_free_bytes=0,
+            reconnects=0,
+            now=1.0,
+        )
+        assert payload["spool"] == {"bytes": 5, "pending": 1, "evicted": 0}
+
+
+class TestBagelVersion:
+    def test_returns_nonempty_string(self) -> None:
+        assert isinstance(heartbeat_mod.bagel_version(), str)
+        assert heartbeat_mod.bagel_version()
+
+    def test_falls_back_when_distribution_metadata_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import importlib.metadata
+
+        def raise_not_found(_name: str) -> str:
+            raise importlib.metadata.PackageNotFoundError("bagel")
+
+        monkeypatch.setattr(heartbeat_mod.importlib.metadata, "version", raise_not_found)
+        version = heartbeat_mod.bagel_version()
+        assert isinstance(version, str) and version != "unknown"
+
+    def test_returns_unknown_when_pyproject_also_unreadable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import importlib.metadata
+
+        def raise_not_found(_name: str) -> str:
+            raise importlib.metadata.PackageNotFoundError("bagel")
+
+        def raise_os_error() -> str:
+            raise OSError("nope")
+
+        monkeypatch.setattr(heartbeat_mod.importlib.metadata, "version", raise_not_found)
+        monkeypatch.setattr(heartbeat_mod, "_pyproject_version", raise_os_error)
+        assert heartbeat_mod.bagel_version() == "unknown"
+
+
+class TestDiskFree:
+    def test_matches_shutil_disk_usage(self, tmp_path: pathlib.Path) -> None:
+        import shutil
+
+        # Free space can shift between the two calls on a live filesystem
+        # (other processes writing concurrently); assert same order of
+        # magnitude rather than bit-for-bit equality to avoid flakes.
+        before = shutil.disk_usage(tmp_path).free
+        got = heartbeat_mod.disk_free(tmp_path)
+        after = shutil.disk_usage(tmp_path).free
+        assert isinstance(got, int)
+        assert min(before, after) * 0.9 <= got <= max(before, after) * 1.1
+
+
+class FakePublisher(Publisher):
+    """In-memory Publisher double: records heartbeat publishes, can be told to fail."""
+
+    def __init__(self) -> None:
+        self.heartbeat_calls: list[dict] = []
+        self._fail_next = 0
+        self._connected = True
+
+    def connect(self) -> None:
+        self._connected = True
+
+    def publish(
+        self, kind: str, payload: dict, *, retain: bool = False, timeout_s: float = 10.0
+    ) -> None:
+        assert kind == "heartbeat"
+        if self._fail_next > 0:
+            self._fail_next -= 1
+            raise PublishError("heartbeat publish failed")
+        self.heartbeat_calls.append(payload)
+
+    def close(self) -> None:
+        self._connected = False
+
+    @property
+    def connected(self) -> bool:
+        return self._connected
+
+    def fail_next(self, n: int) -> None:
+        self._fail_next = n
+
+
+class TestHeartbeatThread:
+    def test_ticks_publish_heartbeat_payloads(self, tmp_path: pathlib.Path) -> None:
+        pub = FakePublisher()
+        calls = []
+
+        def factory() -> dict:
+            calls.append(1)
+            return {"v": 1, "n": len(calls)}
+
+        thread = HeartbeatThread(pub, factory, interval_s=0.01)
+        thread.start()
+        deadline = time.monotonic() + 2.0
+        while len(pub.heartbeat_calls) < 3 and time.monotonic() < deadline:
+            time.sleep(0.01)
+        thread.stop()
+        assert len(pub.heartbeat_calls) >= 3
+        assert not thread.is_alive()
+
+    def test_publish_failure_spools_to_heartbeat_lane(self, tmp_path: pathlib.Path) -> None:
+        pub = FakePublisher()
+        pub.fail_next(1)
+        spool = Spool(tmp_path / "spool")
+        payload = {"v": 1, "marker": "spooled"}
+        thread = HeartbeatThread(pub, lambda: payload, interval_s=10.0, spool=spool)
+
+        thread._tick()  # drive synchronously; no sleeping needed
+
+        assert pub.heartbeat_calls == []
+        pending = list(spool.pending("heartbeat"))
+        assert len(pending) == 1
+        assert pending[0][1] == payload
+
+    def test_publish_failure_without_spool_swallowed(self) -> None:
+        pub = FakePublisher()
+        pub.fail_next(1)
+        thread = HeartbeatThread(pub, lambda: {"v": 1}, interval_s=10.0)
+        thread._tick()  # must not raise
+        assert pub.heartbeat_calls == []
+
+    def test_stop_joins_promptly(self) -> None:
+        pub = FakePublisher()
+        thread = HeartbeatThread(pub, lambda: {"v": 1}, interval_s=HEARTBEAT_INTERVAL_S)
+        thread.start()
+        time.sleep(0.02)
+
+        start = time.monotonic()
+        thread.stop()
+        elapsed = time.monotonic() - start
+
+        assert not thread.is_alive()
+        assert elapsed < 2.0
+
+    def test_module_constant_is_thirty_seconds(self) -> None:
+        assert HEARTBEAT_INTERVAL_S == 30.0

--- a/test/sink/publish/test_heartbeat.py
+++ b/test/sink/publish/test_heartbeat.py
@@ -1,6 +1,7 @@
 """Heartbeat payload building and HeartbeatThread lifecycle (fleet streaming spec §3)."""
 
 import importlib
+import logging
 import pathlib
 import sys
 import time
@@ -10,7 +11,7 @@ import pytest
 from src.sink.publish import heartbeat as heartbeat_mod
 from src.sink.publish.heartbeat import HEARTBEAT_INTERVAL_S, HeartbeatThread, build_heartbeat
 from src.sink.publish.publisher import Publisher, PublishError
-from src.sink.publish.spool import Spool
+from src.sink.publish.spool import Spool, SpoolFullError
 
 
 def test_heartbeat_module_does_not_import_paho_eagerly(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -227,6 +228,7 @@ class TestHeartbeatThread:
         pending = list(spool.pending("heartbeat"))
         assert len(pending) == 1
         assert pending[0][1] == payload
+        assert thread.spool_failures == 0  # the spool write itself succeeded
 
     def test_publish_failure_without_spool_swallowed(self) -> None:
         pub = FakePublisher()
@@ -234,6 +236,42 @@ class TestHeartbeatThread:
         thread = HeartbeatThread(pub, lambda: {"v": 1}, interval_s=10.0)
         thread._tick()  # must not raise
         assert pub.heartbeat_calls == []
+        assert thread.spool_failures == 0  # no spool configured; nothing to fail
+
+    def test_spool_write_failure_after_publish_failure_logs_warning_and_counts(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # PublishError (broker offline) is normal and stays DEBUG-quiet (see
+        # test_publish_failure_spools_to_heartbeat_lane above); a failure
+        # writing to the never-drop "heartbeat" lane afterward is not --
+        # spec §4 requires it be visible, not silently dropped.
+        pub = FakePublisher()
+        pub.fail_next(1000)  # every tick's publish fails
+
+        class BoomSpool:
+            """Duck-typed Spool stand-in: next_seq works, append always fails."""
+
+            def next_seq(self, lane: str) -> int:
+                return 1
+
+            def append(self, lane: str, seq: int, payload: dict) -> None:
+                raise SpoolFullError(f"lane '{lane}': disk full")
+
+        thread = HeartbeatThread(pub, lambda: {"v": 1}, interval_s=10.0, spool=BoomSpool())
+
+        with caplog.at_level(logging.WARNING):
+            thread.start()
+            deadline = time.monotonic() + 2.0
+            while thread.spool_failures < 1 and time.monotonic() < deadline:
+                time.sleep(0.01)
+            assert thread.is_alive()  # the failure never escaped run()'s loop
+            thread.stop()
+
+        assert thread.spool_failures == 1
+        assert pub.heartbeat_calls == []
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert warnings
+        assert any("heartbeat" in r.getMessage() for r in warnings)
 
     def test_stop_joins_promptly(self) -> None:
         pub = FakePublisher()

--- a/test/sink/publish/test_mqtt_publisher.py
+++ b/test/sink/publish/test_mqtt_publisher.py
@@ -261,6 +261,41 @@ class TestReconnectCounter:
         p.close()
         assert p.reconnects == 0
 
+    def test_replace_path_teardown_does_not_count_as_reconnect(
+        self, fake: dict[str, FakeFleetPaho]
+    ) -> None:
+        p = _publisher()
+        p.connect()
+        first = fake["client"]
+
+        # Simulate paho's "socket still live" semantics: when the prior
+        # client's TCP session is still up (e.g. we are replacing it after a
+        # wait_for_publish timeout, not a broker-side drop), disconnect()
+        # fires on_disconnect synchronously -- same as the clean-close case
+        # above. connect()'s replace-path teardown must gate this the same
+        # way close() does.
+        def fake_disconnect() -> None:
+            first.calls.append(("disconnect",))
+            first._connected = False
+            first.on_disconnect(first, None, object(), object(), None)
+
+        first.disconnect = fake_disconnect  # type: ignore[method-assign]
+        p.connect()  # replace-path: tears down `first` before building the new client
+
+        assert p.reconnects == 0
+
+    def test_genuine_drop_outside_our_own_teardown_still_counts(
+        self, fake: dict[str, FakeFleetPaho]
+    ) -> None:
+        p = _publisher()
+        p.connect()
+        client = fake["client"]
+        # An ordinary broker-drop callback -- not fired from within our own
+        # connect()/close() teardown -- must still be counted; the _closing
+        # gate must not swallow this too.
+        client.on_disconnect(client, None, object(), object(), None)
+        assert p.reconnects == 1
+
     def test_handler_exceptions_are_swallowed(self, fake: dict[str, FakeFleetPaho]) -> None:
         p = _publisher()
         p.connect()

--- a/test/sink/publish/test_mqtt_publisher.py
+++ b/test/sink/publish/test_mqtt_publisher.py
@@ -223,6 +223,57 @@ class TestClose:
         p.close()  # must not raise
 
 
+class TestReconnectCounter:
+    def test_on_disconnect_is_registered_at_connect(self, fake: dict[str, FakeFleetPaho]) -> None:
+        p = _publisher()
+        p.connect()
+        assert fake["client"].on_disconnect is not None
+
+    def test_disconnect_callback_increments_reconnects(
+        self, fake: dict[str, FakeFleetPaho]
+    ) -> None:
+        p = _publisher()
+        p.connect()
+        assert p.reconnects == 0
+        client = fake["client"]
+        # Simulate paho VERSION2 firing the callback (client, userdata, flags, rc, props).
+        client.on_disconnect(client, None, object(), object(), None)
+        assert p.reconnects == 1
+        client.on_disconnect(client, None, object(), object(), None)
+        assert p.reconnects == 2
+
+    def test_clean_close_does_not_double_count_as_reconnect(
+        self, fake: dict[str, FakeFleetPaho]
+    ) -> None:
+        p = _publisher()
+        p.connect()
+        # close() drives the fake client to a disconnected state; since our fake
+        # doesn't synchronously invoke on_disconnect (paho's real client does,
+        # once the network thread is stopped), simulate that here.
+        client = fake["client"]
+
+        def fake_disconnect() -> None:
+            client.calls.append(("disconnect",))
+            client._connected = False
+            client.on_disconnect(client, None, object(), object(), None)
+
+        client.disconnect = fake_disconnect  # type: ignore[method-assign]
+        p.close()
+        assert p.reconnects == 0
+
+    def test_handler_exceptions_are_swallowed(self, fake: dict[str, FakeFleetPaho]) -> None:
+        p = _publisher()
+        p.connect()
+        client = fake["client"]
+
+        class Boom:
+            def __add__(self, other: object) -> "Boom":
+                raise RuntimeError("boom")
+
+        p.reconnects = Boom()  # force the increment inside the handler to raise
+        client.on_disconnect(client, None, object(), object(), None)  # must not raise
+
+
 def test_mqtt_module_does_not_import_paho_eagerly(monkeypatch: pytest.MonkeyPatch) -> None:
     for name in [m for m in sys.modules if m == "paho" or m.startswith("paho.")]:
         monkeypatch.delitem(sys.modules, name)

--- a/test/sink/publish/test_router.py
+++ b/test/sink/publish/test_router.py
@@ -396,3 +396,39 @@ class TestStreamRouterThread:
         # The unacked tail is a contiguous run up to total_records -- no gaps,
         # no out-of-order acks.
         assert remaining == list(range(remaining[0], total_records + 1))
+
+
+class TestStreamRouterDeathIsVisible:
+    """A bug in core/spool (not a PublishError) must not die silently.
+
+    run() wraps _tick in a broad except: log, record _fatal_error, exit the
+    loop. `alive` (thread running AND no fatal error) and `last_error` make
+    this visible to FleetService.status() instead of leaving a router that
+    looks merely "not yet reconnected" forever.
+    """
+
+    def test_non_publish_error_kills_thread_and_is_visible(self, tmp_path: pathlib.Path) -> None:
+        router, q, _spool, _pub = _router(tmp_path, flush_interval_s=1.0)
+
+        def boom(*_args: object, **_kwargs: object) -> None:
+            raise RuntimeError("core exploded")
+
+        router._core.offer = boom  # type: ignore[method-assign]
+        q.put(("/imu", 1.0, {"x": 1.0}))
+
+        assert router.alive is False  # never started yet: not alive, but no error either
+        assert router.last_error is None
+
+        router.start()
+        deadline = time.monotonic() + 2.0
+        while router.is_alive() and time.monotonic() < deadline:
+            time.sleep(0.01)
+
+        assert not router.is_alive()
+        assert router.alive is False
+        assert router.last_error is not None
+        assert "core exploded" in router.last_error
+
+        # stop() on an already-dead thread must not raise (no exception escapes).
+        router.stop()
+        assert not router.is_alive()

--- a/test/sink/publish/test_router.py
+++ b/test/sink/publish/test_router.py
@@ -169,12 +169,15 @@ class TestRateCapAndBatch:
 class FakePublisher(Publisher):
     """In-memory Publisher double: records calls, can be told to fail."""
 
-    def __init__(self, *, connect_should_fail: bool = False) -> None:
+    def __init__(
+        self, *, connect_should_fail: bool = False, channel_publish_delay_s: float = 0.0
+    ) -> None:
         self.connect_should_fail = connect_should_fail
         self.connect_calls = 0
         self.schema_calls: list[dict] = []
         self.channel_calls: list[dict] = []
         self._fail_channel_publishes = 0
+        self._channel_publish_delay_s = channel_publish_delay_s
         self._connected = False
 
     def connect(self) -> None:
@@ -189,6 +192,8 @@ class FakePublisher(Publisher):
         if kind == "schema":
             self.schema_calls.append(payload)
         elif kind == "channels":
+            if self._channel_publish_delay_s:
+                time.sleep(self._channel_publish_delay_s)
             if self._fail_channel_publishes > 0:
                 self._fail_channel_publishes -= 1
                 raise PublishError("channels publish failed")
@@ -324,6 +329,33 @@ class TestStreamRouterTick:
         assert [c["seq"] for c in pub.channel_calls] == [1, 2]
         assert list(spool.pending("channels")) == []
 
+    def test_pump_checks_stop_event_between_replay_iterations(self, tmp_path: pathlib.Path) -> None:
+        # A post-outage backlog can hold thousands of records (the channels
+        # lane is size-capped, not count-capped); _pump must notice
+        # self._stop_event mid-replay rather than draining the whole
+        # backlog first.
+        router, _q, spool, pub = _router(tmp_path)
+        for seq in range(1, 6):
+            spool.append("channels", seq, {"seq": seq, "v": 1, "samples": []})
+        router._online = True  # skip _reconnect(); exercise the replay loop directly
+
+        publish = pub.publish
+
+        def publish_then_stop_after_two(
+            kind: str, payload: dict, *, retain: bool = False, timeout_s: float = 10.0
+        ) -> None:
+            publish(kind, payload, retain=retain, timeout_s=timeout_s)
+            if kind == "channels" and len(pub.channel_calls) == 2:
+                router._stop_event.set()
+
+        pub.publish = publish_then_stop_after_two  # type: ignore[method-assign]
+
+        router._pump(now=0.0)
+
+        assert [c["seq"] for c in pub.channel_calls] == [1, 2]
+        # The loop broke before seq 3: unacked, still spooled, correct watermark.
+        assert [seq for seq, _ in spool.pending("channels")] == [3, 4, 5]
+
 
 class TestStreamRouterThread:
     def test_stop_joins_promptly(self, tmp_path: pathlib.Path) -> None:
@@ -337,3 +369,30 @@ class TestStreamRouterThread:
 
         assert not router.is_alive()
         assert elapsed < 2.0
+
+    def test_stop_joins_promptly_mid_large_replay_backlog(self, tmp_path: pathlib.Path) -> None:
+        # Regression for the normal-path violation: a large post-outage
+        # backlog draining slowly must still let stop() honor its
+        # join(timeout=5) bound, not just the connect()-blocking edge case.
+        publish_delay_s = 0.05
+        total_records = 40
+        pub = FakePublisher(channel_publish_delay_s=publish_delay_s)
+        router, _q, spool, _ = _router(tmp_path, publisher=pub)
+        for seq in range(1, total_records + 1):
+            spool.append("channels", seq, {"seq": seq, "v": 1, "samples": []})
+
+        router.start()
+        time.sleep(publish_delay_s * 3)  # a handful of records go out, nowhere near all 40
+
+        start = time.monotonic()
+        router.stop()
+        elapsed = time.monotonic() - start
+
+        assert not router.is_alive()
+        assert elapsed < 5.0
+        remaining = [seq for seq, _ in spool.pending("channels")]
+        assert remaining  # stopped mid-backlog: work was left for next start
+        assert len(remaining) < total_records
+        # The unacked tail is a contiguous run up to total_records -- no gaps,
+        # no out-of-order acks.
+        assert remaining == list(range(remaining[0], total_records + 1))

--- a/test/sink/publish/test_router.py
+++ b/test/sink/publish/test_router.py
@@ -1,11 +1,17 @@
-"""SampleQueue: bounded, drop-oldest, counted (spec §4)."""
+"""SampleQueue: bounded, drop-oldest, counted (spec §4).
+
+RouterCore: extraction, rate-capping, batch-building (spec §2/§4).
+"""
 
 import importlib
 import sys
 
+import pyarrow as pa
 import pytest
 
-from src.sink.publish.router import SampleQueue
+from src.message.base import AccessPath
+from src.sink.publish.config import ResolvedChannel
+from src.sink.publish.router import RouterCore, SampleQueue, extract_value
 
 
 class TestSampleQueue:
@@ -49,3 +55,107 @@ def test_router_module_does_not_import_paho_eagerly(monkeypatch: pytest.MonkeyPa
     monkeypatch.delitem(sys.modules, "src.sink.publish.router", raising=False)
     importlib.import_module("src.sink.publish.router")
     assert not any(m == "paho" or m.startswith("paho.") for m in sys.modules)
+
+
+def _chan(
+    name: str, topic: str, path: list[str], rate_hz: float, type_: str = "number"
+) -> ResolvedChannel:
+    return ResolvedChannel(
+        name=name,
+        type=type_,
+        source_topic=topic,
+        source_field=".".join(path),
+        rate_hz=rate_hz,
+        paths={"value": AccessPath(path=path, pa_type=pa.float64())},
+    )
+
+
+class TestExtractValue:
+    def test_nested(self) -> None:
+        assert extract_value({"a": {"b": 3.5}}, ["a", "b"]) == 3.5
+
+    def test_missing_raises_keyerror(self) -> None:
+        import pytest
+
+        with pytest.raises(KeyError):
+            extract_value({"a": {}}, ["a", "b"])
+
+
+class TestRateCapAndBatch:
+    def test_last_sample_per_interval_wins(self) -> None:
+        core = RouterCore([_chan("imu.x", "/imu", ["x"], rate_hz=1.0)], flush_interval_s=1.0)
+        # three samples inside the same 1 Hz slot: last wins
+        core.offer("/imu", 10.1, {"x": 1.0})
+        core.offer("/imu", 10.5, {"x": 2.0})
+        core.offer("/imu", 10.9, {"x": 3.0})
+        # next slot
+        core.offer("/imu", 11.2, {"x": 4.0})
+        batch = core.flush(t_batch=12.0)
+        assert [(s["t"], s["v"]) for s in batch["samples"]] == [(10.9, 3.0), (11.2, 4.0)]
+        assert batch["v"] == 1 and "seq" not in batch
+
+    def test_channels_from_other_topics_ignored(self) -> None:
+        core = RouterCore([_chan("imu.x", "/imu", ["x"], 5.0)], flush_interval_s=1.0)
+        core.offer("/other", 1.0, {"x": 9.9})
+        assert core.flush(2.0) is None
+
+    def test_missing_field_skipped_and_counted(self) -> None:
+        core = RouterCore([_chan("imu.x", "/imu", ["x"], 5.0)], flush_interval_s=1.0)
+        core.offer("/imu", 1.0, {"y": 1.0})
+        assert core.skipped == 1 and core.flush(2.0) is None
+
+    def test_geo_channel_builds_object(self) -> None:
+        chan = ResolvedChannel(
+            name="odom.geo",
+            type="geo",
+            source_topic="/odom",
+            source_field="lat=a,lon=b",
+            rate_hz=1.0,
+            paths={
+                "lat": AccessPath(path=["a"], pa_type=pa.float64()),
+                "lon": AccessPath(path=["b"], pa_type=pa.float64()),
+            },
+        )
+        core = RouterCore([chan], flush_interval_s=1.0)
+        core.offer("/odom", 3.0, {"a": 37.1, "b": -122.0})
+        (sample,) = core.flush(4.0)["samples"]
+        assert sample["c"] == "odom.geo" and sample["v"] == {"lat": 37.1, "lon": -122.0}
+
+    def test_flush_empties_and_orders_across_channels(self) -> None:
+        core = RouterCore(
+            [_chan("a.x", "/a", ["x"], 10.0), _chan("b.x", "/b", ["x"], 10.0)],
+            flush_interval_s=1.0,
+        )
+        core.offer("/b", 2.0, {"x": 2.0})
+        core.offer("/a", 1.0, {"x": 1.0})
+        batch = core.flush(3.0)
+        assert [s["t"] for s in batch["samples"]] == [1.0, 2.0]
+        assert core.flush(4.0) is None
+
+    def test_should_flush_on_size_or_interval(self) -> None:
+        core = RouterCore([_chan("a.x", "/a", ["x"], 50.0)], flush_interval_s=1.0, max_samples=2)
+        core.flush(0.0)  # set _last_flush
+        assert not core.should_flush(now=0.5, pending_count=1)
+        assert core.should_flush(now=0.5, pending_count=2)
+        assert core.should_flush(now=1.6, pending_count=0)
+
+    def test_late_sample_for_already_emitted_slot_is_dropped(self) -> None:
+        # Slot-survival: once a (channel, slot) has been popped by flush(), a
+        # later-arriving offer() for that same slot -- or an earlier one --
+        # must not resurrect it into a future batch. Without this guard, a
+        # reordered/late sample could re-emit stale data for a slot the
+        # subscriber already received.
+        core = RouterCore([_chan("imu.x", "/imu", ["x"], rate_hz=1.0)], flush_interval_s=1.0)
+        core.offer("/imu", 10.9, {"x": 3.0})  # slot 10
+        batch = core.flush(t_batch=11.0)
+        assert [(s["t"], s["v"]) for s in batch["samples"]] == [(10.9, 3.0)]
+
+        # A late sample lands for the same (already-emitted) slot 10.
+        core.offer("/imu", 10.95, {"x": 99.0})
+        assert core.pending_count == 0
+        assert core.flush(t_batch=12.0) is None
+
+        # The next slot still works normally afterward.
+        core.offer("/imu", 11.4, {"x": 5.0})
+        batch2 = core.flush(t_batch=13.0)
+        assert [(s["t"], s["v"]) for s in batch2["samples"]] == [(11.4, 5.0)]

--- a/test/sink/publish/test_router.py
+++ b/test/sink/publish/test_router.py
@@ -356,6 +356,25 @@ class TestStreamRouterTick:
         # The loop broke before seq 3: unacked, still spooled, correct watermark.
         assert [seq for seq, _ in spool.pending("channels")] == [3, 4, 5]
 
+    def test_pump_returns_immediately_when_stop_event_already_set(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        # Narrows the stop/reconnect race: if stop() lands while a blocked
+        # connect() is in flight, _pump must not fall through into a full
+        # publish pass once that connect() finally resolves and _online
+        # flips true -- it should bail out before ever calling _reconnect()
+        # or publishing anything.
+        router, _q, spool, pub = _router(tmp_path)
+        spool.append("channels", 1, {"seq": 1, "v": 1, "samples": []})
+        router._stop_event.set()
+
+        router._pump(now=0.0)
+
+        assert pub.connect_calls == 0
+        assert pub.channel_calls == []
+        assert not router.online
+        assert [seq for seq, _ in spool.pending("channels")] == [1]
+
 
 class TestStreamRouterThread:
     def test_stop_joins_promptly(self, tmp_path: pathlib.Path) -> None:

--- a/test/sink/publish/test_router.py
+++ b/test/sink/publish/test_router.py
@@ -4,14 +4,19 @@ RouterCore: extraction, rate-capping, batch-building (spec §2/§4).
 """
 
 import importlib
+import pathlib
 import sys
+import time
 
 import pyarrow as pa
 import pytest
 
 from src.message.base import AccessPath
+from src.sink.publish import router as router_mod
 from src.sink.publish.config import ResolvedChannel
-from src.sink.publish.router import RouterCore, SampleQueue, extract_value
+from src.sink.publish.publisher import Publisher, PublishError
+from src.sink.publish.router import RouterCore, SampleQueue, StreamRouter, extract_value
+from src.sink.publish.spool import Spool
 
 
 class TestSampleQueue:
@@ -159,3 +164,176 @@ class TestRateCapAndBatch:
         core.offer("/imu", 11.4, {"x": 5.0})
         batch2 = core.flush(t_batch=13.0)
         assert [(s["t"], s["v"]) for s in batch2["samples"]] == [(11.4, 5.0)]
+
+
+class FakePublisher(Publisher):
+    """In-memory Publisher double: records calls, can be told to fail."""
+
+    def __init__(self, *, connect_should_fail: bool = False) -> None:
+        self.connect_should_fail = connect_should_fail
+        self.connect_calls = 0
+        self.schema_calls: list[dict] = []
+        self.channel_calls: list[dict] = []
+        self._fail_channel_publishes = 0
+        self._connected = False
+
+    def connect(self) -> None:
+        self.connect_calls += 1
+        if self.connect_should_fail:
+            raise PublishError("connect failed")
+        self._connected = True
+
+    def publish(
+        self, kind: str, payload: dict, *, retain: bool = False, timeout_s: float = 10.0
+    ) -> None:
+        if kind == "schema":
+            self.schema_calls.append(payload)
+        elif kind == "channels":
+            if self._fail_channel_publishes > 0:
+                self._fail_channel_publishes -= 1
+                raise PublishError("channels publish failed")
+            self.channel_calls.append(payload)
+        else:
+            raise AssertionError(f"FakePublisher: unexpected kind {kind!r}")
+
+    def close(self) -> None:
+        self._connected = False
+
+    @property
+    def connected(self) -> bool:
+        return self._connected
+
+    def fail_next_channel_publishes(self, n: int) -> None:
+        self._fail_channel_publishes = n
+
+
+def _router(
+    tmp_path: pathlib.Path,
+    *,
+    rate_hz: float = 1.0,
+    flush_interval_s: float = 0.0,
+    publisher: Publisher | None = None,
+) -> tuple[StreamRouter, SampleQueue, Spool, FakePublisher]:
+    core = RouterCore(
+        [_chan("imu.x", "/imu", ["x"], rate_hz=rate_hz)], flush_interval_s=flush_interval_s
+    )
+    q = SampleQueue(maxsize=100)
+    spool = Spool(tmp_path / "spool")
+    pub = publisher if publisher is not None else FakePublisher()
+    router = StreamRouter(core, q, spool, pub, schema_payload={"v": 1, "channels": []})
+    return router, q, spool, pub
+
+
+class TestStreamRouterTick:
+    def test_flow_through_acked(self, tmp_path: pathlib.Path) -> None:
+        router, q, spool, pub = _router(tmp_path)
+
+        q.put(("/imu", 1.0, {"x": 1.0}))
+        router._tick(now=10.0)
+
+        assert router.online
+        assert pub.connect_calls == 1
+        assert pub.schema_calls == [{"v": 1, "channels": []}]
+        assert len(pub.channel_calls) == 1
+        assert pub.channel_calls[0]["seq"] == 1
+        assert [s["v"] for s in pub.channel_calls[0]["samples"]] == [1.0]
+        assert list(spool.pending("channels")) == []
+
+    def test_offline_accumulate_and_backoff_grows(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Deterministic full jitter: always the upper bound, so next_attempt
+        # is exactly now + backoff and the test can drive `now` precisely.
+        monkeypatch.setattr(router_mod.random, "uniform", lambda _lo, hi: hi)
+        pub = FakePublisher(connect_should_fail=True)
+        router, q, spool, _ = _router(tmp_path, publisher=pub)
+
+        q.put(("/imu", 1.0, {"x": 1.0}))
+        router._tick(now=0.0)
+        assert not router.online
+        assert router.backoff == 2.0  # min(60, 1.0 * 2)
+        assert pub.connect_calls == 1
+        assert len(list(spool.pending("channels"))) == 1  # accumulated, unacked
+
+        # Before the backoff deadline (next_attempt == 0.0 + 2.0): no retry.
+        q.put(("/imu", 2.0, {"x": 2.0}))
+        router._tick(now=0.1)
+        assert not router.online
+        assert router.backoff == 2.0
+        assert pub.connect_calls == 1
+        assert len(list(spool.pending("channels"))) == 2  # still accumulating offline
+
+        # At/after the deadline: another attempt, backoff grows again.
+        router._tick(now=2.0)
+        assert not router.online
+        assert router.backoff == 4.0  # min(60, 2.0 * 2)
+        assert pub.connect_calls == 2
+
+    def test_recover_republishes_schema_then_replays_spooled_batches_in_order(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(router_mod.random, "uniform", lambda _lo, hi: hi)
+        pub = FakePublisher(connect_should_fail=True)
+        router, q, spool, _ = _router(tmp_path, publisher=pub)
+
+        q.put(("/imu", 1.0, {"x": 1.0}))
+        router._tick(now=0.0)  # fails; batch seq=1 spooled while offline
+        assert not router.online and router.backoff == 2.0
+
+        q.put(("/imu", 2.0, {"x": 2.0}))
+        router._tick(now=0.1)  # before deadline (2.0): no reconnect attempt
+        assert not router.online and pub.connect_calls == 1
+
+        pub.connect_should_fail = False
+        q.put(("/imu", 3.0, {"x": 3.0}))
+        router._tick(now=2.0)  # deadline reached: recovers, then replays + the live one
+
+        assert router.online
+        assert router.backoff == 1.0  # reset on successful reconnect
+        assert pub.schema_calls == [{"v": 1, "channels": []}]
+        assert [c["seq"] for c in pub.channel_calls] == [1, 2, 3]
+        assert [s["v"] for c in pub.channel_calls for s in c["samples"]] == [1.0, 2.0, 3.0]
+        assert list(spool.pending("channels")) == []
+
+    def test_publish_failure_mid_replay_stops_and_reschedules(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A failure partway through spool.pending() must not spin: the router
+        # goes offline immediately, leaving later seqs unacked for next time.
+        monkeypatch.setattr(router_mod.random, "uniform", lambda _lo, hi: hi)
+        pub = FakePublisher()
+        router, q, spool, _ = _router(tmp_path, publisher=pub)
+
+        q.put(("/imu", 1.0, {"x": 1.0}))
+        router._tick(now=0.0)  # online, seq=1 published+acked
+        assert router.online and pub.channel_calls[-1]["seq"] == 1
+
+        pub.fail_next_channel_publishes(1)
+        q.put(("/imu", 2.0, {"x": 2.0}))
+        router._tick(now=1.0)  # seq=2 spooled, then publish fails -> offline
+        assert not router.online
+        assert router.backoff == 2.0
+        assert [seq for seq, _ in spool.pending("channels")] == [2]
+
+        router._tick(now=1.0)  # before deadline (1.0 + 2.0 = 3.0): no retry, no spin
+        assert pub.connect_calls == 1  # unchanged: still the initial connect from tick 1
+        assert not router.online
+
+        router._tick(now=3.0)  # deadline reached: recovers and replays seq 2
+        assert router.online
+        assert [c["seq"] for c in pub.channel_calls] == [1, 2]
+        assert list(spool.pending("channels")) == []
+
+
+class TestStreamRouterThread:
+    def test_stop_joins_promptly(self, tmp_path: pathlib.Path) -> None:
+        router, _q, _spool, _pub = _router(tmp_path, flush_interval_s=1.0)
+        router.start()
+        time.sleep(0.05)
+
+        start = time.monotonic()
+        router.stop()
+        elapsed = time.monotonic() - start
+
+        assert not router.is_alive()
+        assert elapsed < 2.0

--- a/test/sink/publish/test_router.py
+++ b/test/sink/publish/test_router.py
@@ -1,0 +1,51 @@
+"""SampleQueue: bounded, drop-oldest, counted (spec §4)."""
+
+import importlib
+import sys
+
+import pytest
+
+from src.sink.publish.router import SampleQueue
+
+
+class TestSampleQueue:
+    def test_put_and_drain_fifo(self) -> None:
+        q = SampleQueue(maxsize=10)
+        for i in range(3):
+            q.put(("/imu", float(i), {"n": i}))
+        got = q.drain(max_items=10, timeout_s=0.01)
+        assert [s[1] for s in got] == [0.0, 1.0, 2.0]
+        assert q.depth == 0
+
+    def test_overflow_drops_oldest_and_counts(self) -> None:
+        q = SampleQueue(maxsize=3)
+        for i in range(5):
+            q.put(("/imu", float(i), {}))
+        assert q.dropped == 2
+        got = q.drain(max_items=10, timeout_s=0.01)
+        assert [s[1] for s in got] == [2.0, 3.0, 4.0]
+
+    def test_drain_respects_max_items(self) -> None:
+        q = SampleQueue(maxsize=10)
+        for i in range(6):
+            q.put(("/t", float(i), {}))
+        got = q.drain(max_items=4, timeout_s=0.01)
+        assert len(got) == 4 and q.depth == 2
+
+    def test_drain_times_out_empty(self) -> None:
+        q = SampleQueue(maxsize=4)
+        assert q.drain(max_items=4, timeout_s=0.01) == []
+
+    def test_as_tap_feeds_queue(self) -> None:
+        q = SampleQueue(maxsize=4)
+        tap = q.as_tap()
+        tap("/imu", 1.0, {"x": 1})
+        assert q.depth == 1
+
+
+def test_router_module_does_not_import_paho_eagerly(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in [m for m in sys.modules if m == "paho" or m.startswith("paho.")]:
+        monkeypatch.delitem(sys.modules, name)
+    monkeypatch.delitem(sys.modules, "src.sink.publish.router", raising=False)
+    importlib.import_module("src.sink.publish.router")
+    assert not any(m == "paho" or m.startswith("paho.") for m in sys.modules)

--- a/test/sink/publish/test_service.py
+++ b/test/sink/publish/test_service.py
@@ -1,0 +1,360 @@
+"""FleetService lifecycle: start/stop/pause/resume/status (fleet streaming spec §2/§5)."""
+
+import importlib
+import json
+import pathlib
+import sys
+import time
+
+import pyarrow as pa
+import pytest
+
+from src.sink.publish import StreamConfigError
+from src.sink.publish.config import StreamsConfig
+from src.sink.publish.publisher import Publisher, PublishError
+from src.sink.publish.service import FleetService
+from src.sink.publish.spool import Spool
+
+
+def test_service_module_does_not_import_paho_eagerly(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in [m for m in sys.modules if m == "paho" or m.startswith("paho.")]:
+        monkeypatch.delitem(sys.modules, name)
+    monkeypatch.delitem(sys.modules, "src.sink.publish.service", raising=False)
+    importlib.import_module("src.sink.publish.service")
+    assert not any(m == "paho" or m.startswith("paho.") for m in sys.modules)
+
+
+class FakeWriter:
+    """Duck-typed stand-in for TopicBufferWriter: struct + set_tap recording."""
+
+    def __init__(self, struct: pa.StructType) -> None:
+        self._struct = struct
+        self._tap = None
+        self.tap_calls: list[object] = []
+
+    @property
+    def struct(self) -> pa.StructType:
+        return self._struct
+
+    def set_tap(self, tap: object) -> None:
+        self._tap = tap
+        self.tap_calls.append(tap)
+
+    def feed(self, topic: str, t: float, msg: dict) -> None:
+        """Simulate a live message arriving: fire the tap, like buffer.append() does."""
+        if self._tap is not None:
+            self._tap(topic, t, msg)
+
+
+class FakeSink:
+    """Duck-typed stand-in for TopicSink: a `_buffers` dict, like the real sink."""
+
+    def __init__(self, buffers: dict[str, FakeWriter]) -> None:
+        self._buffers = buffers
+
+    @property
+    def subscribed_topics(self) -> list[str]:
+        return list(self._buffers)
+
+
+class FakePublisher(Publisher):
+    """In-memory Publisher double: records every kind of publish; can fail on demand."""
+
+    def __init__(self, *, connect_should_fail: bool = False) -> None:
+        self.connect_should_fail = connect_should_fail
+        self.connect_calls = 0
+        self.schema_calls: list[dict] = []
+        self.channel_calls: list[dict] = []
+        self.heartbeat_calls: list[dict] = []
+        self.close_calls = 0
+        self.reconnects = 0
+        self._connected = False
+
+    def connect(self) -> None:
+        self.connect_calls += 1
+        if self.connect_should_fail:
+            raise PublishError("connect failed")
+        self._connected = True
+
+    def publish(
+        self, kind: str, payload: dict, *, retain: bool = False, timeout_s: float = 10.0
+    ) -> None:
+        if kind == "schema":
+            self.schema_calls.append(payload)
+        elif kind == "channels":
+            self.channel_calls.append(payload)
+        elif kind == "heartbeat":
+            self.heartbeat_calls.append(payload)
+        else:
+            raise AssertionError(f"FakePublisher: unexpected kind {kind!r}")
+
+    def close(self) -> None:
+        self.close_calls += 1
+        self._connected = False
+
+    @property
+    def connected(self) -> bool:
+        return self._connected
+
+
+def _imu_streams(**overrides: object) -> StreamsConfig:
+    config = {
+        "flush_interval_s": overrides.pop("flush_interval_s", 0.05),
+        "channels": [{"topic": "/imu", "fields": ["x"], "rate_hz": 50.0}],
+    }
+    config.update(overrides)
+    return StreamsConfig.build(config)
+
+
+def _imu_struct() -> pa.StructType:
+    return pa.struct([pa.field("x", pa.float64())])
+
+
+def _wait_until(predicate: object, timeout_s: float = 2.0) -> bool:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return predicate()
+
+
+class TestStart:
+    def test_wires_taps_and_publishes_schema_on_first_pump(self, tmp_path: pathlib.Path) -> None:
+        writer = FakeWriter(_imu_struct())
+        sink = FakeSink({"/imu": writer})
+        pub = FakePublisher()
+        spool = Spool(tmp_path / "spool")
+        service = FleetService(sink=sink, streams=_imu_streams(), publisher=pub, spool=spool)
+
+        service.start()
+        try:
+            assert writer._tap is not None
+            assert _wait_until(lambda: bool(pub.schema_calls))
+            assert pub.schema_calls[0] == {
+                "v": 1,
+                "channels": [
+                    {
+                        "c": "imu.x",
+                        "type": "number",
+                        "unit": None,
+                        "source_topic": "/imu",
+                        "source_field": "x",
+                    }
+                ],
+            }
+        finally:
+            service.stop()
+
+    def test_unsubscribed_topic_raises_stream_config_error(self, tmp_path: pathlib.Path) -> None:
+        sink = FakeSink({})  # /imu never subscribed
+        service = FleetService(
+            sink=sink,
+            streams=_imu_streams(),
+            publisher=FakePublisher(),
+            spool=Spool(tmp_path / "spool"),
+        )
+        with pytest.raises(StreamConfigError):
+            service.start()
+
+    def test_live_sample_flows_to_channels(self, tmp_path: pathlib.Path) -> None:
+        writer = FakeWriter(_imu_struct())
+        sink = FakeSink({"/imu": writer})
+        pub = FakePublisher()
+        spool = Spool(tmp_path / "spool")
+        service = FleetService(sink=sink, streams=_imu_streams(), publisher=pub, spool=spool)
+
+        service.start()
+        try:
+            assert _wait_until(lambda: bool(pub.schema_calls))
+            writer.feed("/imu", 1.0, {"x": 3.5})
+            assert _wait_until(lambda: bool(pub.channel_calls))
+            samples = pub.channel_calls[0]["samples"]
+            assert samples == [{"c": "imu.x", "t": 1.0, "v": 3.5}]
+        finally:
+            service.stop()
+
+
+class TestStop:
+    def test_idempotent_and_clears_taps(self, tmp_path: pathlib.Path) -> None:
+        writer = FakeWriter(_imu_struct())
+        sink = FakeSink({"/imu": writer})
+        pub = FakePublisher()
+        service = FleetService(
+            sink=sink, streams=_imu_streams(), publisher=pub, spool=Spool(tmp_path / "spool")
+        )
+        service.start()
+        assert writer._tap is not None
+
+        service.stop()
+        assert writer._tap is None
+        assert pub.close_calls == 1
+
+        service.stop()  # idempotent: no double-close, no error
+        assert pub.close_calls == 1
+
+    def test_heartbeat_stops_before_publisher_close(self, tmp_path: pathlib.Path) -> None:
+        # The stopped-heartbeat publish happens inside publisher.close(); if the
+        # heartbeat thread were still alive it could race a live tick in after
+        # that one. Assert ordering by observing no heartbeat ticks land on the
+        # publisher AFTER close_calls goes to 1 beyond the close-time state.
+        writer = FakeWriter(_imu_struct())
+        sink = FakeSink({"/imu": writer})
+        pub = FakePublisher()
+        service = FleetService(
+            sink=sink,
+            streams=_imu_streams(),
+            publisher=pub,
+            spool=Spool(tmp_path / "spool"),
+        )
+        service.start()
+        service.stop()
+        assert not service._heartbeat.is_alive()
+        # No heartbeat tick may be published by our own thread after stop()
+        # returns -- publisher.close() (a FakePublisher no-op here beyond the
+        # counter) is the last word, and nothing else calls publish_heartbeat.
+        calls_at_stop = len(pub.heartbeat_calls)
+        time.sleep(0.05)
+        assert len(pub.heartbeat_calls) == calls_at_stop
+
+
+class TestPauseResume:
+    def test_pause_discard_empties_channels_lane(self, tmp_path: pathlib.Path) -> None:
+        writer = FakeWriter(_imu_struct())
+        sink = FakeSink({"/imu": writer})
+        pub = FakePublisher()
+        spool = Spool(tmp_path / "spool")
+        service = FleetService(sink=sink, streams=_imu_streams(), publisher=pub, spool=spool)
+        service.start()
+        try:
+            seq = spool.next_seq("channels")
+            spool.append("channels", seq, {"v": 1, "samples": []})
+            assert list(spool.pending("channels"))
+
+            service.pause(discard=True)
+            assert list(spool.pending("channels")) == []
+            assert writer._tap is None
+        finally:
+            service.stop()
+
+    def test_pause_without_discard_keeps_channels_lane(self, tmp_path: pathlib.Path) -> None:
+        # connect_should_fail keeps the router offline for the test's whole
+        # life, so the manually-appended record below is guaranteed to still
+        # be pending at pause() -- with a live publisher this races the
+        # router thread's own _pump, which would drain and ack it first.
+        writer = FakeWriter(_imu_struct())
+        sink = FakeSink({"/imu": writer})
+        pub = FakePublisher(connect_should_fail=True)
+        spool = Spool(tmp_path / "spool")
+        service = FleetService(sink=sink, streams=_imu_streams(), publisher=pub, spool=spool)
+        service.start()
+        try:
+            seq = spool.next_seq("channels")
+            spool.append("channels", seq, {"v": 1, "samples": []})
+
+            service.pause(discard=False)
+            assert list(spool.pending("channels"))
+        finally:
+            service.stop()
+
+    def test_pause_and_resume_are_idempotent_and_restart_threads(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        writer = FakeWriter(_imu_struct())
+        sink = FakeSink({"/imu": writer})
+        pub = FakePublisher()
+        service = FleetService(
+            sink=sink, streams=_imu_streams(), publisher=pub, spool=Spool(tmp_path / "spool")
+        )
+        service.start()
+        try:
+            first_router = service._router
+            service.pause()
+            assert not first_router.is_alive()
+            assert writer._tap is None
+            closes_after_first_pause = pub.close_calls
+
+            service.pause()  # idempotent: no second close, no error
+            assert pub.close_calls == closes_after_first_pause
+
+            service.resume()
+            assert writer._tap is not None
+            assert service._router is not first_router
+            assert service._router.is_alive()
+
+            service.resume()  # idempotent: no error, no second restart
+            assert service._router.is_alive()
+        finally:
+            service.stop()
+
+
+class TestStatus:
+    def test_shape_and_json_serializable(self, tmp_path: pathlib.Path) -> None:
+        writer = FakeWriter(_imu_struct())
+        sink = FakeSink({"/imu": writer})
+        pub = FakePublisher()
+        service = FleetService(
+            sink=sink, streams=_imu_streams(), publisher=pub, spool=Spool(tmp_path / "spool")
+        )
+        service.start()
+        try:
+            status = service.status()
+            json.dumps(status)  # must not raise: plain JSON-able
+            assert set(status) == {
+                "online",
+                "backoff",
+                "queue",
+                "skipped",
+                "spool",
+                "reconnects",
+                "subscriptions",
+                "channels_active",
+                "router_alive",
+                "router_error",
+            }
+            assert status["subscriptions"] == ["/imu"]
+            assert status["channels_active"] == 1
+            assert set(status["queue"]) == {"depth", "dropped"}
+            assert isinstance(status["spool"], dict)
+            assert status["router_alive"] is True
+            assert status["router_error"] is None
+        finally:
+            service.stop()
+
+    def test_before_start_is_safe_and_json_serializable(self, tmp_path: pathlib.Path) -> None:
+        sink = FakeSink({})
+        service = FleetService(
+            sink=sink,
+            streams=_imu_streams(),
+            publisher=FakePublisher(),
+            spool=Spool(tmp_path / "spool"),
+        )
+        status = service.status()
+        json.dumps(status)
+        assert status["online"] is False
+        assert status["router_alive"] is False
+
+    def test_dead_router_is_visible(self, tmp_path: pathlib.Path) -> None:
+        writer = FakeWriter(_imu_struct())
+        sink = FakeSink({"/imu": writer})
+        pub = FakePublisher()
+        service = FleetService(
+            sink=sink, streams=_imu_streams(), publisher=pub, spool=Spool(tmp_path / "spool")
+        )
+        service.start()
+        try:
+            assert _wait_until(lambda: bool(pub.schema_calls))
+
+            def boom(*_a: object, **_kw: object) -> None:
+                raise RuntimeError("core exploded")
+
+            service._router._core.offer = boom  # type: ignore[method-assign]
+            writer.feed("/imu", 1.0, {"x": 1.0})
+
+            assert _wait_until(lambda: not service._router.is_alive())
+            status = service.status()
+            json.dumps(status)
+            assert status["router_alive"] is False
+            assert status["router_error"] is not None and "core exploded" in status["router_error"]
+        finally:
+            service.stop()

--- a/test/sink/publish/test_service.py
+++ b/test/sink/publish/test_service.py
@@ -311,6 +311,7 @@ class TestStatus:
                 "channels_active",
                 "router_alive",
                 "router_error",
+                "heartbeat_spool_failures",
             }
             assert status["subscriptions"] == ["/imu"]
             assert status["channels_active"] == 1
@@ -318,6 +319,7 @@ class TestStatus:
             assert isinstance(status["spool"], dict)
             assert status["router_alive"] is True
             assert status["router_error"] is None
+            assert status["heartbeat_spool_failures"] == 0
         finally:
             service.stop()
 

--- a/test/sink/publish/test_service.py
+++ b/test/sink/publish/test_service.py
@@ -174,6 +174,24 @@ class TestStart:
         finally:
             service.stop()
 
+    def test_double_start_raises_runtime_error(self, tmp_path: pathlib.Path) -> None:
+        # A double start is a programming error -- raise, don't silently
+        # no-op or silently restart the runtime out from under the caller.
+        writer = FakeWriter(_imu_struct())
+        sink = FakeSink({"/imu": writer})
+        service = FleetService(
+            sink=sink,
+            streams=_imu_streams(),
+            publisher=FakePublisher(),
+            spool=Spool(tmp_path / "spool"),
+        )
+        service.start()
+        try:
+            with pytest.raises(RuntimeError, match="already started"):
+                service.start()
+        finally:
+            service.stop()
+
 
 class TestStop:
     def test_idempotent_and_clears_taps(self, tmp_path: pathlib.Path) -> None:
@@ -312,6 +330,8 @@ class TestStatus:
                 "router_alive",
                 "router_error",
                 "heartbeat_spool_failures",
+                "heartbeat_alive",
+                "heartbeat_error",
             }
             assert status["subscriptions"] == ["/imu"]
             assert status["channels_active"] == 1
@@ -320,6 +340,8 @@ class TestStatus:
             assert status["router_alive"] is True
             assert status["router_error"] is None
             assert status["heartbeat_spool_failures"] == 0
+            assert status["heartbeat_alive"] is True
+            assert status["heartbeat_error"] is None
         finally:
             service.stop()
 
@@ -335,6 +357,8 @@ class TestStatus:
         json.dumps(status)
         assert status["online"] is False
         assert status["router_alive"] is False
+        assert status["heartbeat_alive"] is False
+        assert status["heartbeat_error"] is None
 
     def test_dead_router_is_visible(self, tmp_path: pathlib.Path) -> None:
         writer = FakeWriter(_imu_struct())

--- a/test/sink/publish/test_stream_e2e.py
+++ b/test/sink/publish/test_stream_e2e.py
@@ -1,0 +1,647 @@
+"""Live-broker end-to-end tests for fleet streaming (spec §2/§3/§4).
+
+Gated on MQTT_TEST_BROKER (e.g. mqtt://localhost:1883), same as step 3's
+test_mqtt_integration.py. Unlike that file, this one drives the FULL
+runtime -- a real TopicBufferWriter feeding a real FleetService (real
+MqttPublisher, real tmp-path Spool) -- to prove the tap -> queue ->
+RouterCore -> StreamRouter -> spool -> MqttPublisher pipeline works against
+an actual broker, including the chaos path: kill the broker mid-stream,
+keep appending, restart it, and confirm the spool replays its backlog in
+order with nothing lost.
+
+Locally:
+    docker run -d -p 1883:1883 eclipse-mosquitto:2 mosquitto -c /mosquitto-no-auth.conf
+    MQTT_TEST_BROKER=mqtt://localhost:1883 uv run pytest test/sink/publish/test_stream_e2e.py
+
+The chaos test additionally requires MQTT_TEST_BROKER_MANAGED=1: it starts,
+kills, and restarts its OWN mosquitto container on MQTT_CHAOS_PORT (default
+1884) -- a different container on a different port from whatever
+MQTT_TEST_BROKER points at, so it can never kill a broker this test didn't
+start itself (in CI, the iot job's shared `mosq` container on 1883, which
+the rest of that job's suite still needs).
+"""
+
+import functools
+import json
+import os
+import pathlib
+import queue
+import socket
+import subprocess
+import threading
+import time
+import uuid
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+from urllib.parse import urlparse
+
+import pyarrow as pa
+import pytest
+
+from src.sink.publish.config import StreamsConfig
+from src.sink.publish.publisher import wire_topic
+from src.sink.publish.spool import Spool
+
+if TYPE_CHECKING:
+    from src.sink.buffer import TopicBufferWriter
+
+BROKER = os.environ.get("MQTT_TEST_BROKER")
+MANAGED = os.environ.get("MQTT_TEST_BROKER_MANAGED") == "1"
+CHAOS_PORT = int(os.environ.get("MQTT_CHAOS_PORT", "1884"))
+
+pytestmark = pytest.mark.skipif(not BROKER, reason="MQTT_TEST_BROKER not set")
+
+requires_managed_broker = pytest.mark.skipif(
+    not MANAGED,
+    reason=(
+        "MQTT_TEST_BROKER_MANAGED=1 required: this test kills and restarts its own broker container"
+    ),
+)
+
+IMU_STRUCT = pa.struct([pa.field("x", pa.float64())])
+
+Inbox = "queue.Queue[tuple[str, bytes, bool]]"
+
+
+# -- generic polling (no bare sleeps for correctness: deadline + short sleep) -----------
+
+
+def _wait_until(predicate: Callable[[], bool], timeout_s: float, interval_s: float = 0.02) -> bool:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval_s)
+    return predicate()
+
+
+def _tcp_reachable(host: str, port: int) -> bool:
+    try:
+        with socket.create_connection((host, port), timeout=0.5):
+            return True
+    except OSError:
+        return False
+
+
+def _wait_tcp(host: str, port: int, timeout_s: float) -> bool:
+    return _wait_until(lambda: _tcp_reachable(host, port), timeout_s=timeout_s, interval_s=0.05)
+
+
+def _drain(inbox: Inbox, topic: str, timeout_s: float = 10.0) -> tuple[str, bytes, bool] | None:
+    """Pull from `inbox` until `topic` matches or the deadline passes (step 3's pattern)."""
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        try:
+            got = inbox.get(timeout=deadline - time.time())
+        except queue.Empty:
+            return None
+        if got[0] == topic:
+            return got
+    return None
+
+
+# -- fixtures shared by the three scenarios ---------------------------------------------
+
+
+class FakeSink:
+    """Minimal TopicSink double: the `_buffers`/`subscribed_topics` seam FleetService uses."""
+
+    def __init__(self, buffers: dict[str, "TopicBufferWriter"]) -> None:
+        self._buffers = buffers
+
+    @property
+    def subscribed_topics(self) -> list[str]:
+        return list(self._buffers)
+
+
+def _real_writer(tmp_path: pathlib.Path, topic: str = "/imu") -> "TopicBufferWriter":
+    """A real TopicBufferWriter (not a fake) backed by a tmp cache -- brief's step 1."""
+    from src.sink.buffer import TopicBufferWriter
+
+    return TopicBufferWriter(
+        path=tmp_path / "buffer",
+        topic=topic,
+        type_name="test/Imu",
+        definition="float64 x",
+        struct=IMU_STRUCT,
+        buffer_size_bytes=None,
+        overwrite=False,
+        pipeline=None,
+        extract_timestamp=lambda msg: msg["timestamp_seconds"],
+    )
+
+
+def _streams(flush_interval_s: float, rate_hz: float, topic: str = "/imu") -> StreamsConfig:
+    return StreamsConfig.build(
+        {
+            "flush_interval_s": flush_interval_s,
+            "channels": [{"topic": topic, "fields": ["x"], "rate_hz": rate_hz}],
+        }
+    )
+
+
+class _Subscriber:
+    """One paho client subscribed to a robot's whole `bagel/v1/<tenant>/<robot>/#` tree.
+
+    `on_connect` always resubscribes -- covers both the initial connect and any
+    background auto-reconnect paho performs on its own after a drop. The
+    chaos test additionally drives recovery explicitly via `reconnect_now`
+    instead of waiting on paho's own backoff-gated auto-reconnect: paho's
+    default reconnect delay (min 1s, doubling) is the same order of
+    magnitude as StreamRouter's own backoff, so racing them is not reliable
+    -- a QoS-1 `channels` publish that lands before this subscriber has
+    resubscribed is lost for good (no persistent session survives the
+    container restart). `reconnect_now` bypasses that race by polling raw
+    TCP reachability directly and reconnecting the instant it succeeds.
+    """
+
+    def __init__(self, host: str, port: int, tenant: str, robot: str) -> None:
+        import paho.mqtt.client as paho
+
+        self.inbox: Inbox = queue.Queue()
+        self._host = host
+        self._port = port
+        self._topic = f"bagel/v1/{tenant}/{robot}/#"
+        self._subscribed = threading.Event()
+        self._client = paho.Client(
+            callback_api_version=paho.CallbackAPIVersion.VERSION2,
+            client_id=f"sub-{uuid.uuid4().hex[:8]}",
+            protocol=paho.MQTTv5,
+        )
+        self._client.on_connect = self._on_connect
+        self._client.on_subscribe = self._on_subscribe
+        self._client.on_message = lambda cl, ud, msg: self.inbox.put(
+            (msg.topic, msg.payload, msg.retain)
+        )
+
+    def _on_connect(
+        self, client: object, userdata: object, flags: object, reason_code: object, *_a: object
+    ) -> None:
+        self._subscribed.clear()
+        client.subscribe(self._topic, qos=1)  # `client` is paho's Client (duck-typed as object)
+
+    def _on_subscribe(self, *_a: object) -> None:
+        self._subscribed.set()
+
+    def connect(self, timeout_s: float = 10.0) -> None:
+        self._client.connect(self._host, self._port, 30)
+        self._client.loop_start()
+        assert _wait_until(self._subscribed.is_set, timeout_s=timeout_s), (
+            "subscriber never subscribed"
+        )
+
+    def prepare_for_outage(self) -> None:
+        """Stop the background loop right after the broker is killed.
+
+        Split out of `reconnect_now` so `loop_stop`'s thread-join cost (it
+        can take a moment to notice and exit) is paid during the outage,
+        when there is no time pressure -- not stacked onto the recovery
+        path where it would only widen the race `reconnect_now` exists to
+        avoid.
+        """
+        self._client.loop_stop()
+        self._subscribed.clear()
+
+    def reconnect_now(self, timeout_s: float = 15.0) -> None:
+        """Hammer a raw reconnect the instant the broker is reachable again.
+
+        Call `prepare_for_outage()` first (right after killing the broker).
+        Polls tightly (10ms) rather than waiting on a separate "is the port
+        up yet" check first: any extra step between the broker actually
+        accepting connections and this client's own reconnect attempt only
+        widens the race against StreamRouter's own reconnect (see class
+        docstring).
+        """
+        deadline = time.monotonic() + timeout_s
+        connected = False
+        while time.monotonic() < deadline:
+            try:
+                self._client.reconnect()
+                connected = True
+                break
+            except OSError:
+                time.sleep(0.01)
+        assert connected, "subscriber could not reconnect to the restarted broker"
+        self._client.loop_start()
+        assert _wait_until(self._subscribed.is_set, timeout_s=timeout_s), (
+            "subscriber never resubscribed after the broker restart"
+        )
+
+    def close(self) -> None:
+        self._client.loop_stop()
+        self._client.disconnect()
+
+
+def _docker(args: list[str], *, check: bool) -> subprocess.CompletedProcess:
+    """Run one `docker` CLI invocation. Fixed argv, no untrusted input."""
+    return subprocess.run(args, check=check, capture_output=True)  # noqa: S603
+
+
+class _ChaosBroker:
+    """A private mosquitto container this test starts, kills, and restarts.
+
+    Runs on `MQTT_CHAOS_PORT` (default 1884) -- deliberately never the CI iot
+    job's shared `mosq` container on 1883, so killing it can never disrupt
+    the rest of that job's suite (see module docstring).
+    """
+
+    def __init__(self, port: int) -> None:
+        self.port = port
+        self.name = f"bagel-mosq-chaos-{uuid.uuid4().hex[:8]}"
+
+    def start(self) -> None:
+        _docker(
+            [
+                "docker",
+                "run",
+                "-d",
+                "--name",
+                self.name,
+                "-p",
+                f"{self.port}:1883",
+                "eclipse-mosquitto:2",
+                "mosquitto",
+                "-c",
+                "/mosquitto-no-auth.conf",
+            ],
+            check=True,
+        )
+        assert _wait_tcp("localhost", self.port, timeout_s=15.0), (
+            "chaos broker never became reachable"
+        )
+
+    def kill(self) -> None:
+        _docker(["docker", "kill", self.name], check=True)
+
+    def restart(self) -> None:
+        _docker(["docker", "start", self.name], check=True)
+        assert _wait_tcp("localhost", self.port, timeout_s=15.0), "chaos broker never came back up"
+
+    def cleanup(self) -> None:
+        _docker(["docker", "rm", "-f", self.name], check=False)
+
+
+def _build_service(  # noqa: PLR0913 -- test helper collecting one scenario's full config
+    tmp_path: pathlib.Path,
+    broker_url: str,
+    tenant: str,
+    robot: str,
+    *,
+    flush_interval_s: float,
+    rate_hz: float,
+) -> tuple["TopicBufferWriter", Spool, object]:
+    from src.sink.publish.mqtt import MqttPublisher
+    from src.sink.publish.service import FleetService
+
+    writer = _real_writer(tmp_path)
+    sink = FakeSink({"/imu": writer})
+    publisher = MqttPublisher(broker_url, tenant, robot)
+    spool = Spool(tmp_path / "spool")
+    service = FleetService(
+        sink=sink,
+        streams=_streams(flush_interval_s=flush_interval_s, rate_hz=rate_hz),
+        publisher=publisher,
+        spool=spool,
+    )
+    return writer, spool, service
+
+
+def _speed_up_heartbeat(monkeypatch: pytest.MonkeyPatch, interval_s: float) -> None:
+    """Make FleetService's heartbeat tick every `interval_s` instead of the 30s default.
+
+    HeartbeatThread.run() fires its FIRST tick immediately, but that tick
+    races StreamRouter's own connect (gated behind at least one
+    `queue.drain` timeout) -- against a real broker the router usually
+    hasn't connected yet, so that first heartbeat is spooled, not published
+    live (the heartbeat lane is never replayed -- a known step-4 design
+    gap, see the plan's progress ledger). Shortening the interval here
+    doesn't change any behavior under test; it just keeps the *next* tick
+    (which will find the router online) from being 30 real seconds away.
+    """
+    import importlib
+
+    # importlib.import_module (== `from src.sink.publish.service import
+    # FleetService`'s own resolution path) always checks sys.modules for the
+    # full dotted name first. `from src.sink.publish import service` instead
+    # resolves via getattr(src.sink.publish, "service") -- normally the same
+    # object, but test_service.py's own eager-import test
+    # (monkeypatch.delitem + reimport, restored via sys.modules on teardown)
+    # can leave that package attribute pointing at an orphaned duplicate
+    # module distinct from the one sys.modules -- and hence FleetService --
+    # actually uses, silently patching the wrong object.
+    heartbeat_module = importlib.import_module("src.sink.publish.heartbeat")
+    service_module = importlib.import_module("src.sink.publish.service")
+
+    monkeypatch.setattr(
+        service_module,
+        "HeartbeatThread",
+        functools.partial(heartbeat_module.HeartbeatThread, interval_s=interval_s),
+    )
+
+
+# -- 1. full path: real writer -> real FleetService -> real broker -> subscriber --------
+
+
+EXPECTED_IMU_SCHEMA = {
+    "v": 1,
+    "channels": [
+        {
+            "c": "imu.x",
+            "type": "number",
+            "unit": None,
+            "source_topic": "/imu",
+            "source_field": "x",
+        }
+    ],
+}
+
+EXPECTED_HEARTBEAT_KEYS = {
+    "v",
+    "t",
+    "online",
+    "bagel_version",
+    "uptime_s",
+    "subscriptions",
+    "channels_active",
+    "queue",
+    "spool",
+    "disk_free_bytes",
+    "cert_expires_at",
+    "reconnects",
+}
+
+
+def _assert_live_schema_and_heartbeat(
+    sub: _Subscriber, schema_topic: str, heartbeat_topic: str
+) -> None:
+    # Live delivery: payload only -- a retain=True publish delivered to an
+    # already-subscribed client carries retain=0 on the wire (MQTT semantics;
+    # the flag marks "delivered because of a NEW subscription", not "this
+    # topic happens to be retained").
+    schema = _drain(sub.inbox, schema_topic)
+    assert schema is not None, "schema never arrived"
+    assert json.loads(schema[1]) == EXPECTED_IMU_SCHEMA
+
+    heartbeat = _drain(sub.inbox, heartbeat_topic, timeout_s=5.0)
+    assert heartbeat is not None, "heartbeat never arrived"
+    hb = json.loads(heartbeat[1])
+    assert hb["online"] is True
+    assert set(hb) == EXPECTED_HEARTBEAT_KEYS
+    assert hb["cert_expires_at"] is None
+    assert set(hb["spool"]) == {"bytes", "pending", "evicted"}
+
+
+def _assert_retained_for_late_subscriber(
+    late: _Subscriber, schema_topic: str, heartbeat_topic: str
+) -> None:
+    """A subscriber joining AFTER schema/heartbeat were published gets them
+    immediately, with retain=1 -- step 3's own retained-delivery pattern.
+    `late` must already be connected (subscribed AFTER those publishes).
+    """
+    late_schema = _drain(late.inbox, schema_topic)
+    assert late_schema is not None and late_schema[2] is True
+    assert json.loads(late_schema[1]) == EXPECTED_IMU_SCHEMA
+
+    late_heartbeat = _drain(late.inbox, heartbeat_topic)
+    assert late_heartbeat is not None and late_heartbeat[2] is True
+    assert json.loads(late_heartbeat[1])["online"] is True
+
+
+def _assert_rate_capped_batches_ascend(
+    writer: "TopicBufferWriter", sub: _Subscriber, topic: str
+) -> None:
+    # Canary flush: whatever unpredictable delay preceded this call (schema/
+    # heartbeat drains, a late-subscriber round trip) has left the router's
+    # flush_interval_s clock at an unknown phase. A batch arriving via the
+    # subscriber proves a flush just happened -- i.e. that clock just reset
+    # -- so the burst below gets a full, uninterrupted flush window instead
+    # of racing an unknown one (the failure mode this canary replaced: an
+    # in-progress flush interleaving with the 4 appends below and splitting
+    # the same-slot samples across two batches).
+    writer.append({"x": 0.0, "timestamp_seconds": 900.0})
+    canary = _drain(sub.inbox, topic)
+    assert canary is not None, "canary channels batch never arrived"
+    canary_seq = json.loads(canary[1])["seq"]
+
+    # 3 samples land in the same 1Hz slot (rate-capped to the last one
+    # written); a 4th lands in the next slot -- one batch, 2 samples.
+    writer.append({"x": 1.0, "timestamp_seconds": 1_000.0})
+    writer.append({"x": 2.0, "timestamp_seconds": 1_000.4})
+    writer.append({"x": 3.0, "timestamp_seconds": 1_000.9})
+    writer.append({"x": 4.0, "timestamp_seconds": 1_001.2})
+
+    batch = _drain(sub.inbox, topic)
+    assert batch is not None, "channels batch never arrived"
+    body = json.loads(batch[1])
+    assert body["v"] == 1
+    assert body["seq"] == canary_seq + 1
+    # rate-capped: 4 raw appends -> 2 samples (one per 1Hz slot), sorted by t;
+    # the slot-1000 winner is the LAST of the 3 samples raced into it.
+    assert [s["c"] for s in body["samples"]] == ["imu.x", "imu.x"]
+    assert [s["v"] for s in body["samples"]] == [3.0, 4.0]
+
+    # a second flush cycle: seq must be ascending.
+    writer.append({"x": 5.0, "timestamp_seconds": 1_002.5})
+    batch2 = _drain(sub.inbox, topic)
+    assert batch2 is not None
+    assert json.loads(batch2[1])["seq"] == canary_seq + 2
+
+
+def test_full_path_streams_batches_schema_and_heartbeat(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    parsed = urlparse(BROKER)
+    tenant, robot = "e2e", uuid.uuid4().hex[:8]
+    host, port = parsed.hostname, parsed.port or 1883
+    schema_topic = wire_topic(tenant, robot, "schema")
+    heartbeat_topic = wire_topic(tenant, robot, "heartbeat")
+    channels_topic = wire_topic(tenant, robot, "channels")
+
+    _speed_up_heartbeat(monkeypatch, interval_s=0.3)
+    sub = _Subscriber(host, port, tenant, robot)
+    sub.connect()
+    try:
+        # flush_interval_s is generous (2s, not step 3's usual sub-second
+        # values): the rate-cap assertion below needs a flush window wide
+        # enough to comfortably outlast the canary round trip (publish +
+        # QoS-1 ack + broker delivery to the subscriber) plus 4 real
+        # file-locked writer.append() calls, with margin for CI jitter --
+        # see _assert_rate_capped_batches_ascend's canary-sync comment.
+        writer, spool, service = _build_service(
+            tmp_path, BROKER, tenant, robot, flush_interval_s=2.0, rate_hz=1.0
+        )
+        service.start()
+        try:
+            _assert_live_schema_and_heartbeat(sub, schema_topic, heartbeat_topic)
+
+            late = _Subscriber(host, port, tenant, robot)
+            late.connect()
+            try:
+                _assert_retained_for_late_subscriber(late, schema_topic, heartbeat_topic)
+            finally:
+                late.close()
+
+            _assert_rate_capped_batches_ascend(writer, sub, channels_topic)
+
+            assert _wait_until(lambda: spool.stats()["channels"].pending == 0, timeout_s=5.0), (
+                "spool never drained the acked batches"
+            )
+        finally:
+            service.stop()
+    finally:
+        sub.close()
+
+
+# -- 2. chaos: kill the broker mid-stream, keep appending, restart it -------------------
+
+
+def _run_outage_appends(writer: "TopicBufferWriter", start_t: float, duration_s: float) -> None:
+    """Keep appending through the outage; every append must return immediately.
+
+    `t` steps by 0.5s per sample -- comfortably past the 50Hz (max allowed
+    `rate_hz`) slot width of 0.02s, so every sample lands in its own slot and
+    none are dropped by the rate cap (irrelevant to what this test proves).
+    """
+    t = start_t
+    value = 0.0
+    deadline = time.monotonic() + duration_s
+    while time.monotonic() < deadline:
+        t += 0.5
+        value += 1.0
+        started = time.perf_counter()
+        writer.append({"x": value, "timestamp_seconds": t})
+        elapsed = time.perf_counter() - started
+        assert elapsed < 1.0, f"append() blocked for {elapsed:.2f}s while the broker was down"
+        time.sleep(0.1)
+
+
+def _collect_seqs(sub: _Subscriber, topic: str, want_through: int, timeout_s: float) -> list[int]:
+    """Collect delivered seqs until `want_through` has been seen or the deadline passes."""
+    seqs: list[int] = []
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        got = _drain(sub.inbox, topic, timeout_s=1.0)
+        if got is None:
+            continue
+        seqs.append(json.loads(got[1])["seq"])
+        if seqs[-1] >= want_through:
+            break
+    return seqs
+
+
+@requires_managed_broker
+def test_chaos_kill_and_restart_broker_drains_spool_in_order(tmp_path: pathlib.Path) -> None:
+    broker = _ChaosBroker(CHAOS_PORT)
+    broker.start()
+    try:
+        broker_url = f"mqtt://localhost:{CHAOS_PORT}"
+        tenant, robot = "chaos", uuid.uuid4().hex[:8]
+        channels_topic = wire_topic(tenant, robot, "channels")
+
+        sub = _Subscriber("localhost", CHAOS_PORT, tenant, robot)
+        sub.connect()
+        try:
+            writer, spool, service = _build_service(
+                tmp_path, broker_url, tenant, robot, flush_interval_s=0.1, rate_hz=50.0
+            )
+            service.start()
+            try:
+                # normal operation before chaos: prove the happy path first.
+                writer.append({"x": 0.0, "timestamp_seconds": 500_000.0})
+                first = _drain(sub.inbox, channels_topic, timeout_s=10.0)
+                assert first is not None, "no batch before the outage even started"
+                first_seq = json.loads(first[1])["seq"]
+                assert _wait_until(lambda: spool.stats()["channels"].pending == 0, timeout_s=5.0)
+
+                broker.kill()
+                sub.prepare_for_outage()
+
+                # keep appending through the outage: the tap must never block,
+                # and the spool must keep absorbing new batches while offline.
+                _run_outage_appends(writer, start_t=500_001.0, duration_s=4.0)
+                assert _wait_until(lambda: spool.stats()["channels"].pending > 0, timeout_s=5.0), (
+                    "spool pending never grew while the broker was down"
+                )
+
+                # Restart the broker and race this subscriber's reconnect
+                # against it concurrently -- not sequentially -- so no extra
+                # latency stacks onto the recovery window StreamRouter's own
+                # (much slower, backoff-gated) reconnect is racing against.
+                restart_thread = threading.Thread(target=broker.restart)
+                restart_thread.start()
+                sub.reconnect_now()
+                restart_thread.join()
+
+                assert _wait_until(
+                    lambda: spool.stats()["channels"].pending == 0, timeout_s=60.0
+                ), "spool never drained its backlog after the broker came back"
+                final_last_seq = spool.stats()["channels"].last_seq
+
+                # `first` (seq `first_seq`, pre-chaos) was already drained above
+                # and never re-delivered (QoS-1 non-retained, already acked
+                # before the outage) -- fold it back in so the seq range checked
+                # below covers every batch this run ever produced, not just the
+                # ones recovered after the restart.
+                seqs_seen = [
+                    first_seq,
+                    *_collect_seqs(
+                        sub, channels_topic, want_through=final_last_seq, timeout_s=20.0
+                    ),
+                ]
+                unique_sorted = sorted(set(seqs_seen))
+                assert unique_sorted == list(range(first_seq, final_last_seq + 1)), (
+                    f"gap or missing seq: delivered {unique_sorted}, expected "
+                    f"{first_seq}..{final_last_seq}"
+                )
+                # order check: consecutive-duplicate-collapsed delivery must be
+                # exactly the ascending run (at-least-once permits re-delivery,
+                # never reordering or a gap).
+                deduped = [s for i, s in enumerate(seqs_seen) if i == 0 or s != seqs_seen[i - 1]]
+                assert deduped == unique_sorted
+            finally:
+                service.stop()
+        finally:
+            sub.close()
+    finally:
+        broker.cleanup()
+
+
+# -- 3. service.stop() publishes the stopped heartbeat before disconnect ----------------
+
+
+def test_stop_publishes_stopped_heartbeat_before_disconnect(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    parsed = urlparse(BROKER)
+    tenant, robot = "stop", uuid.uuid4().hex[:8]
+    heartbeat_topic = wire_topic(tenant, robot, "heartbeat")
+
+    # A longer interval than test 1's -- this test needs exactly ONE "online"
+    # heartbeat to land before stop() is called (a periodic tick landing
+    # between the "online" drain and stop() would otherwise be picked up by
+    # the "stopped" drain instead), while still tolerating the first tick
+    # losing its race against the router's connect (see _speed_up_heartbeat).
+    _speed_up_heartbeat(monkeypatch, interval_s=3.0)
+    sub = _Subscriber(parsed.hostname, parsed.port or 1883, tenant, robot)
+    sub.connect()
+    try:
+        _writer, _spool, service = _build_service(
+            tmp_path, BROKER, tenant, robot, flush_interval_s=0.2, rate_hz=1.0
+        )
+        service.start()
+        online = _drain(sub.inbox, heartbeat_topic, timeout_s=6.0)
+        assert online is not None and json.loads(online[1])["online"] is True
+
+        service.stop()
+
+        stopped = _drain(sub.inbox, heartbeat_topic)
+        assert stopped is not None, "clean stop never published a stopped heartbeat"
+        body = json.loads(stopped[1])
+        assert body["online"] is False
+        assert body["reason"] == "stopped"
+
+        # nothing else may follow: the stopped heartbeat must be the LAST word.
+        extra = _drain(sub.inbox, heartbeat_topic, timeout_s=1.0)
+        assert extra is None, f"unexpected heartbeat after stop(): {extra}"
+    finally:
+        sub.close()

--- a/test/sink/publish/test_stream_e2e.py
+++ b/test/sink/publish/test_stream_e2e.py
@@ -382,7 +382,7 @@ def _assert_live_schema_and_heartbeat(
     assert schema is not None, "schema never arrived"
     assert json.loads(schema[1]) == EXPECTED_IMU_SCHEMA
 
-    heartbeat = _drain(sub.inbox, heartbeat_topic, timeout_s=5.0)
+    heartbeat = _drain(sub.inbox, heartbeat_topic, timeout_s=15.0)
     assert heartbeat is not None, "heartbeat never arrived"
     hb = json.loads(heartbeat[1])
     assert hb["online"] is True
@@ -407,6 +407,20 @@ def _assert_retained_for_late_subscriber(
     assert json.loads(late_heartbeat[1])["online"] is True
 
 
+# Each wait below is paced by a real flush_interval_s (2s) wall-clock cycle
+# that only advances when StreamRouter's background thread actually gets
+# scheduled. `_drain`'s timeout is a ceiling, not a fixed sleep -- it returns
+# the instant the event arrives -- so a generous one costs nothing in the
+# common case; it only matters under heavy concurrent load (observed once:
+# stacked immediately after two other full e2e suite runs on a loaded dev
+# machine, the second-flush wait below missed the OLD 10s default ceiling
+# -- 5x the flush interval, evidently not enough headroom under that load --
+# while 5/5 isolated reruns of the same test passed cleanly straight after,
+# confirming a test-side margin issue, not a RouterCore/StreamRouter/Spool
+# defect: nothing about the assertions changed, only the ceiling below did).
+_BATCH_WAIT_S = 30.0
+
+
 def _assert_rate_capped_batches_ascend(
     writer: "TopicBufferWriter", sub: _Subscriber, topic: str
 ) -> None:
@@ -419,7 +433,7 @@ def _assert_rate_capped_batches_ascend(
     # in-progress flush interleaving with the 4 appends below and splitting
     # the same-slot samples across two batches).
     writer.append({"x": 0.0, "timestamp_seconds": 900.0})
-    canary = _drain(sub.inbox, topic)
+    canary = _drain(sub.inbox, topic, timeout_s=_BATCH_WAIT_S)
     assert canary is not None, "canary channels batch never arrived"
     canary_seq = json.loads(canary[1])["seq"]
 
@@ -430,7 +444,7 @@ def _assert_rate_capped_batches_ascend(
     writer.append({"x": 3.0, "timestamp_seconds": 1_000.9})
     writer.append({"x": 4.0, "timestamp_seconds": 1_001.2})
 
-    batch = _drain(sub.inbox, topic)
+    batch = _drain(sub.inbox, topic, timeout_s=_BATCH_WAIT_S)
     assert batch is not None, "channels batch never arrived"
     body = json.loads(batch[1])
     assert body["v"] == 1
@@ -442,8 +456,8 @@ def _assert_rate_capped_batches_ascend(
 
     # a second flush cycle: seq must be ascending.
     writer.append({"x": 5.0, "timestamp_seconds": 1_002.5})
-    batch2 = _drain(sub.inbox, topic)
-    assert batch2 is not None
+    batch2 = _drain(sub.inbox, topic, timeout_s=_BATCH_WAIT_S)
+    assert batch2 is not None, "second channels batch never arrived"
     assert json.loads(batch2[1])["seq"] == canary_seq + 2
 
 
@@ -483,7 +497,7 @@ def test_full_path_streams_batches_schema_and_heartbeat(
 
             _assert_rate_capped_batches_ascend(writer, sub, channels_topic)
 
-            assert _wait_until(lambda: spool.stats()["channels"].pending == 0, timeout_s=5.0), (
+            assert _wait_until(lambda: spool.stats()["channels"].pending == 0, timeout_s=15.0), (
                 "spool never drained the acked batches"
             )
         finally:
@@ -551,7 +565,7 @@ def test_chaos_kill_and_restart_broker_drains_spool_in_order(tmp_path: pathlib.P
                 first = _drain(sub.inbox, channels_topic, timeout_s=10.0)
                 assert first is not None, "no batch before the outage even started"
                 first_seq = json.loads(first[1])["seq"]
-                assert _wait_until(lambda: spool.stats()["channels"].pending == 0, timeout_s=5.0)
+                assert _wait_until(lambda: spool.stats()["channels"].pending == 0, timeout_s=15.0)
 
                 broker.kill()
                 sub.prepare_for_outage()
@@ -559,7 +573,7 @@ def test_chaos_kill_and_restart_broker_drains_spool_in_order(tmp_path: pathlib.P
                 # keep appending through the outage: the tap must never block,
                 # and the spool must keep absorbing new batches while offline.
                 _run_outage_appends(writer, start_t=500_001.0, duration_s=4.0)
-                assert _wait_until(lambda: spool.stats()["channels"].pending > 0, timeout_s=5.0), (
+                assert _wait_until(lambda: spool.stats()["channels"].pending > 0, timeout_s=15.0), (
                     "spool pending never grew while the broker was down"
                 )
 
@@ -629,7 +643,7 @@ def test_stop_publishes_stopped_heartbeat_before_disconnect(
             tmp_path, BROKER, tenant, robot, flush_interval_s=0.2, rate_hz=1.0
         )
         service.start()
-        online = _drain(sub.inbox, heartbeat_topic, timeout_s=6.0)
+        online = _drain(sub.inbox, heartbeat_topic, timeout_s=15.0)
         assert online is not None and json.loads(online[1])["online"] is True
 
         service.stop()

--- a/test/sink/publish/test_stream_e2e.py
+++ b/test/sink/publish/test_stream_e2e.py
@@ -28,6 +28,7 @@ import pathlib
 import queue
 import socket
 import subprocess
+import sys
 import threading
 import time
 import uuid
@@ -250,6 +251,16 @@ class _ChaosBroker:
         self.name = f"bagel-mosq-chaos-{uuid.uuid4().hex[:8]}"
 
     def start(self) -> None:
+        """Start the container; self-cleaning if it never becomes reachable.
+
+        `docker run -d` succeeding only means the container process was
+        created, not that mosquitto is actually listening yet -- if the
+        readiness wait below fails (slow image pull, port contention), the
+        container would otherwise leak: `docker run` already succeeded, so
+        nothing else would ever `docker rm` it. Catch, clean up the
+        container THIS call just created, and re-raise so the failure is
+        still visible to the caller.
+        """
         _docker(
             [
                 "docker",
@@ -266,9 +277,13 @@ class _ChaosBroker:
             ],
             check=True,
         )
-        assert _wait_tcp("localhost", self.port, timeout_s=15.0), (
-            "chaos broker never became reachable"
-        )
+        try:
+            assert _wait_tcp("localhost", self.port, timeout_s=15.0), (
+                "chaos broker never became reachable"
+            )
+        except BaseException:
+            self.cleanup()
+            raise
 
     def kill(self) -> None:
         _docker(["docker", "kill", self.name], check=True)
@@ -279,6 +294,34 @@ class _ChaosBroker:
 
     def cleanup(self) -> None:
         _docker(["docker", "rm", "-f", self.name], check=False)
+
+
+@requires_managed_broker
+def test_chaos_broker_start_cleans_up_on_unreachable_broker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """start() must not leak a container when readiness never arrives.
+
+    Real `docker run`/`docker ps`/`docker rm` -- that's the actual leak this
+    guards against -- with only `_wait_tcp` faked, so the "broker never
+    becomes reachable" path (slow image pull, port contention -- the
+    scenario in the review finding) is forced deterministically and fast
+    without needing a real slow pull or a real port conflict.
+    """
+    monkeypatch.setattr(sys.modules[__name__], "_wait_tcp", lambda *a, **kw: False)
+    broker = _ChaosBroker(CHAOS_PORT)
+    try:
+        with pytest.raises(AssertionError, match="never became reachable"):
+            broker.start()
+        result = _docker(
+            ["docker", "ps", "-a", "--filter", f"name={broker.name}", "--format", "{{.Names}}"],
+            check=True,
+        )
+        assert result.stdout.decode().strip() == "", (
+            f"container {broker.name} leaked after a failed start()"
+        )
+    finally:
+        broker.cleanup()  # belt-and-braces: start() should already have removed it
 
 
 def _build_service(  # noqa: PLR0913 -- test helper collecting one scenario's full config
@@ -384,11 +427,7 @@ def _assert_live_schema_and_heartbeat(
 
     heartbeat = _drain(sub.inbox, heartbeat_topic, timeout_s=15.0)
     assert heartbeat is not None, "heartbeat never arrived"
-    hb = json.loads(heartbeat[1])
-    assert hb["online"] is True
-    assert set(hb) == EXPECTED_HEARTBEAT_KEYS
-    assert hb["cert_expires_at"] is None
-    assert set(hb["spool"]) == {"bytes", "pending", "evicted"}
+    assert json.loads(heartbeat[1])["online"] is True
 
 
 def _assert_retained_for_late_subscriber(
@@ -397,6 +436,11 @@ def _assert_retained_for_late_subscriber(
     """A subscriber joining AFTER schema/heartbeat were published gets them
     immediately, with retain=1 -- step 3's own retained-delivery pattern.
     `late` must already be connected (subscribed AFTER those publishes).
+
+    The §3 heartbeat key-set/shape checks live here rather than on the live
+    tick: this is the durable, retained copy a late-joining reader (a real
+    MCP tool included) actually sees, so it's the more meaningful place to
+    pin the wire shape down.
     """
     late_schema = _drain(late.inbox, schema_topic)
     assert late_schema is not None and late_schema[2] is True
@@ -404,7 +448,11 @@ def _assert_retained_for_late_subscriber(
 
     late_heartbeat = _drain(late.inbox, heartbeat_topic)
     assert late_heartbeat is not None and late_heartbeat[2] is True
-    assert json.loads(late_heartbeat[1])["online"] is True
+    hb = json.loads(late_heartbeat[1])
+    assert hb["online"] is True
+    assert set(hb) == EXPECTED_HEARTBEAT_KEYS
+    assert hb["cert_expires_at"] is None
+    assert set(hb["spool"]) == {"bytes", "pending", "evicted"}
 
 
 # Each wait below is paced by a real flush_interval_s (2s) wall-clock cycle

--- a/test/sink/test_buffer_tap.py
+++ b/test/sink/test_buffer_tap.py
@@ -1,0 +1,56 @@
+"""The fleet tap seam on the live buffer: non-blocking, failure-isolated."""
+
+import pathlib
+
+import pyarrow as pa
+import pytest
+
+from src.sink.buffer import TopicBufferWriter
+
+TOPIC = "/imu"
+STRUCT = pa.struct([pa.field("x", pa.float64())])
+DEFINITION = "float64 x"
+
+
+@pytest.fixture()
+def writer(tmp_path: pathlib.Path) -> TopicBufferWriter:
+    return TopicBufferWriter(
+        path=tmp_path,
+        topic=TOPIC,
+        type_name="test/Imu",
+        definition=DEFINITION,
+        struct=STRUCT,
+        buffer_size_bytes=None,
+        overwrite=False,
+        pipeline=None,
+        extract_timestamp=lambda msg: msg["timestamp_seconds"],
+    )
+
+
+def test_append_without_tap_unchanged(writer: TopicBufferWriter) -> None:
+    writer.append({"x": 1.0, "timestamp_seconds": 5.0})
+    assert writer.message_count == 1
+
+
+def test_tap_receives_topic_timestamp_and_raw_msg(writer: TopicBufferWriter) -> None:
+    seen = []
+    writer.set_tap(lambda topic, t, msg: seen.append((topic, t, msg)))
+    writer.append({"x": 2.5, "timestamp_seconds": 7.0})
+    assert seen == [("/imu", 7.0, {"x": 2.5, "timestamp_seconds": 7.0})]
+
+
+def test_tap_exception_never_breaks_append(writer: TopicBufferWriter) -> None:
+    def boom(topic: str, t: float, msg: dict) -> None:
+        raise RuntimeError("tap exploded")
+
+    writer.set_tap(boom)
+    writer.append({"x": 1.0, "timestamp_seconds": 1.0})  # must not raise
+    assert writer.message_count == 1
+
+
+def test_tap_can_be_cleared(writer: TopicBufferWriter) -> None:
+    seen = []
+    writer.set_tap(lambda *a: seen.append(a))
+    writer.set_tap(None)
+    writer.append({"x": 1.0, "timestamp_seconds": 1.0})
+    assert seen == []


### PR DESCRIPTION
## Stacked PR

Base is `feat/fleet-step4` (PR #208, currently OPEN), not `main` — this is
step 5 of the fleet-streaming plan, stacked on step 4's not-yet-merged
router/heartbeat/service work. Diff here is scoped to step 5 only (the
`test/sink/publish/test_stream_e2e.py` live-broker/chaos suite plus the CI
wiring for it); review the cumulative diff against `main` via #208's own
stack, or diff this branch against `feat/fleet-step4` directly for the
step-5-only delta.

## What step 5 proves

Tasks 1–4 delivered the full fleet-streaming runtime: tap → bounded queue →
`RouterCore` → `StreamRouter` → disk spool → `MqttPublisher`, plus
`HeartbeatThread` and `FleetService`'s lifecycle. Step 5 is verification —
no new runtime code — proving that pipeline against a **real** broker,
including a broker outage, and opening this PR.

- **Tap seam is the only shared-code change** (`src/sink/buffer.py`,
  landed in Task 1): `TopicBufferWriter.set_tap()` plus the `struct`
  property the router needs to resolve channel schemas. Everything else in
  steps 1–5 is new, additive code under `src/sink/publish/`.
- **Spool-ordered single publish path**: `StreamRouter._pump` always starts
  from `spool.pending("channels")`, and a freshly-flushed live batch is
  appended to the spool (with its seq) before `_pump` runs in the same
  tick. Replay-then-live is emergent from that ordering, not a separate
  code path — the spool is the single source of publish order whether a
  record arrived from a prior outage or this tick's live samples.
- **Backoff + jitter**: `StreamRouter` reconnects with full-jitter
  exponential backoff (1s → 60s cap) on publish/connect failure, and
  recovers to the 1s floor on a successful reconnect.
- **Dead-router visibility**: an unhandled exception in `_tick` is caught,
  logged, and recorded as `_fatal_error` instead of dying silently: `alive`
  and `last_error` surface it through `FleetService.status()`.
- **Heartbeat shape**: the §3 payload is unchanged; `status()` additionally
  carries `router_alive`, `router_error`, and `heartbeat_spool_failures`
  from the Task 3/4 review rounds, and the heartbeat's own `spool` object
  gained an additive `evicted` field. `cert_expires_at` stays `null` until
  identity/enrollment lands in step 6.
- **Startup-wiring deferral (ruled, peer-notified)**: deciding *when* to
  call `FleetService.start()` is out of scope here — it's conditioned on
  identity existing, which step 6 delivers. No dev/test entrypoint ships in
  this step to black-box-drive it early; the spec's own sanctioned driver
  (`bagel fleet selftest`, step 7 §8) is the right trade over a side door in
  the public image during the stealth window. Peer's parser tolerates the
  contest window opened before this plan; the ruling stands.
- **Heartbeat-lane-never-drains** (carried as a design note, not fixed
  here): a heartbeat that fails to publish live gets appended to the
  spool's `heartbeat` lane, but nothing ever replays that lane — only the
  *next* periodic tick publishes a fresh payload. Spec §4's "never drop"
  posture may want to become "never drop EVENTS; heartbeat = retained-latest
  semantics" — flagged as a step-7 follow-up, not resolved in step 5.

## The three e2e tests (`test/sink/publish/test_stream_e2e.py`)

Env-gated on `MQTT_TEST_BROKER`, same pattern as step 3's
`test_mqtt_integration.py`.

1. **Full path**: a real `TopicBufferWriter` (tmp cache) feeds a real
   `FleetService` (real `MqttPublisher` + tmp `Spool`) against a live
   broker. A subscriber asserts a channels batch with `v==1`, ascending
   `seq`, and rate-capped samples (4 raw appends → 2 surviving samples, the
   same-slot winner being the last one written); schema and heartbeat
   arrive retained (proven via a late-joining subscriber, since a
   retain=1 publish delivered to an already-subscribed client carries
   retain=0 on the wire — that's MQTT semantics, not a bug) with the §3
   keys.
2. **Chaos (the cloud-side M5 mirror)**: kills a broker container
   mid-stream via `docker kill`, keeps appending (proving the tap never
   blocks and the spool's `channels` lane pending count grows), restarts
   the container, and confirms every batch this run produced replays
   exactly once per seq in ascending order (subscriber-side dedupe by seq
   allowed under at-least-once) with the spool draining back to zero
   pending. This test manages its own **private** mosquitto container on
   `MQTT_CHAOS_PORT` (default 1884) — a different container on a different
   port from whatever `MQTT_TEST_BROKER` points at — gated on a second env
   var, `MQTT_TEST_BROKER_MANAGED=1`, so it can never kill a broker it
   didn't start itself. In CI, the `iot` job's own broker *is* the
   container that job starts, so setting `MQTT_TEST_BROKER_MANAGED: "1"`
   there is safe: the chaos test's isolation from that shared `mosq`
   container (on 1883) holds regardless.
3. **Clean stop**: `FleetService.stop()` publishes the stopped heartbeat
   (`online: false`, `reason: "stopped"`) as the last heartbeat a
   subscriber sees, before disconnect — proving the ordering
   `heartbeat.stop()` → `publisher.close()` documented in `service.py`.

All three run 3x locally with no flakes. The full local suite
(`uv run pytest -q test/sink test/test_packaging.py -p no:cacheprovider`)
passes 3x in a row (257 tests). The lazy-import sweep
(`git grep -n "^import paho\|^from paho" -- 'src/sink/publish/'`) finds
nothing, matching the fleet gate's optional-dependency contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
