### PR TITLE
feat(fleet): step 6 — enrollment, identity, dev mode, startup wiring

### DIFF
--- a/plugin/references/settings-knobs.md
+++ b/plugin/references/settings-knobs.md
@@ -22,4 +22,8 @@ Defined in `settings.py`; set via the container environment or `.env`.
 | `FLEET_ENABLED` | true | Kill switch for fleet streaming (beta). `0` makes the publish subsystem inert: nothing connects, nothing leaves the box |
 | `FLEET_SPOOL_MAX_BYTES` | 256 MB | Disk cap for the fleet spool's channels lane; oldest segments evicted first. Events/heartbeats are never dropped and are exempt |
 | `FLEET_QUEUE_MAX_SAMPLES` | 10000 | Max samples in the router's bounded queue between the buffer tap and the router thread; oldest sample dropped on overflow, queue never blocks the tap |
+| `FLEET_IDENTITY_DIRECTORY` | `~/.bagel/identity` | Directory holding this robot's fleet enrollment identity: `robot.key` (0600), `robot.crt`, `ca.crt`, `identity.yaml` |
+| `FLEET_DEV_INSECURE` | false | Dev-only escape hatch: allows an unencrypted `mqtt://` fleet broker when the host resolves to loopback/private. Production stays `mqtts://` with an enrolled identity |
+| `FLEET_ENROLL_TOKEN` | unset | One-time enrollment token for first-boot fleet enrollment. Consumed at first boot, never persisted |
+| `FLEET_ENROLL_URL` | unset | Enrollment server base URL, paired with `FLEET_ENROLL_TOKEN`, used for first-boot enrollment and identity renewal |
 | `BAGEL_FLEET` (build arg) | true | Compose build arg; `false` omits the MQTT client from the iot/ros2 images entirely |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ iot = [
 ]
 fleet = [
     "paho-mqtt>=2.1.0,<3.0.0",
+    "cryptography>=43.0.0,<47.0.0",
 ]
 upload = [
     "azure-storage-blob>=12.24.0,<13.0.0",

--- a/server.py
+++ b/server.py
@@ -28,6 +28,7 @@ from src.pipeline import (
 )
 from src.pipeline.tasks.waffle import snap as waffle_snap
 from src.sink import startup
+from src.sink.publish import identity as fleet_identity
 
 server = mcp_compat.create_server(
     name="Bagel MCP Server",
@@ -1129,6 +1130,9 @@ def snap_hardware(directory: str = ".") -> dict[str, Any]:
 
 
 if __name__ == "__main__":
+    # No-op unless FLEET_ENROLL_TOKEN/_URL are set and unenrolled; before the
+    # startup.start gate so its manifest's `streams:` wiring finds the identity.
+    fleet_identity.maybe_enroll_on_first_boot()
     if settings.STARTUP_PIPELINES_FILE and pathlib.Path(settings.STARTUP_PIPELINES_FILE).exists():
         # Standing pipelines: re-establish subscriptions (and their attached pipelines)
         # on boot, so they survive container restarts.

--- a/settings.py
+++ b/settings.py
@@ -96,6 +96,27 @@ class Settings(BaseSettings):
     # room for the newest; the queue never blocks the tap.
     FLEET_QUEUE_MAX_SAMPLES: int = 10_000
 
+    # Directory holding this robot's fleet enrollment identity: robot.key
+    # (mode 0600), robot.crt, ca.crt, identity.yaml (tenant, robot_id,
+    # broker_url, enroll_url, expires_at). See src/sink/publish/identity.py.
+    FLEET_IDENTITY_DIRECTORY: str = str(pathlib.Path.home() / ".bagel" / "identity")
+
+    # Dev-only escape hatch: allows an unencrypted mqtt:// fleet broker when
+    # the host resolves to loopback or a private (RFC1918/RFC4193) address.
+    # False in production -- mqtts:// with an enrolled identity is the only
+    # transport allowed. See src/sink/publish/connect.py.
+    FLEET_DEV_INSECURE: bool = False
+
+    # One-time enrollment token for first-boot fleet enrollment. Consumed at
+    # first boot (POSTed to FLEET_ENROLL_URL to obtain identity; once
+    # identity.yaml exists this and FLEET_ENROLL_URL are no longer needed)
+    # and never persisted -- it never reaches disk or a log line.
+    FLEET_ENROLL_TOKEN: str | None = None
+
+    # Enrollment server base URL used for first-boot enrollment (paired with
+    # FLEET_ENROLL_TOKEN) and identity renewal. See src/sink/publish/identity.py.
+    FLEET_ENROLL_URL: str | None = None
+
     # Default quantization resolution in meters for cloudini lossy compression
     CLOUDINI_DEFAULT_RESOLUTION: float = 0.001
     ###############################################

--- a/src/sink/publish/__init__.py
+++ b/src/sink/publish/__init__.py
@@ -22,6 +22,20 @@ class FleetDisabledError(Exception):
     """Raised when FLEET_ENABLED=0 has switched the publish subsystem off."""
 
 
+class FleetNotEnrolledError(Exception):
+    """Raised when fleet identity is required but the robot has not enrolled."""
+
+
+class EnrollmentError(Exception):
+    """Raised when the enrollment server rejects or fails an enroll/renew request."""
+
+    def __init__(self, status: int, reason: str) -> None:
+        """Initialize EnrollmentError with the HTTP status and a reason (never the token)."""
+        self.status = status
+        self.reason = reason
+        super().__init__(f"enrollment failed ({status}): {reason}")
+
+
 class StreamConfigError(Exception):
     """Raised when the manifest's `streams:` section fails load-time validation."""
 

--- a/src/sink/publish/config.py
+++ b/src/sink/publish/config.py
@@ -293,6 +293,31 @@ def _resolve_channel_rule(
     return resolved
 
 
+def _validate_broker(broker: object) -> None:
+    """Validate an optional `streams.broker` URL (mqtt(s):// scheme + host + port).
+
+    Split out of `StreamsConfig.build` to keep that method's cyclomatic
+    complexity in check after the Codex-review fixes below added branches to it.
+
+    urlparse() itself can raise a raw ValueError on a malformed authority
+    (e.g. an unbalanced "["), and .port raises ValueError on a non-numeric or
+    out-of-range port -- both must surface as a typed StreamConfigError, not
+    an untyped crash (Codex review).
+    """
+    try:
+        parsed = urlparse(str(broker))
+        _ = parsed.port  # accessed only to trigger its ValueError on a bad port
+    except ValueError as exc:
+        raise StreamConfigError(
+            "streams.broker", f"malformed mqtt:// or mqtts:// URL: {broker!r} ({exc})"
+        ) from exc
+    if parsed.scheme not in ("mqtt", "mqtts") or not parsed.hostname:
+        raise StreamConfigError(
+            "streams.broker",
+            f"must be an mqtt:// or mqtts:// URL with a host: {broker!r}",
+        )
+
+
 class StreamsConfig(BaseModel):
     """The whole `streams:` manifest section, shape-validated."""
 
@@ -315,22 +340,7 @@ class StreamsConfig(BaseModel):
             raise StreamConfigError("streams", f"unknown keys {sorted(unknown)}")
         broker = config.get("broker")
         if broker is not None:
-            # urlparse() itself can raise a raw ValueError on a malformed
-            # authority (e.g. an unbalanced "["), and .port raises ValueError
-            # on a non-numeric or out-of-range port -- both must surface as a
-            # typed StreamConfigError, not an untyped crash (Codex review).
-            try:
-                parsed = urlparse(str(broker))
-                _ = parsed.port  # accessed only to trigger its ValueError on a bad port
-            except ValueError as exc:
-                raise StreamConfigError(
-                    "streams.broker", f"malformed mqtt:// or mqtts:// URL: {broker!r} ({exc})"
-                ) from exc
-            if parsed.scheme not in ("mqtt", "mqtts") or not parsed.hostname:
-                raise StreamConfigError(
-                    "streams.broker",
-                    f"must be an mqtt:// or mqtts:// URL with a host: {broker!r}",
-                )
+            _validate_broker(broker)
         flush = config.get("flush_interval_s", 1.0)
         if not isinstance(flush, int | float) or isinstance(flush, bool) or flush <= 0:
             raise StreamConfigError("streams.flush_interval_s", f"must be > 0: {flush!r}")

--- a/src/sink/publish/config.py
+++ b/src/sink/publish/config.py
@@ -44,7 +44,13 @@ def resolve_path(struct: pa.StructType, dotted: str, *, field_label: str) -> Acc
 
 
 def field_unit(struct: pa.StructType, dotted: str) -> str | None:
-    """Return the Arrow field metadata unit (key "unit") for a dotted path, if present.
+    """Return the Arrow field metadata unit (key "units") for a dotted path, if present.
+
+    "units" (plural) is the canonical key -- see ``src/topic/base.py``'s
+    ``UNITS_KEY`` -- and the only key any registry (e.g. ArduPilot's schema
+    builder) actually writes; there is no ``b"unit"`` (singular) fallback
+    since nothing produces that key (Codex review: this used to read the
+    wrong key and silently lost every real schema's unit metadata).
 
     Assumes ``dotted`` already resolves against ``struct`` (call after
     ``resolve_path`` succeeds); an unresolvable path yields ``None`` rather
@@ -62,7 +68,7 @@ def field_unit(struct: pa.StructType, dotted: str) -> str | None:
         current = field.type
     if field is None or field.metadata is None:
         return None
-    value = field.metadata.get(b"unit")
+    value = field.metadata.get(b"units")
     if value is None:
         return None
     return value.decode() if isinstance(value, bytes) else value
@@ -300,9 +306,26 @@ class StreamsConfig(BaseModel):
         """Build and validate streams config from dict."""
         if not isinstance(config, dict):
             raise StreamConfigError("streams", f"must be a mapping: {config!r}")
+        # Codex review (3909410575): unlike channels[]/events[] entries, the
+        # top-level streams: mapping never rejected an unknown key -- a typo
+        # (e.g. "channnels") silently fell back to the default empty list
+        # instead of erroring. Mirror ChannelRule.build/EventRule.build's style.
+        unknown = set(config) - {"broker", "flush_interval_s", "channels", "events"}
+        if unknown:
+            raise StreamConfigError("streams", f"unknown keys {sorted(unknown)}")
         broker = config.get("broker")
         if broker is not None:
-            parsed = urlparse(str(broker))
+            # urlparse() itself can raise a raw ValueError on a malformed
+            # authority (e.g. an unbalanced "["), and .port raises ValueError
+            # on a non-numeric or out-of-range port -- both must surface as a
+            # typed StreamConfigError, not an untyped crash (Codex review).
+            try:
+                parsed = urlparse(str(broker))
+                _ = parsed.port  # accessed only to trigger its ValueError on a bad port
+            except ValueError as exc:
+                raise StreamConfigError(
+                    "streams.broker", f"malformed mqtt:// or mqtts:// URL: {broker!r} ({exc})"
+                ) from exc
             if parsed.scheme not in ("mqtt", "mqtts") or not parsed.hostname:
                 raise StreamConfigError(
                     "streams.broker",

--- a/src/sink/publish/connect.py
+++ b/src/sink/publish/connect.py
@@ -103,10 +103,13 @@ def resolve_publisher_kwargs(streams: StreamsConfig, identity: Identity | None) 
     this is a dev-only, unenrolled robot and the kwargs use the documented
     placeholder identity ``tenant="dev"``, ``robot="robot"``.
 
-    Any other broker scheme raises ``StreamConfigError`` (``StreamsConfig``
-    and ``Identity.broker_url`` both already constrain the scheme to
-    ``mqtt``/``mqtts``, so this is a defensive fallback, not a reachable
-    default path).
+    Any other broker scheme raises ``StreamConfigError`` naming the scheme.
+    ``StreamsConfig.build`` constrains ``streams.broker`` to ``mqtt``/``mqtts``,
+    but ``load_identity``/``enroll`` do NOT validate ``broker_url``'s scheme --
+    an ``identity.yaml`` written by a compromised or misbehaving enrollment
+    server (or hand-edited on disk) can carry any scheme at all. This branch
+    is that guard, not dead code: it is the last line of defense against a
+    malicious ``broker_url`` reaching ``MqttPublisher`` unchecked.
 
     Returns:
         A dict of exactly the kwargs ``MqttPublisher(**kwargs)`` accepts.

--- a/src/sink/publish/connect.py
+++ b/src/sink/publish/connect.py
@@ -1,0 +1,175 @@
+"""Connection policy: turn stream config + fleet identity into MqttPublisher kwargs.
+
+One function, ``resolve_publisher_kwargs``, decides two things every time a
+fleet publisher is (re)built: which broker to dial, and whether the
+transport is allowed. ``mqtts://`` is the only production path -- it always
+requires an enrolled identity, whose cert/key paths become the TLS kwargs.
+``mqtt://`` (plaintext) exists only for local development: it requires both
+the ``FLEET_DEV_INSECURE`` escape hatch *and* a broker host that resolves to
+loopback or a private (RFC1918/RFC4193) address, so a misconfigured
+production robot can never silently fall back to an unauthenticated,
+unencrypted broker on the public internet.
+
+The returned dict is exactly the kwargs ``MqttPublisher(**kwargs)`` accepts
+(``broker_url``, ``tenant``, ``robot``, and -- for ``mqtts://`` -- the three
+``tls_*`` paths); ``tenant``/``robot`` live in that same dict for a caller
+that also needs them separately (e.g. ``Spool.for_robot(f"{tenant}/{robot}")``,
+which wants the combined ``Identity.robot`` form rather than these two
+split fields).
+
+``identity``, ``StreamsConfig``, and ``settings`` are imported only inside
+functions (or under ``TYPE_CHECKING``) so importing this module carries no
+weight beyond the stdlib -- consistent with the rest of this package, which
+imports paho/cryptography only where they are actually used.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+from typing import TYPE_CHECKING
+from urllib.parse import urlparse
+
+from src.sink.publish import FleetNotEnrolledError, StreamConfigError
+
+if TYPE_CHECKING:
+    from src.sink.publish.config import StreamsConfig
+    from src.sink.publish.identity import Identity
+
+_DEV_TENANT = "dev"
+_DEV_ROBOT = "robot"
+
+
+def _resolved_addresses(host: str) -> list[ipaddress.IPv4Address | ipaddress.IPv6Address]:
+    """Resolve ``host`` via ``socket.getaddrinfo``; ``[]`` on failure or no results.
+
+    A real DNS lookup at call time -- tests must monkeypatch ``socket.getaddrinfo``,
+    never let this hit the network.
+    """
+    try:
+        results = socket.getaddrinfo(host, None)
+    except socket.gaierror:
+        return []
+    try:
+        return [
+            ipaddress.ip_address(sockaddr[0]) for _fam, _typ, _proto, _canon, sockaddr in results
+        ]
+    except ValueError:
+        # A resolved "address" that ipaddress can't parse can't be confirmed
+        # private -- fail closed, same as a resolution failure.
+        return []
+
+
+def _is_local_or_private(host: str) -> bool:
+    """Return whether ``host`` names a loopback or private (non-routable) address.
+
+    ``"localhost"`` is accepted by name without resolution. A literal IPv4 or
+    IPv6 address is checked directly via ``ipaddress`` (loopback or private).
+    Any other hostname is resolved with ``socket.getaddrinfo`` (see
+    ``_resolved_addresses``), and ALL returned addresses must be
+    loopback/private for the host to pass, so a DNS answer mixing a private
+    and a public address is rejected rather than trusted on its best entry.
+    A resolution failure or an empty result list returns False (fail closed:
+    an unresolvable host is never treated as private).
+    """
+    if host == "localhost":
+        return True
+    try:
+        literal = ipaddress.ip_address(host)
+        addresses = [literal]
+    except ValueError:
+        addresses = _resolved_addresses(host)
+    return bool(addresses) and all(a.is_loopback or a.is_private for a in addresses)
+
+
+def resolve_publisher_kwargs(streams: StreamsConfig, identity: Identity | None) -> dict:
+    """Decide the broker and auth for a fleet publisher; return MqttPublisher kwargs.
+
+    Broker precedence: ``streams.broker`` (from the manifest) wins if set,
+    else ``identity.broker_url`` (assigned by the enrollment server). If
+    neither is available, raises ``FleetNotEnrolledError`` naming both the
+    manifest setting and the enrollment path as remedies.
+
+    ``mqtts://`` requires ``identity``: the returned kwargs carry
+    ``tenant``/``robot`` from it and TLS material (``tls_ca_certs``,
+    ``tls_certfile``, ``tls_keyfile``) from its stored cert paths. No
+    anonymous TLS -- an ``mqtts://`` broker with no identity always raises.
+
+    ``mqtt://`` (plaintext) requires ``settings.FLEET_DEV_INSECURE`` to be
+    true (else a ``StreamConfigError`` naming that setting) AND the broker
+    host to resolve as loopback/private per ``_is_local_or_private`` (else a
+    ``StreamConfigError`` naming the host). Identity is optional here: with
+    one, ``tenant``/``robot`` come from it same as ``mqtts://``; without one,
+    this is a dev-only, unenrolled robot and the kwargs use the documented
+    placeholder identity ``tenant="dev"``, ``robot="robot"``.
+
+    Any other broker scheme raises ``StreamConfigError`` (``StreamsConfig``
+    and ``Identity.broker_url`` both already constrain the scheme to
+    ``mqtt``/``mqtts``, so this is a defensive fallback, not a reachable
+    default path).
+
+    Returns:
+        A dict of exactly the kwargs ``MqttPublisher(**kwargs)`` accepts.
+
+    Raises:
+        FleetNotEnrolledError: no broker configured, or ``mqtts://`` chosen
+            with no enrolled identity.
+        StreamConfigError: ``mqtt://`` chosen without ``FLEET_DEV_INSECURE``,
+            or with a host that is not loopback/private, or an unsupported
+            broker scheme.
+
+    """
+    from settings import settings
+
+    broker_url = streams.broker or (identity.broker_url if identity is not None else None)
+    if not broker_url:
+        raise FleetNotEnrolledError(
+            "no fleet broker configured: set 'streams.broker' in the manifest, "
+            "or enroll this robot (identity.enroll) so 'identity.broker_url' is "
+            "available"
+        )
+
+    scheme = urlparse(broker_url).scheme
+
+    if scheme == "mqtts":
+        if identity is None:
+            raise FleetNotEnrolledError(
+                f"mqtts://{urlparse(broker_url).hostname} requires an enrolled fleet "
+                "identity for TLS material and tenant/robot; enroll this robot "
+                "(identity.enroll) first"
+            )
+        return {
+            "broker_url": broker_url,
+            "tenant": identity.tenant,
+            "robot": identity.robot_id,
+            "tls_ca_certs": str(identity.ca_path),
+            "tls_certfile": str(identity.cert_path),
+            "tls_keyfile": str(identity.key_path),
+        }
+
+    if scheme == "mqtt":
+        if not settings.FLEET_DEV_INSECURE:
+            raise StreamConfigError(
+                "streams.broker",
+                f"plaintext mqtt:// broker {broker_url!r} requires "
+                "FLEET_DEV_INSECURE=1 (local development only); use mqtts:// "
+                "with an enrolled identity otherwise",
+            )
+        host = urlparse(broker_url).hostname
+        if host is None or not _is_local_or_private(host):
+            raise StreamConfigError(
+                "streams.broker",
+                f"mqtt:// host {host!r} does not resolve to loopback/private: "
+                "FLEET_DEV_INSECURE only permits a local or private-network broker",
+            )
+        if identity is not None:
+            tenant, robot = identity.tenant, identity.robot_id
+        else:
+            # Dev-only, unenrolled robot: a fixed placeholder identity, never
+            # used for anything but a local mqtt:// broker gated above.
+            tenant, robot = _DEV_TENANT, _DEV_ROBOT
+        return {"broker_url": broker_url, "tenant": tenant, "robot": robot}
+
+    raise StreamConfigError(
+        "streams.broker", f"unsupported broker scheme {scheme!r}: {broker_url!r}"
+    )

--- a/src/sink/publish/heartbeat.py
+++ b/src/sink/publish/heartbeat.py
@@ -5,19 +5,22 @@ distribution first (works for a `uv sync`/pip-installed image); when that
 distribution metadata is absent -- as in a source checkout run via `uv run`
 without `uv sync --package/-e` having registered it, which is the live path
 in this worktree -- it falls back to parsing `pyproject.toml`'s
-`[project].version` directly. Either miss returns `"unknown"` rather than
-raising: a heartbeat must go out even if its own version string is a mystery.
+`[project].version` directly with a small zero-dependency regex, NOT
+`tomllib` (Codex review: `tomllib` is stdlib only on Python 3.11+, and this
+module must import cleanly on the 3.10-based ros2-humble/iron images too --
+a module-level `import tomllib` broke CI's image import-probe on those).
+Either miss returns `"unknown"` rather than raising: a heartbeat must go out
+even if its own version string is a mystery.
 """
 
 import importlib.metadata
 import logging
 import pathlib
+import re
 import shutil
 import threading
 import time
 from collections.abc import Callable
-
-import tomllib
 
 from src.sink.publish.publisher import Publisher, PublishError
 from src.sink.publish.spool import Spool
@@ -26,12 +29,23 @@ HEARTBEAT_INTERVAL_S = 30.0
 
 _DISTRIBUTION_NAME = "bagel"
 
+_VERSION_LINE_RE = re.compile(r'^version\s*=\s*"([^"]+)"', re.MULTILINE)
 
-def _pyproject_version() -> str:
-    """Read `[project].version` from the repo's pyproject.toml (fallback path)."""
-    root = pathlib.Path(__file__).resolve().parents[3]
-    data = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
-    return str(data["project"]["version"])
+
+def _pyproject_version(root: pathlib.Path | None = None) -> str:
+    """Read `[project].version` from a pyproject.toml (fallback path).
+
+    Parsed with a plain regex rather than `tomllib` -- zero dependencies, and
+    it works on every Python this repo targets (not just 3.11+). `root`
+    defaults to the repo root inferred from this file's location; a caller
+    (tests) may pass a different directory containing its own pyproject.toml.
+    """
+    root = root if root is not None else pathlib.Path(__file__).resolve().parents[3]
+    text = (root / "pyproject.toml").read_text(encoding="utf-8")
+    match = _VERSION_LINE_RE.search(text)
+    if match is None:
+        raise ValueError(f"no version = \"...\" line found in {root / 'pyproject.toml'}")
+    return match.group(1)
 
 
 def bagel_version() -> str:

--- a/src/sink/publish/heartbeat.py
+++ b/src/sink/publish/heartbeat.py
@@ -69,14 +69,17 @@ def build_heartbeat(  # noqa: PLR0913
     disk_free_bytes: int,
     reconnects: int,
     now: float | None = None,
+    cert_expires_at: str | None = None,
 ) -> dict:
     """Build the §3 heartbeat payload.
 
     `spool_stats` maps lane name -> a value exposing `bytes`/`pending`/
     `evicted` (either as dict keys or attributes, e.g. `Spool.stats()`'s
     `LaneStats`); this aggregates the channels/events/heartbeat lanes into
-    one `spool` object by summing each field. `cert_expires_at` is always
-    `None` here -- identity/enrollment lands in step 6.
+    one `spool` object by summing each field. `cert_expires_at` defaults to
+    `None` (an unenrolled robot, or a caller with no identity wired) and is
+    otherwise passed straight through from the caller's `Identity.expires_at`
+    -- `FleetService` supplies it once constructed with an `identity`.
     """
     t = now if now is not None else time.time()
     return {
@@ -94,7 +97,7 @@ def build_heartbeat(  # noqa: PLR0913
             "evicted": sum(_lane_field(s, "evicted") for s in spool_stats.values()),
         },
         "disk_free_bytes": disk_free_bytes,
-        "cert_expires_at": None,
+        "cert_expires_at": cert_expires_at,
         "reconnects": reconnects,
     }
 
@@ -112,6 +115,15 @@ class HeartbeatThread(threading.Thread):
     spool's "heartbeat" lane instead (best-effort -- a spool failure here is
     swallowed too, since a heartbeat thread that dies is worse than one that
     occasionally fails to record a missed beat).
+
+    An optional `renewal_check` callable is invoked once per tick, before
+    the payload is built -- it exists purely as a convenient, already-running
+    clock for certificate renewal (`FleetService` wires its own
+    `identity.should_attempt_renewal`/`identity.renew` closure in here when
+    constructed with an `identity`). It runs inside its own try/except,
+    entirely separate from the payload-factory/publish/spool handling below:
+    an exception from it is logged at WARNING and otherwise ignored -- it
+    must never be able to skip a beat or kill this thread.
     """
 
     def __init__(
@@ -120,13 +132,18 @@ class HeartbeatThread(threading.Thread):
         payload_factory: Callable[[], dict],
         interval_s: float = HEARTBEAT_INTERVAL_S,
         spool: Spool | None = None,
+        renewal_check: Callable[[], None] | None = None,
     ) -> None:
-        """Wire the publisher, payload builder, and optional spool; does not start the thread."""
+        """Wire the publisher, payload builder, optional spool, and optional renewal hook.
+
+        Does not start the thread.
+        """
         super().__init__(daemon=True)
         self._publisher = publisher
         self._payload_factory = payload_factory
         self._interval_s = interval_s
         self._spool = spool
+        self._renewal_check = renewal_check
         self._stop_event = threading.Event()
         self._spool_failures = 0
         self._last_error: str | None = None
@@ -160,7 +177,18 @@ class HeartbeatThread(threading.Thread):
         `spool_failures` so it is visible to an operator via
         `FleetService.status()`, instead of vanishing at DEBUG. Either way
         the thread never dies and no exception escapes this method.
+
+        `renewal_check()` (if wired) runs first, in its own try/except --
+        see the class docstring. Its outcome (and any exception from it) has
+        no bearing on whether this beat's payload is built or published.
         """
+        if self._renewal_check is not None:
+            try:
+                self._renewal_check()
+            except Exception as exc:
+                logging.getLogger(__name__).warning(
+                    "renewal_check hook failed: %s", exc, exc_info=True
+                )
         try:
             payload = self._payload_factory()
         except Exception as exc:

--- a/src/sink/publish/identity.py
+++ b/src/sink/publish/identity.py
@@ -101,6 +101,18 @@ def _url_passes_scheme_gate(url: str) -> bool:
     return bool(parsed.hostname) and _connect._is_local_or_private(parsed.hostname)
 
 
+def _validate_enroll_url(enroll_url: str) -> None:
+    """Validate `enroll()`'s URL: http(s) scheme, then the scheme gate.
+
+    Split out of `enroll()` to keep that function's cyclomatic complexity in
+    check after the Codex-review scheme-gate check added a branch to it.
+    """
+    if not enroll_url.startswith(("https://", "http://")):
+        raise ValueError(f"enroll_url must be http(s): {enroll_url}")
+    if not _url_passes_scheme_gate(enroll_url):
+        raise EnrollmentError(0, "insecure enroll_url")
+
+
 @dataclasses.dataclass
 class Identity:
     """A robot's enrolled fleet identity: certs on disk plus broker metadata.
@@ -229,10 +241,7 @@ def enroll(token: str, enroll_url: str, directory: pathlib.Path) -> Identity:
             send the one-time token in cleartext).
 
     """
-    if not enroll_url.startswith(("https://", "http://")):
-        raise ValueError(f"enroll_url must be http(s): {enroll_url}")
-    if not _url_passes_scheme_gate(enroll_url):
-        raise EnrollmentError(0, "insecure enroll_url")
+    _validate_enroll_url(enroll_url)
 
     private_key_pem, csr_pem = generate_key_and_csr()
 

--- a/src/sink/publish/identity.py
+++ b/src/sink/publish/identity.py
@@ -53,6 +53,7 @@ import urllib.request
 
 import yaml
 
+from settings import settings
 from src.sink.publish import EnrollmentError, FleetNotEnrolledError
 
 _REQUIRED_RESPONSE_FIELDS = (
@@ -693,3 +694,42 @@ def renew(identity: Identity) -> Identity | None:
         except Exception:  # best-effort; must not mask the original failure
             logger.warning("failed to record renewal attempt after unexpected error", exc_info=True)
         return None
+
+
+def maybe_enroll_on_first_boot() -> None:
+    """Enroll this robot at boot if a one-time token+URL are configured and it isn't yet.
+
+    Called from server.py's ``__main__`` block, BEFORE ``startup.start()``, so
+    a fresh enrollment's identity is already on disk by the time the
+    manifest's ``streams:`` wiring looks for one (see ``src/sink/startup.py``).
+
+    A no-op unless both ``settings.FLEET_ENROLL_TOKEN`` and
+    ``settings.FLEET_ENROLL_URL`` are set AND ``settings.FLEET_IDENTITY_DIRECTORY``
+    is not already enrolled (``is_enrolled()``) -- an already-enrolled robot,
+    or one with no token configured at all, does nothing here.
+
+    Never raises: enrollment failing at boot (bad token, unreachable server,
+    ...) must not brick the container -- it is logged at ERROR (the reason
+    only; per ``enroll()``'s contract the token itself never appears in the
+    exception or reaches this log line) and the server continues booting
+    unenrolled. A successful enrollment logs the assigned tenant/robot --
+    again, never the token.
+    """
+    logger = logging.getLogger(__name__)
+    token = settings.FLEET_ENROLL_TOKEN
+    url = settings.FLEET_ENROLL_URL
+    if not token or not url:
+        return
+    directory = settings.FLEET_IDENTITY_DIRECTORY
+    if is_enrolled(directory):
+        return
+    try:
+        result = enroll(token, url, pathlib.Path(directory))
+    except Exception as exc:
+        logger.error("First-boot fleet enrollment failed: %s", exc)
+        return
+    logger.info(
+        "First-boot fleet enrollment succeeded: tenant=%s robot=%s",
+        result.tenant,
+        result.robot_id,
+    )

--- a/src/sink/publish/identity.py
+++ b/src/sink/publish/identity.py
@@ -779,10 +779,14 @@ def maybe_enroll_on_first_boot() -> None:
     a fresh enrollment's identity is already on disk by the time the
     manifest's ``streams:`` wiring looks for one (see ``src/sink/startup.py``).
 
-    A no-op unless both ``settings.FLEET_ENROLL_TOKEN`` and
-    ``settings.FLEET_ENROLL_URL`` are set AND ``settings.FLEET_IDENTITY_DIRECTORY``
-    is not already enrolled (``is_enrolled()``) -- an already-enrolled robot,
-    or one with no token configured at all, does nothing here.
+    A no-op unless ``settings.FLEET_ENABLED`` is true (the kill switch's
+    documented "makes the subsystem inert" contract -- Codex review: this
+    was previously unchecked here, so ``FLEET_ENABLED=0`` did not stop a
+    first-boot enrollment keygen+POST), AND both ``settings.FLEET_ENROLL_TOKEN``
+    and ``settings.FLEET_ENROLL_URL`` are set AND
+    ``settings.FLEET_IDENTITY_DIRECTORY`` is not already enrolled
+    (``is_enrolled()``) -- an already-enrolled robot, or one with no token
+    configured at all, does nothing here.
 
     Never raises: enrollment failing at boot (bad token, unreachable server,
     ...) must not brick the container -- it is logged at ERROR (the reason
@@ -792,6 +796,12 @@ def maybe_enroll_on_first_boot() -> None:
     again, never the token.
     """
     logger = logging.getLogger(__name__)
+    if not settings.FLEET_ENABLED:
+        logger.debug(
+            "First-boot fleet enrollment skipped: FLEET_ENABLED=0 (kill switch makes the "
+            "fleet subsystem inert)"
+        )
+        return
     token = settings.FLEET_ENROLL_TOKEN
     url = settings.FLEET_ENROLL_URL
     if not token or not url:

--- a/src/sink/publish/identity.py
+++ b/src/sink/publish/identity.py
@@ -1,4 +1,4 @@
-"""Fleet enrollment client: keygen, CSR, identity storage (spec §6).
+"""Fleet enrollment and renewal client: keygen, CSR, identity storage (spec §6).
 
 The private key never leaves the process: it is generated on the robot,
 only the CSR (public key + advisory CN) crosses the network. ``cryptography``
@@ -13,13 +13,23 @@ atomic (sibling tempfile + os.replace).
 
 The enrollment token appears in the POST body only. It is never logged,
 never stored, and never embedded in an ``EnrollmentError`` reason.
+
+``renew()`` (see below) refreshes an existing identity's certificate ahead
+of expiry: ``should_attempt_renewal`` decides when it is due, and ``renew``
+does the mTLS POST + atomic file replacement. See ``renew()``'s docstring
+for the ordering guarantees and what it does NOT do (force a live publisher
+reconnect).
 """
 
 import dataclasses
+import datetime
 import json
+import logging
 import os
 import pathlib
+import ssl
 import tempfile
+import time
 import urllib.error
 import urllib.request
 
@@ -35,6 +45,12 @@ _REQUIRED_RESPONSE_FIELDS = (
     "robot_id",
     "expires_at",
 )
+
+_RENEWAL_WINDOW_S = 30 * 86400
+_RENEWAL_MIN_INTERVAL_S = 86400
+# Statuses the cloud uses to mean "renewal isn't offered on this deployment
+# yet" (the flag is off) rather than "the request failed" -- expected, quiet.
+_RENEWAL_NOT_OFFERED_STATUSES = (404, 501)
 
 
 @dataclasses.dataclass
@@ -283,3 +299,217 @@ def is_enrolled(directory: pathlib.Path) -> bool:
     except FleetNotEnrolledError:
         return False
     return True
+
+
+def should_attempt_renewal(now: float, expires_at: str, last_attempt_at: float | None) -> bool:
+    """Whether a renewal attempt is due: within 30 days of expiry, rate-limited to once/day.
+
+    ``expires_at`` is an ISO-8601 timestamp with an explicit timezone (a bare
+    "Z" suffix is accepted and treated as UTC -- that's the form the enroll
+    and renew server responses use). ``now`` and ``last_attempt_at`` are Unix
+    epoch seconds, matching ``time.time()`` -- the same clock ``renew()`` and
+    ``HeartbeatThread`` use elsewhere.
+
+    True iff the certificate expires within 30 days
+    (``expires_epoch - now <= 30 * 86400``, inclusive: exactly 30 days out
+    already counts as within the window) AND either no renewal has ever been
+    attempted (``last_attempt_at is None``) or at least 86400s (1 day) have
+    elapsed since the last one (inclusive: exactly 86400s counts as due
+    again).
+
+    Raises:
+        ValueError: ``expires_at`` parses but carries no timezone.
+
+    """
+    expires_dt = datetime.datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
+    if expires_dt.tzinfo is None:
+        raise ValueError(f"expires_at must be timezone-aware: {expires_at!r}")
+    within_window = (expires_dt.timestamp() - now) <= _RENEWAL_WINDOW_S
+    if not within_window:
+        return False
+    if last_attempt_at is None:
+        return True
+    return (now - last_attempt_at) >= _RENEWAL_MIN_INTERVAL_S
+
+
+def _build_mtls_context(identity: Identity) -> ssl.SSLContext:
+    """Build the mTLS client context for a renewal POST.
+
+    The CURRENT cert/key pair authenticates this robot to the server
+    (``load_cert_chain``); ``ca_path`` verifies the server's cert
+    (``load_verify_locations``). Broken out as its own function so unit
+    tests can monkeypatch/spy the construction (e.g. wrap
+    ``ssl.SSLContext.load_cert_chain`` and assert it was called with
+    ``identity.cert_path``/``identity.key_path``) without standing up a real
+    TLS listener -- the real-TLS path is e2e territory. The actual POST in
+    those tests hits a plain-HTTP in-test fake server: ``urlopen`` simply
+    ignores ``context=`` for an ``http://`` URL, so the same code runs
+    against both.
+    """
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    context.load_cert_chain(certfile=str(identity.cert_path), keyfile=str(identity.key_path))
+    context.load_verify_locations(cafile=str(identity.ca_path))
+    return context
+
+
+def _write_identity_yaml(
+    identity: Identity, *, expires_at: str, last_renewal_attempt_at: float
+) -> None:
+    """Atomically (re)write ``identity.yaml`` alongside ``identity``'s key file.
+
+    Used by both the success and failure paths of ``renew()``: on failure
+    only ``last_renewal_attempt_at`` changes (``expires_at`` is echoed back
+    unchanged); on success both are the new values. Like ``enroll()``, this
+    rewrites the whole document from ``identity``'s known fields rather than
+    reading-modifying-writing the file on disk, so any unknown key a future
+    version added to it (other than the five ``load_identity`` requires plus
+    this one) is not preserved across a renewal -- same tradeoff `enroll()`
+    already makes.
+    """
+    directory = identity.key_path.parent
+    doc = {
+        "tenant": identity.tenant,
+        "robot_id": identity.robot_id,
+        "broker_url": identity.broker_url,
+        "enroll_url": identity.enroll_url,
+        "expires_at": expires_at,
+        "last_renewal_attempt_at": last_renewal_attempt_at,
+    }
+    _atomic_write(directory / "identity.yaml", yaml.safe_dump(doc).encode())
+
+
+def _record_renewal_attempt(identity: Identity, attempt_at: float) -> None:
+    """Persist ``last_renewal_attempt_at`` with ``expires_at`` unchanged (a failed attempt)."""
+    _write_identity_yaml(
+        identity, expires_at=identity.expires_at, last_renewal_attempt_at=attempt_at
+    )
+
+
+def _renew_inner(  # noqa: PLR0911 -- one early return per distinct failure branch, each logged/recorded differently
+    identity: Identity, now: float, logger: logging.Logger
+) -> Identity | None:
+    """Attempt the actual renewal; ``renew()`` wraps this in a catch-all safety net."""
+    if not identity.enroll_url.startswith(("https://", "http://")):
+        logger.warning("renewal skipped: enroll_url is not http(s): %s", identity.enroll_url)
+        _record_renewal_attempt(identity, now)
+        return None
+
+    new_key_pem, new_csr_pem = generate_key_and_csr(common_name=identity.robot_id)
+
+    body = json.dumps({"csr_pem": new_csr_pem.decode()}).encode()
+    request = urllib.request.Request(  # noqa: S310 -- scheme enforced to http(s) above
+        f"{identity.enroll_url}/v1/renew",
+        data=body,
+        headers={"Content-Type": "application/json"},
+    )
+    context = _build_mtls_context(identity)
+    try:
+        # urlopen raises HTTPError on non-2xx; context= is a no-op for the
+        # http:// scheme a test's fake server uses, exercised for real only
+        # against an https:// enroll_url in production.
+        with urllib.request.urlopen(request, context=context, timeout=30) as response:  # noqa: S310
+            raw = response.read()
+    except urllib.error.HTTPError as exc:
+        status = exc.code
+        # No token in a renewal request, so (unlike enroll()) nothing needs
+        # redacting before this snippet goes to the log -- see the module's
+        # renew() docstring.
+        snippet = exc.read().decode("utf-8", errors="replace")[:200]
+        if status in _RENEWAL_NOT_OFFERED_STATUSES:
+            logger.info("renewal not offered by server yet (status %d): %s", status, snippet)
+        else:
+            logger.warning("renewal request failed (status %d): %s", status, snippet)
+        _record_renewal_attempt(identity, now)
+        return None
+    except urllib.error.URLError as exc:
+        logger.warning("renewal request failed: %s", exc.reason)
+        _record_renewal_attempt(identity, now)
+        return None
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        logger.warning("renewal response malformed: %s", exc)
+        _record_renewal_attempt(identity, now)
+        return None
+    if not isinstance(payload, dict):
+        logger.warning("renewal response malformed: not a JSON object")
+        _record_renewal_attempt(identity, now)
+        return None
+    missing = [field for field in ("cert_pem", "expires_at") if field not in payload]
+    if missing:
+        logger.warning("renewal response missing fields: %s", missing)
+        _record_renewal_attempt(identity, now)
+        return None
+
+    # Key first (0600), then the cert, then (if offered) the CA, then the
+    # yaml pointer document last -- same crash-safety ordering as enroll():
+    # a crash mid-sequence never leaves a readable key with a stale cert
+    # alongside it plus an identity.yaml that still claims the old expiry.
+    _atomic_write(identity.key_path, new_key_pem, mode=0o600)
+    _atomic_write(identity.cert_path, payload["cert_pem"].encode())
+    if "ca_pem" in payload:
+        _atomic_write(identity.ca_path, payload["ca_pem"].encode())
+    _write_identity_yaml(identity, expires_at=payload["expires_at"], last_renewal_attempt_at=now)
+
+    return dataclasses.replace(identity, expires_at=payload["expires_at"])
+
+
+def renew(identity: Identity) -> Identity | None:
+    """Renew ``identity``'s certificate: a NEW key + CSR, POSTed over mTLS.
+
+    Generates a brand new private key and CSR -- not a re-use of the current
+    key -- and POSTs it to ``{identity.enroll_url}/v1/renew`` authenticated
+    with the CURRENT cert/key pair over mTLS (``ssl.SSLContext`` +
+    ``load_cert_chain``/``load_verify_locations``, see
+    ``_build_mtls_context``). Per spec §6, renewal happens "with a new CSR";
+    read strictly, a new CSR implies a new key backing it, so a compromised
+    old key is never perpetuated across a renewal.
+
+    On a 200 response, ``robot.key`` (0600), ``robot.crt``, ``ca.crt`` (only
+    if the response carries a ``ca_pem`` -- the server need not re-issue the
+    CA on every renewal), and ``identity.yaml`` (updated ``expires_at`` and
+    ``last_renewal_attempt_at``) are all replaced atomically, and the
+    returned ``Identity`` reflects the new files. On any failure below --
+    including a 501/404 meaning the server does not offer renewal on this
+    deployment yet -- NOTHING is written except ``last_renewal_attempt_at``
+    in ``identity.yaml``: the old key/cert/ca and ``expires_at`` are left
+    completely untouched, so a failed renewal never leaves the robot with a
+    broken or missing identity.
+
+    IMPORTANT: this only replaces files on disk (and the in-memory
+    ``Identity`` this function returns). The LIVE MQTT publisher connection
+    keeps authenticating with the OLD cert until its own next reconnect --
+    renewing does not force a reconnect. A caller that wants the running
+    connection to pick up the new cert must swap its ``Identity`` reference
+    to the returned value and either wait for the publisher's normal
+    reconnect cycle or trigger one itself.
+
+    Returns:
+        The new ``Identity`` on a 200 response with a well-formed body.
+        ``None`` if the server does not offer renewal yet (501/404 -- logged
+        at INFO: the cloud ships renewal disabled behind a flag, so this is
+        the expected path for now) or on any other failure (transport
+        error, non-200/non-(501/404) status, malformed body, or an
+        unexpected exception -- logged at WARNING). Either way, an attempt
+        is recorded to ``identity.yaml`` before returning so
+        ``should_attempt_renewal`` backs off correctly on the next tick.
+
+        Never raises: every exception this function can encounter is caught
+        here, logged, and turned into a ``None`` return with the attempt
+        recorded -- a renewal hiccup must never be able to take down the
+        heartbeat thread that drives it (see ``HeartbeatThread``'s
+        ``renewal_check`` hook).
+
+    """
+    logger = logging.getLogger(__name__)
+    now = time.time()
+    try:
+        return _renew_inner(identity, now, logger)
+    except Exception as exc:  # renew() must never raise -- see docstring
+        logger.warning("renewal failed unexpectedly: %s", exc, exc_info=True)
+        try:
+            _record_renewal_attempt(identity, now)
+        except Exception:  # best-effort; must not mask the original failure
+            logger.warning("failed to record renewal attempt after unexpected error", exc_info=True)
+        return None

--- a/src/sink/publish/identity.py
+++ b/src/sink/publish/identity.py
@@ -6,18 +6,36 @@ is imported lazily (inside functions) so importing this module never trips
 the package's no-eager-import invariant alongside paho.
 
 Identity is stored as four files under a directory (default
-``~/.bagel/identity``, see ``settings.FLEET_IDENTITY_DIRECTORY``):
-``robot.key`` (mode 0600), ``robot.crt``, ``ca.crt``, and ``identity.yaml``
-(tenant, robot_id, broker_url, enroll_url, expires_at). All writes are
-atomic (sibling tempfile + os.replace).
+``~/.bagel/identity``, see ``settings.FLEET_IDENTITY_DIRECTORY``): a key
+(mode 0600), a cert, a CA cert, and ``identity.yaml``, which carries
+``tenant``, ``robot_id``, ``broker_url``, ``enroll_url``, ``expires_at``,
+and -- a pointer scheme -- the OPTIONAL ``key_file``/``cert_file``/
+``ca_file`` basenames naming the other three files. ``enroll()`` always
+writes them (as ``robot.key``/``robot.crt``/``ca.crt``, the historical fixed
+names) so every identity this module writes carries an explicit pointer;
+``load_identity`` defaults each to its historical fixed name when absent, so
+an identity.yaml written before this scheme existed still loads unchanged.
+``renew()`` is the reason the pointer is optional/overridable in the first
+place: each successful renewal writes its new key/cert (and CA, if the
+server issued one) under fresh, never-before-used basenames rather than
+overwriting the files identity.yaml currently points at -- see its
+docstring for why. All writes are atomic (sibling tempfile + os.replace).
+
+``enroll_url`` and the OPTIONAL ``renew_url`` are both BASE urls (no
+trailing path) -- the client appends ``/v1/enroll`` and ``/v1/renew``
+itself. They commonly point at different hosts entirely: enroll is a
+path-routed HTTPS endpoint (e.g. an ALB), while renew is an mTLS listener on
+the broker itself, which is a separate host:port -- so ``renew()`` targets
+``identity.renew_url`` when the enroll response carried one, falling back to
+``identity.enroll_url`` (today's behavior) when it didn't.
 
 The enrollment token appears in the POST body only. It is never logged,
 never stored, and never embedded in an ``EnrollmentError`` reason.
 
 ``renew()`` (see below) refreshes an existing identity's certificate ahead
 of expiry: ``should_attempt_renewal`` decides when it is due, and ``renew``
-does the mTLS POST + atomic file replacement. See ``renew()``'s docstring
-for the ordering guarantees and what it does NOT do (force a live publisher
+does the mTLS POST + atomic pointer swap. See ``renew()``'s docstring for
+the ordering guarantees and what it does NOT do (force a live publisher
 reconnect).
 """
 
@@ -55,7 +73,15 @@ _RENEWAL_NOT_OFFERED_STATUSES = (404, 501)
 
 @dataclasses.dataclass
 class Identity:
-    """A robot's enrolled fleet identity: certs on disk plus broker metadata."""
+    """A robot's enrolled fleet identity: certs on disk plus broker metadata.
+
+    ``renew_url``, when set, is where ``renew()`` targets its POST instead of
+    ``enroll_url`` -- see the module docstring for why enroll and renew can
+    live on different hosts. Defaults to ``None`` (no renew endpoint known:
+    ``renew()`` falls back to ``enroll_url``) so every existing construction
+    of this dataclass -- and every identity.yaml written before this field
+    existed -- keeps working unchanged.
+    """
 
     tenant: str
     robot_id: str
@@ -65,6 +91,7 @@ class Identity:
     key_path: pathlib.Path
     cert_path: pathlib.Path
     ca_path: pathlib.Path
+    renew_url: str | None = None
 
     @property
     def robot(self) -> str:
@@ -133,7 +160,11 @@ def enroll(token: str, enroll_url: str, directory: pathlib.Path) -> Identity:
     POSTs ``{"token": token, "csr_pem": ...}`` to ``{enroll_url}/v1/enroll``. On a
     200 response, writes ``robot.key`` (0600), ``robot.crt``, ``ca.crt``, and
     ``identity.yaml`` atomically under ``directory`` and returns the resulting
-    Identity. The token is sent in the request body only -- it is never logged
+    Identity. If the response carries an OPTIONAL ``renew_url`` (see the
+    module docstring: renew commonly lives on a different host than enroll),
+    it is stored too and ``renew()`` targets it instead of ``enroll_url``;
+    absent, ``renew()`` falls back to ``enroll_url``. The token is sent in
+    the request body only -- it is never logged
     and never appears in a raised error's message: an other-status HTTPError
     body is echoed as a snippet for diagnostics, but the literal token is
     redacted from it first (defense against a debug-mode server, a reflecting
@@ -206,13 +237,30 @@ def enroll(token: str, enroll_url: str, directory: pathlib.Path) -> Identity:
     _atomic_write(cert_path, payload["cert_pem"].encode())
     _atomic_write(ca_path, payload["ca_pem"].encode())
 
+    # renew_url is OPTIONAL in the response (see the module docstring): a
+    # server that doesn't send one means "renew from the same base as
+    # enroll" -- so the key is only written when the response actually
+    # carried it, keeping "absent" and "explicitly the same as enroll_url"
+    # distinguishable on disk.
+    renew_url = payload.get("renew_url")
+
     doc = {
         "tenant": payload["tenant"],
         "robot_id": payload["robot_id"],
         "broker_url": payload["broker_url"],
         "enroll_url": enroll_url,
         "expires_at": payload["expires_at"],
+        # Pointer fields, written explicitly even though they equal
+        # load_identity's own defaults -- see the module docstring: every
+        # identity this module writes carries an explicit pointer, so the
+        # pointer scheme is the one mechanism rather than "implicit legacy
+        # fixed names vs. explicit renewed names".
+        "key_file": key_path.name,
+        "cert_file": cert_path.name,
+        "ca_file": ca_path.name,
     }
+    if renew_url is not None:
+        doc["renew_url"] = renew_url
     _atomic_write(identity_path, yaml.safe_dump(doc).encode())
 
     return Identity(
@@ -224,11 +272,19 @@ def enroll(token: str, enroll_url: str, directory: pathlib.Path) -> Identity:
         key_path=key_path,
         cert_path=cert_path,
         ca_path=ca_path,
+        renew_url=renew_url,
     )
 
 
 def load_identity(directory: pathlib.Path) -> Identity:
     """Load a previously stored Identity from ``directory``.
+
+    The key/cert/CA basenames come from identity.yaml's optional
+    ``key_file``/``cert_file``/``ca_file`` pointer fields (see the module
+    docstring), defaulting to the historical fixed names
+    (``robot.key``/``robot.crt``/``ca.crt``) when a field is absent -- so an
+    identity.yaml from before the pointer scheme, or one hand-written
+    without it, still loads correctly.
 
     Raises:
         FleetNotEnrolledError: if identity.yaml is missing, unparsable, missing a
@@ -237,9 +293,6 @@ def load_identity(directory: pathlib.Path) -> Identity:
     """
     directory = pathlib.Path(directory)
     identity_path = directory / "identity.yaml"
-    key_path = directory / "robot.key"
-    cert_path = directory / "robot.crt"
-    ca_path = directory / "ca.crt"
 
     try:
         text = identity_path.read_text()
@@ -276,6 +329,11 @@ def load_identity(directory: pathlib.Path) -> Identity:
     if missing:
         raise FleetNotEnrolledError(f"identity.yaml at {identity_path} missing: {missing}")
 
+    key_path = directory / data.get("key_file", "robot.key")
+    cert_path = directory / data.get("cert_file", "robot.crt")
+    ca_path = directory / data.get("ca_file", "ca.crt")
+    renew_url = data.get("renew_url")  # optional -- absent means "fall back to enroll_url"
+
     for path in (key_path, cert_path, ca_path):
         if not path.is_file():
             raise FleetNotEnrolledError(f"missing identity file: {path}")
@@ -289,6 +347,7 @@ def load_identity(directory: pathlib.Path) -> Identity:
         key_path=key_path,
         cert_path=cert_path,
         ca_path=ca_path,
+        renew_url=renew_url,
     )
 
 
@@ -352,19 +411,33 @@ def _build_mtls_context(identity: Identity) -> ssl.SSLContext:
     return context
 
 
-def _write_identity_yaml(
-    identity: Identity, *, expires_at: str, last_renewal_attempt_at: float
+def _write_identity_yaml(  # noqa: PLR0913 -- one field per identity.yaml key; splitting hides the pointer's atomicity
+    identity: Identity,
+    *,
+    expires_at: str,
+    last_renewal_attempt_at: float,
+    key_file: str,
+    cert_file: str,
+    ca_file: str,
 ) -> None:
-    """Atomically (re)write ``identity.yaml`` alongside ``identity``'s key file.
+    """Atomically (re)write ``identity.yaml`` -- THE commit point for a renewal.
 
-    Used by both the success and failure paths of ``renew()``: on failure
-    only ``last_renewal_attempt_at`` changes (``expires_at`` is echoed back
-    unchanged); on success both are the new values. Like ``enroll()``, this
-    rewrites the whole document from ``identity``'s known fields rather than
-    reading-modifying-writing the file on disk, so any unknown key a future
-    version added to it (other than the five ``load_identity`` requires plus
-    this one) is not preserved across a renewal -- same tradeoff `enroll()`
-    already makes.
+    This is a single ``_atomic_write`` (sibling tempfile + ``os.replace``, so
+    it is itself atomic: readers only ever see the fully-old or fully-new
+    document, never a partial one). ``renew()`` relies on that: it always
+    finishes writing a COMPLETE, self-consistent key/cert/ca file set under
+    fresh basenames *before* calling this, so this call is the one moment a
+    renewal actually takes effect -- see ``_renew_inner``'s success path and
+    ``renew()``'s docstring for the full crash-safety argument.
+
+    Used by both the success and failure paths of ``renew()``: on failure,
+    ``key_file``/``cert_file``/``ca_file``/``expires_at`` are ``identity``'s
+    CURRENT (unchanged) pointer/expiry -- only ``last_renewal_attempt_at``
+    moves; on success they are the new pointer and the new expiry. Like
+    ``enroll()``, this rewrites the whole document from known fields rather
+    than reading-modifying-writing the file on disk, so any unknown key a
+    future version added to it is not preserved across a renewal -- same
+    tradeoff ``enroll()`` already makes.
     """
     directory = identity.key_path.parent
     doc = {
@@ -374,14 +447,114 @@ def _write_identity_yaml(
         "enroll_url": identity.enroll_url,
         "expires_at": expires_at,
         "last_renewal_attempt_at": last_renewal_attempt_at,
+        "key_file": key_file,
+        "cert_file": cert_file,
+        "ca_file": ca_file,
     }
+    if identity.renew_url is not None:
+        doc["renew_url"] = identity.renew_url
     _atomic_write(directory / "identity.yaml", yaml.safe_dump(doc).encode())
 
 
 def _record_renewal_attempt(identity: Identity, attempt_at: float) -> None:
-    """Persist ``last_renewal_attempt_at`` with ``expires_at`` unchanged (a failed attempt)."""
+    """Persist ``last_renewal_attempt_at``; pointer and ``expires_at`` unchanged (a failed attempt).
+
+    Passes ``identity``'s CURRENT file basenames straight through -- a
+    failed attempt never moves the pointer, so this can't be the thing that
+    turns a matched pair into a mismatched one (see ``renew()``'s
+    docstring).
+    """
     _write_identity_yaml(
-        identity, expires_at=identity.expires_at, last_renewal_attempt_at=attempt_at
+        identity,
+        expires_at=identity.expires_at,
+        last_renewal_attempt_at=attempt_at,
+        key_file=identity.key_path.name,
+        cert_file=identity.cert_path.name,
+        ca_file=identity.ca_path.name,
+    )
+
+
+def _commit_renewed_files(
+    identity: Identity, new_key_pem: bytes, payload: dict, now: float
+) -> Identity:
+    """Commit a renewal via the pointer scheme: write, then swap, then clean up.
+
+    NOT an in-place overwrite of ``identity.key_path``/``cert_path``/
+    ``ca_path`` -- overwriting those in place is exactly what let a crash
+    between the key and cert writes leave identity.yaml's fixed pointer
+    resolving to a mismatched new-key/old-cert pair, permanently:
+    ``is_enrolled()`` still blesses it, and every subsequent renewal's
+    ``_build_mtls_context`` fails the same way forever, since it's the same
+    broken pair being loaded and re-authenticated with each time.
+
+    Instead:
+      1. Write the COMPLETE new file set under fresh, never-before-used
+         basenames. identity.yaml still names the OLD files, which this step
+         never touches -- so a crash anywhere in this step leaves the old
+         pointer resolving to the old, complete, matched, USABLE pair; these
+         new files are just inert orphans until step 2 commits.
+      2. ONE atomic identity.yaml write (``_write_identity_yaml``, itself a
+         single tempfile+os.replace) repoints
+         ``key_file``/``cert_file``/``ca_file`` at the new basenames. This is
+         the only moment the renewal takes effect: a crash before it leaves
+         the old pointer untouched; a crash during/after it means
+         ``os.replace`` either didn't happen (old pointer survives) or fully
+         happened (new pointer, already fully written by step 1) -- never a
+         mix. There is no reachable state where the pointer names a
+         mismatched key/cert pair.
+      3. Best-effort cleanup of the now-superseded old files. Step 2 already
+         committed, so this is pure disk hygiene, not correctness: if it's
+         skipped (a crash) or fails (permissions), the old files are just
+         harmless, unreferenced orphans -- nothing in identity.yaml points at
+         them anymore.
+
+    ``payload`` must already be validated to carry ``cert_pem``/``expires_at``
+    -- this function assumes a well-formed 200 response.
+    """
+    directory = identity.key_path.parent
+    # Nanosecond-precision version tag: guarantees the new basenames never
+    # collide with identity's current ones, or a prior renewal's run
+    # back-to-back -- a collision would mean this renewal's step-1 writes
+    # land on the file identity.yaml CURRENTLY points at, before the step-2
+    # swap, which would recreate exactly the in-place-overwrite hazard this
+    # scheme exists to avoid.
+    version = time.time_ns()
+    new_key_file = f"robot-{version}.key"
+    new_cert_file = f"robot-{version}.crt"
+    write_new_ca = "ca_pem" in payload
+    new_ca_file = f"ca-{version}.crt" if write_new_ca else identity.ca_path.name
+
+    _atomic_write(directory / new_key_file, new_key_pem, mode=0o600)
+    _atomic_write(directory / new_cert_file, payload["cert_pem"].encode())
+    if write_new_ca:
+        _atomic_write(directory / new_ca_file, payload["ca_pem"].encode())
+
+    _write_identity_yaml(
+        identity,
+        expires_at=payload["expires_at"],
+        last_renewal_attempt_at=now,
+        key_file=new_key_file,
+        cert_file=new_cert_file,
+        ca_file=new_ca_file,
+    )
+
+    for old_path in (identity.key_path, identity.cert_path):
+        try:
+            old_path.unlink()
+        except OSError:
+            pass  # orphan is inert -- identity.yaml no longer points at it
+    if write_new_ca:
+        try:
+            identity.ca_path.unlink()
+        except OSError:
+            pass
+
+    return dataclasses.replace(
+        identity,
+        expires_at=payload["expires_at"],
+        key_path=directory / new_key_file,
+        cert_path=directory / new_cert_file,
+        ca_path=directory / new_ca_file,
     )
 
 
@@ -389,8 +562,14 @@ def _renew_inner(  # noqa: PLR0911 -- one early return per distinct failure bran
     identity: Identity, now: float, logger: logging.Logger
 ) -> Identity | None:
     """Attempt the actual renewal; ``renew()`` wraps this in a catch-all safety net."""
-    if not identity.enroll_url.startswith(("https://", "http://")):
-        logger.warning("renewal skipped: enroll_url is not http(s): %s", identity.enroll_url)
+    # renew_url, when the enroll response carried one, else fall back to
+    # enroll_url (today's behavior) -- see the module docstring: enroll and
+    # renew commonly live on different hosts (enroll: path-routed HTTPS;
+    # renew: an mTLS listener on the broker itself), so deriving the renew
+    # target from enroll_url alone would 404 against a real cloud deployment.
+    target_base = identity.renew_url or identity.enroll_url
+    if not target_base.startswith(("https://", "http://")):
+        logger.warning("renewal skipped: renew target is not http(s): %s", target_base)
         _record_renewal_attempt(identity, now)
         return None
 
@@ -398,7 +577,7 @@ def _renew_inner(  # noqa: PLR0911 -- one early return per distinct failure bran
 
     body = json.dumps({"csr_pem": new_csr_pem.decode()}).encode()
     request = urllib.request.Request(  # noqa: S310 -- scheme enforced to http(s) above
-        f"{identity.enroll_url}/v1/renew",
+        f"{target_base}/v1/renew",
         data=body,
         headers={"Content-Type": "application/json"},
     )
@@ -406,7 +585,7 @@ def _renew_inner(  # noqa: PLR0911 -- one early return per distinct failure bran
     try:
         # urlopen raises HTTPError on non-2xx; context= is a no-op for the
         # http:// scheme a test's fake server uses, exercised for real only
-        # against an https:// enroll_url in production.
+        # against an https:// renew target in production.
         with urllib.request.urlopen(request, context=context, timeout=30) as response:  # noqa: S310
             raw = response.read()
     except urllib.error.HTTPError as exc:
@@ -442,38 +621,39 @@ def _renew_inner(  # noqa: PLR0911 -- one early return per distinct failure bran
         _record_renewal_attempt(identity, now)
         return None
 
-    # Key first (0600), then the cert, then (if offered) the CA, then the
-    # yaml pointer document last -- same crash-safety ordering as enroll():
-    # a crash mid-sequence never leaves a readable key with a stale cert
-    # alongside it plus an identity.yaml that still claims the old expiry.
-    _atomic_write(identity.key_path, new_key_pem, mode=0o600)
-    _atomic_write(identity.cert_path, payload["cert_pem"].encode())
-    if "ca_pem" in payload:
-        _atomic_write(identity.ca_path, payload["ca_pem"].encode())
-    _write_identity_yaml(identity, expires_at=payload["expires_at"], last_renewal_attempt_at=now)
-
-    return dataclasses.replace(identity, expires_at=payload["expires_at"])
+    return _commit_renewed_files(identity, new_key_pem, payload, now)
 
 
 def renew(identity: Identity) -> Identity | None:
     """Renew ``identity``'s certificate: a NEW key + CSR, POSTed over mTLS.
 
     Generates a brand new private key and CSR -- not a re-use of the current
-    key -- and POSTs it to ``{identity.enroll_url}/v1/renew`` authenticated
-    with the CURRENT cert/key pair over mTLS (``ssl.SSLContext`` +
-    ``load_cert_chain``/``load_verify_locations``, see
+    key -- and POSTs it to ``{identity.renew_url or identity.enroll_url}/v1/renew``
+    (see the module docstring: enroll and renew commonly live on different
+    hosts) authenticated with the CURRENT cert/key pair over mTLS
+    (``ssl.SSLContext`` + ``load_cert_chain``/``load_verify_locations``, see
     ``_build_mtls_context``). Per spec §6, renewal happens "with a new CSR";
     read strictly, a new CSR implies a new key backing it, so a compromised
     old key is never perpetuated across a renewal.
 
-    On a 200 response, ``robot.key`` (0600), ``robot.crt``, ``ca.crt`` (only
-    if the response carries a ``ca_pem`` -- the server need not re-issue the
-    CA on every renewal), and ``identity.yaml`` (updated ``expires_at`` and
-    ``last_renewal_attempt_at``) are all replaced atomically, and the
-    returned ``Identity`` reflects the new files. On any failure below --
-    including a 501/404 meaning the server does not offer renewal on this
-    deployment yet -- NOTHING is written except ``last_renewal_attempt_at``
-    in ``identity.yaml``: the old key/cert/ca and ``expires_at`` are left
+    On a 200 response, this uses identity.yaml's pointer scheme (see the
+    module docstring) rather than overwriting the current key/cert/ca files
+    in place: the new key (0600), cert, and (only if the response carries a
+    ``ca_pem``) CA are all written under fresh, never-before-used basenames
+    first; THEN one atomic identity.yaml write repoints
+    ``key_file``/``cert_file``/``ca_file`` at them (with the new
+    ``expires_at`` and ``last_renewal_attempt_at``) -- the single moment the
+    renewal takes effect; THEN the now-superseded old files are unlinked,
+    best-effort. An in-place overwrite instead would let a crash between the
+    key and cert writes leave the pointer resolving to a mismatched
+    new-key/old-cert pair FOREVER (``is_enrolled()`` still blesses it, and
+    every subsequent renewal's ``_build_mtls_context`` fails the same way
+    against the same broken pair) -- the pointer scheme makes that state
+    unreachable: identity.yaml always names either the complete old pair or
+    the complete new one, never a mix. On any failure below -- including a
+    501/404 meaning the server does not offer renewal on this deployment yet
+    -- the pointer is NEVER moved: only ``last_renewal_attempt_at`` changes
+    in ``identity.yaml``, and the old key/cert/ca/``expires_at`` are left
     completely untouched, so a failed renewal never leaves the robot with a
     broken or missing identity.
 

--- a/src/sink/publish/identity.py
+++ b/src/sink/publish/identity.py
@@ -62,6 +62,13 @@ def _atomic_write(target: pathlib.Path, data: bytes, *, mode: int | None = None)
     When ``mode`` is given, the temp file's fd is chmod'd before the write so the
     file lands at that mode the instant it becomes visible at ``target`` -- there
     is no window where the final path exists with looser permissions.
+
+    Note: even when ``mode`` is omitted (``robot.crt``, ``ca.crt``,
+    ``identity.yaml``), ``tempfile.mkstemp`` itself creates the temp file at 0600
+    on POSIX, and ``os.replace`` preserves the source inode's mode -- so those
+    files end up 0600 too, stricter than the spec requires (only ``robot.key``
+    is mandated at 0600). Intentional, not a mode explicitly chosen for them;
+    noted here for a future consumer who needs a world/group-readable cert.
     """
     target.parent.mkdir(parents=True, exist_ok=True)
     fd, tmp_name = tempfile.mkstemp(prefix=f".{target.name}.", dir=target.parent)
@@ -111,14 +118,17 @@ def enroll(token: str, enroll_url: str, directory: pathlib.Path) -> Identity:
     200 response, writes ``robot.key`` (0600), ``robot.crt``, ``ca.crt``, and
     ``identity.yaml`` atomically under ``directory`` and returns the resulting
     Identity. The token is sent in the request body only -- it is never logged
-    and never appears in a raised error's message.
+    and never appears in a raised error's message: an other-status HTTPError
+    body is echoed as a snippet for diagnostics, but the literal token is
+    redacted from it first (defense against a debug-mode server, a reflecting
+    proxy/WAF, or a malicious enroll endpoint handing the token straight back).
 
     Raises:
         ValueError: if ``enroll_url`` is not http(s).
         EnrollmentError: on a non-200 response (401 "unknown token", 410
-            "used/expired", other statuses carry a body snippet), a malformed
-            200 body (missing required fields), or a transport failure
-            (status 0, the URLError reason).
+            "used/expired", other statuses carry a token-redacted body
+            snippet), a malformed 200 body (missing required fields), or a
+            transport failure (status 0, the URLError reason).
 
     """
     if not enroll_url.startswith(("https://", "http://")):
@@ -140,7 +150,12 @@ def enroll(token: str, enroll_url: str, directory: pathlib.Path) -> Identity:
             status = response.status
     except urllib.error.HTTPError as exc:
         status = exc.code
-        snippet = exc.read().decode("utf-8", errors="replace")[:200]
+        # The request body carried the token, so an echoing/reflecting server
+        # (debug mode, a WAF, a malicious endpoint) could hand it straight back
+        # in its error body. Redact before truncating -- never truncate first,
+        # or a token straddling the cut point survives partially intact.
+        body_text = exc.read().decode("utf-8", errors="replace")
+        snippet = body_text.replace(token, "***REDACTED***")[:200]
         if status == 401:  # noqa: PLR2004 -- protocol status code, not a magic threshold
             reason = "unknown token"
         elif status == 410:  # noqa: PLR2004 -- protocol status code, not a magic threshold

--- a/src/sink/publish/identity.py
+++ b/src/sink/publish/identity.py
@@ -23,7 +23,11 @@ docstring for why. All writes are atomic (sibling tempfile + os.replace).
 
 ``enroll_url`` and the OPTIONAL ``renew_url`` are both BASE urls (no
 trailing path) -- the client appends ``/v1/enroll`` and ``/v1/renew``
-itself. They commonly point at different hosts entirely: enroll is a
+itself. A trailing slash on the configured base is tolerated: it is
+stripped before the path is appended (so ``.../v1/enroll``, never
+``..//v1/enroll``), but the BASE value itself -- as stored in
+``identity.yaml`` and on the returned ``Identity`` -- is left exactly as
+given. They commonly point at different hosts entirely: enroll is a
 path-routed HTTPS endpoint (e.g. an ALB), while renew is an mTLS listener on
 the broker itself, which is a separate host:port -- so ``renew()`` targets
 ``identity.renew_url`` when the enroll response carried one, falling back to
@@ -93,6 +97,18 @@ class Identity:
     cert_path: pathlib.Path
     ca_path: pathlib.Path
     renew_url: str | None = None
+    last_renewal_attempt_at: float | None = None
+    """Unix epoch seconds of the most recent renewal attempt, on disk or None.
+
+    Populated by ``load_identity`` from identity.yaml's ``last_renewal_attempt_at``
+    (tolerating an absent or wrong-typed value as ``None``) so
+    ``FleetService`` can seed its own in-memory rate-limit tracking from it
+    at construction time -- without this, the daily rate limit
+    (``_RENEWAL_MIN_INTERVAL_S``) resets on every process restart, letting a
+    crashlooping robot inside the 30-day renewal window fire a fresh renewal
+    POST roughly every restart. Defaults to ``None`` so every existing
+    construction of this dataclass keeps working unchanged.
+    """
 
     @property
     def robot(self) -> str:
@@ -114,7 +130,12 @@ def _atomic_write(target: pathlib.Path, data: bytes, *, mode: int | None = None)
     is mandated at 0600). Intentional, not a mode explicitly chosen for them;
     noted here for a future consumer who needs a world/group-readable cert.
     """
-    target.parent.mkdir(parents=True, exist_ok=True)
+    # mode=0o700: the identity directory holds a private key plus mTLS
+    # material, so it should never be group/other-readable. Only applies at
+    # creation time -- an already-existing directory keeps whatever mode it
+    # already has (exist_ok=True), which is fine: this only needs to nail
+    # down the mode the FIRST time this directory is ever created.
+    target.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
     fd, tmp_name = tempfile.mkstemp(prefix=f".{target.name}.", dir=target.parent)
     tmp = pathlib.Path(tmp_name)
     try:
@@ -186,7 +207,7 @@ def enroll(token: str, enroll_url: str, directory: pathlib.Path) -> Identity:
 
     body = json.dumps({"token": token, "csr_pem": csr_pem.decode()}).encode()
     request = urllib.request.Request(  # noqa: S310 -- scheme enforced to http(s) above
-        f"{enroll_url}/v1/enroll",
+        f"{enroll_url.rstrip('/')}/v1/enroll",
         data=body,
         headers={"Content-Type": "application/json"},
     )
@@ -277,6 +298,44 @@ def enroll(token: str, enroll_url: str, directory: pathlib.Path) -> Identity:
     )
 
 
+def _resolve_pointer_field(
+    data: dict, field_name: str, default_name: str, identity_path: pathlib.Path
+) -> str:
+    """Resolve one of identity.yaml's optional key_file/cert_file/ca_file pointers.
+
+    Absent entirely -> ``default_name`` (the historical fixed name -- see
+    ``load_identity``'s docstring). Present but not a ``str`` (e.g. an
+    explicit ``key_file: null``) -> ``FleetNotEnrolledError``: unlike the
+    "absent" case, ``.get(field, default)``'s default would NOT have applied
+    here (the key is present), so silently falling back would hide a corrupt
+    document; raising instead is what makes a hand-edited ``key_file: null``
+    behave like "not enrolled" rather than a raw ``TypeError`` from
+    ``directory / None`` deeper in the caller.
+    """
+    if field_name not in data:
+        return default_name
+    value = data[field_name]
+    if not isinstance(value, str):
+        raise FleetNotEnrolledError(
+            f"identity.yaml at {identity_path} has non-string {field_name}: {value!r}"
+        )
+    return value
+
+
+def _parse_last_renewal_attempt_at(data: dict) -> float | None:
+    """Parse identity.yaml's OPTIONAL ``last_renewal_attempt_at``, tolerantly.
+
+    Unlike the pointer fields, an absent or wrong-typed value here is not
+    treated as corrupt -- there's no crash-risk equivalent of the
+    ``directory / None`` hazard the pointer fields have, so this simply
+    means "no attempt recorded yet" (``None``) rather than raising.
+    """
+    value = data.get("last_renewal_attempt_at")
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        return None
+    return value
+
+
 def load_identity(directory: pathlib.Path) -> Identity:
     """Load a previously stored Identity from ``directory``.
 
@@ -330,10 +389,25 @@ def load_identity(directory: pathlib.Path) -> Identity:
     if missing:
         raise FleetNotEnrolledError(f"identity.yaml at {identity_path} missing: {missing}")
 
-    key_path = directory / data.get("key_file", "robot.key")
-    cert_path = directory / data.get("cert_file", "robot.crt")
-    ca_path = directory / data.get("ca_file", "ca.crt")
+    # expires_at is required (checked above), but a hand-edited or corrupt
+    # document can still carry the right KEY with the wrong type -- notably
+    # an unquoted ISO timestamp, which YAML's implicit resolver parses as a
+    # datetime object, not str. should_attempt_renewal expects a str it can
+    # call .replace() on, so treat a non-str value the same as "not enrolled"
+    # rather than let a TypeError surface later, deep in the renewal path.
+    if not isinstance(expires_at, str):
+        raise FleetNotEnrolledError(
+            f"identity.yaml at {identity_path} has non-string expires_at: {expires_at!r}"
+        )
+
+    # The three pointer fields are OPTIONAL (see the module docstring and
+    # `_resolve_pointer_field`'s docstring for the absent-vs-wrong-type
+    # distinction that matters here).
+    key_path = directory / _resolve_pointer_field(data, "key_file", "robot.key", identity_path)
+    cert_path = directory / _resolve_pointer_field(data, "cert_file", "robot.crt", identity_path)
+    ca_path = directory / _resolve_pointer_field(data, "ca_file", "ca.crt", identity_path)
     renew_url = data.get("renew_url")  # optional -- absent means "fall back to enroll_url"
+    last_renewal_attempt_at = _parse_last_renewal_attempt_at(data)
 
     for path in (key_path, cert_path, ca_path):
         if not path.is_file():
@@ -349,6 +423,7 @@ def load_identity(directory: pathlib.Path) -> Identity:
         cert_path=cert_path,
         ca_path=ca_path,
         renew_url=renew_url,
+        last_renewal_attempt_at=last_renewal_attempt_at,
     )
 
 
@@ -556,6 +631,7 @@ def _commit_renewed_files(
         key_path=directory / new_key_file,
         cert_path=directory / new_cert_file,
         ca_path=directory / new_ca_file,
+        last_renewal_attempt_at=now,
     )
 
 
@@ -578,7 +654,7 @@ def _renew_inner(  # noqa: PLR0911 -- one early return per distinct failure bran
 
     body = json.dumps({"csr_pem": new_csr_pem.decode()}).encode()
     request = urllib.request.Request(  # noqa: S310 -- scheme enforced to http(s) above
-        f"{target_base}/v1/renew",
+        f"{target_base.rstrip('/')}/v1/renew",
         data=body,
         headers={"Content-Type": "application/json"},
     )

--- a/src/sink/publish/identity.py
+++ b/src/sink/publish/identity.py
@@ -54,11 +54,13 @@ import tempfile
 import time
 import urllib.error
 import urllib.request
+from urllib.parse import urlparse
 
 import yaml
 
 from settings import settings
 from src.sink.publish import EnrollmentError, FleetNotEnrolledError
+from src.sink.publish import connect as _connect
 
 _REQUIRED_RESPONSE_FIELDS = (
     "cert_pem",
@@ -74,6 +76,29 @@ _RENEWAL_MIN_INTERVAL_S = 86400
 # Statuses the cloud uses to mean "renewal isn't offered on this deployment
 # yet" (the flag is off) rather than "the request failed" -- expected, quiet.
 _RENEWAL_NOT_OFFERED_STATUSES = (404, 501)
+
+
+def _url_passes_scheme_gate(url: str) -> bool:
+    """Whether `url` may be used for an enroll/renew POST (Codex review).
+
+    Mirrors connect.py's own mqtt(s):// transport policy exactly, reusing
+    (not duplicating) its ``_is_local_or_private`` helper: ``https://`` is
+    always fine; plaintext ``http://`` is fine only when the host is
+    loopback/private, or when ``settings.FLEET_DEV_INSECURE`` is set (local
+    development only) -- otherwise the one-time enrollment token (or, for
+    renew, the mTLS-authenticated request) would go out in cleartext to an
+    arbitrary nonlocal host. Any other scheme (including no scheme at all)
+    fails the gate; callers already reject those separately with a more
+    specific error before this is even consulted.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme == "https":
+        return True
+    if parsed.scheme != "http":
+        return False
+    if settings.FLEET_DEV_INSECURE:
+        return True
+    return bool(parsed.hostname) and _connect._is_local_or_private(parsed.hostname)
 
 
 @dataclasses.dataclass
@@ -196,12 +221,18 @@ def enroll(token: str, enroll_url: str, directory: pathlib.Path) -> Identity:
         ValueError: if ``enroll_url`` is not http(s).
         EnrollmentError: on a non-200 response (401 "unknown token", 410
             "used/expired", other statuses carry a token-redacted body
-            snippet), a malformed 200 body (missing required fields), or a
-            transport failure (status 0, the URLError reason).
+            snippet), a malformed 200 body (missing required fields), a
+            transport failure (status 0, the URLError reason), or an
+            ``enroll_url`` that fails the scheme gate (status 0, reason
+            "insecure enroll_url" -- see ``_url_passes_scheme_gate``: a
+            nonlocal ``http://`` URL without ``FLEET_DEV_INSECURE`` would
+            send the one-time token in cleartext).
 
     """
     if not enroll_url.startswith(("https://", "http://")):
         raise ValueError(f"enroll_url must be http(s): {enroll_url}")
+    if not _url_passes_scheme_gate(enroll_url):
+        raise EnrollmentError(0, "insecure enroll_url")
 
     private_key_pem, csr_pem = generate_key_and_csr()
 
@@ -647,6 +678,17 @@ def _renew_inner(  # noqa: PLR0911 -- one early return per distinct failure bran
     target_base = identity.renew_url or identity.enroll_url
     if not target_base.startswith(("https://", "http://")):
         logger.warning("renewal skipped: renew target is not http(s): %s", target_base)
+        _record_renewal_attempt(identity, now)
+        return None
+    # Same scheme gate as enroll() (Codex review), applied here at USE time
+    # since the renew target is read from stored/on-disk state rather than
+    # validated once at enrollment: a nonlocal http:// target would send
+    # the mTLS-authenticated renewal request in cleartext. renew() never
+    # raises (see its docstring), so an insecure target is treated the same
+    # as the "not http(s) at all" branch above -- logged, attempt recorded,
+    # None returned.
+    if not _url_passes_scheme_gate(target_base):
+        logger.warning("renewal skipped: insecure renew target: %s", target_base)
         _record_renewal_attempt(identity, now)
         return None
 

--- a/src/sink/publish/identity.py
+++ b/src/sink/publish/identity.py
@@ -1,0 +1,270 @@
+"""Fleet enrollment client: keygen, CSR, identity storage (spec §6).
+
+The private key never leaves the process: it is generated on the robot,
+only the CSR (public key + advisory CN) crosses the network. ``cryptography``
+is imported lazily (inside functions) so importing this module never trips
+the package's no-eager-import invariant alongside paho.
+
+Identity is stored as four files under a directory (default
+``~/.bagel/identity``, see ``settings.FLEET_IDENTITY_DIRECTORY``):
+``robot.key`` (mode 0600), ``robot.crt``, ``ca.crt``, and ``identity.yaml``
+(tenant, robot_id, broker_url, enroll_url, expires_at). All writes are
+atomic (sibling tempfile + os.replace).
+
+The enrollment token appears in the POST body only. It is never logged,
+never stored, and never embedded in an ``EnrollmentError`` reason.
+"""
+
+import dataclasses
+import json
+import os
+import pathlib
+import tempfile
+import urllib.error
+import urllib.request
+
+import yaml
+
+from src.sink.publish import EnrollmentError, FleetNotEnrolledError
+
+_REQUIRED_RESPONSE_FIELDS = (
+    "cert_pem",
+    "ca_pem",
+    "broker_url",
+    "tenant",
+    "robot_id",
+    "expires_at",
+)
+
+
+@dataclasses.dataclass
+class Identity:
+    """A robot's enrolled fleet identity: certs on disk plus broker metadata."""
+
+    tenant: str
+    robot_id: str
+    broker_url: str
+    enroll_url: str
+    expires_at: str
+    key_path: pathlib.Path
+    cert_path: pathlib.Path
+    ca_path: pathlib.Path
+
+    @property
+    def robot(self) -> str:
+        """The tenant/robot_id identity string used by Spool.for_robot / MqttPublisher."""
+        return f"{self.tenant}/{self.robot_id}"
+
+
+def _atomic_write(target: pathlib.Path, data: bytes, *, mode: int | None = None) -> None:
+    """Write ``data`` to ``target`` atomically via a sibling tempfile + os.replace.
+
+    When ``mode`` is given, the temp file's fd is chmod'd before the write so the
+    file lands at that mode the instant it becomes visible at ``target`` -- there
+    is no window where the final path exists with looser permissions.
+    """
+    target.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{target.name}.", dir=target.parent)
+    tmp = pathlib.Path(tmp_name)
+    try:
+        if mode is not None:
+            os.fchmod(fd, mode)
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(data)
+        os.replace(tmp, target)
+    finally:
+        tmp.unlink(missing_ok=True)
+
+
+def generate_key_and_csr(common_name: str = "robot") -> tuple[bytes, bytes]:
+    """Generate an EC (SECP256R1) private key and a CSR for it.
+
+    Returns:
+        (private_key_pem, csr_pem): the private key as PKCS8 PEM (unencrypted --
+        it never leaves the process) and the CSR as PEM. The CSR's subject CN is
+        advisory only: the enrollment server assigns the real robot identity and
+        forces the CN it signs against.
+
+    """
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import ec
+    from cryptography.x509.oid import NameOID
+
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    private_key_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    csr = x509.CertificateSigningRequestBuilder(
+        subject_name=x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, common_name)])
+    ).sign(private_key, hashes.SHA256())
+    csr_pem = csr.public_bytes(serialization.Encoding.PEM)
+    return private_key_pem, csr_pem
+
+
+def enroll(token: str, enroll_url: str, directory: pathlib.Path) -> Identity:
+    """Enroll this robot: keygen, POST the CSR, store the returned identity.
+
+    POSTs ``{"token": token, "csr_pem": ...}`` to ``{enroll_url}/v1/enroll``. On a
+    200 response, writes ``robot.key`` (0600), ``robot.crt``, ``ca.crt``, and
+    ``identity.yaml`` atomically under ``directory`` and returns the resulting
+    Identity. The token is sent in the request body only -- it is never logged
+    and never appears in a raised error's message.
+
+    Raises:
+        ValueError: if ``enroll_url`` is not http(s).
+        EnrollmentError: on a non-200 response (401 "unknown token", 410
+            "used/expired", other statuses carry a body snippet), a malformed
+            200 body (missing required fields), or a transport failure
+            (status 0, the URLError reason).
+
+    """
+    if not enroll_url.startswith(("https://", "http://")):
+        raise ValueError(f"enroll_url must be http(s): {enroll_url}")
+
+    private_key_pem, csr_pem = generate_key_and_csr()
+
+    body = json.dumps({"token": token, "csr_pem": csr_pem.decode()}).encode()
+    request = urllib.request.Request(  # noqa: S310 -- scheme enforced to http(s) above
+        f"{enroll_url}/v1/enroll",
+        data=body,
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        # urlopen raises HTTPError on non-2xx, so a rejected/failed enroll
+        # takes the except branches below rather than falling through.
+        with urllib.request.urlopen(request, timeout=30) as response:  # noqa: S310
+            raw = response.read()
+            status = response.status
+    except urllib.error.HTTPError as exc:
+        status = exc.code
+        snippet = exc.read().decode("utf-8", errors="replace")[:200]
+        if status == 401:  # noqa: PLR2004 -- protocol status code, not a magic threshold
+            reason = "unknown token"
+        elif status == 410:  # noqa: PLR2004 -- protocol status code, not a magic threshold
+            reason = "used/expired"
+        else:
+            reason = snippet or (exc.reason if isinstance(exc.reason, str) else str(exc.reason))
+        raise EnrollmentError(status, reason) from exc
+    except urllib.error.URLError as exc:
+        raise EnrollmentError(0, str(exc.reason)) from exc
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise EnrollmentError(status, f"malformed response: {exc}") from exc
+
+    if not isinstance(payload, dict):
+        raise EnrollmentError(status, "malformed response: not a JSON object")
+
+    missing = [field for field in _REQUIRED_RESPONSE_FIELDS if field not in payload]
+    if missing:
+        raise EnrollmentError(status, f"malformed response: missing {missing}")
+
+    directory = pathlib.Path(directory)
+    key_path = directory / "robot.key"
+    cert_path = directory / "robot.crt"
+    ca_path = directory / "ca.crt"
+    identity_path = directory / "identity.yaml"
+
+    # Key first (0600), then the certs, then the yaml pointer document --
+    # a crash mid-sequence never leaves a readable key with no cert alongside it.
+    _atomic_write(key_path, private_key_pem, mode=0o600)
+    _atomic_write(cert_path, payload["cert_pem"].encode())
+    _atomic_write(ca_path, payload["ca_pem"].encode())
+
+    doc = {
+        "tenant": payload["tenant"],
+        "robot_id": payload["robot_id"],
+        "broker_url": payload["broker_url"],
+        "enroll_url": enroll_url,
+        "expires_at": payload["expires_at"],
+    }
+    _atomic_write(identity_path, yaml.safe_dump(doc).encode())
+
+    return Identity(
+        tenant=payload["tenant"],
+        robot_id=payload["robot_id"],
+        broker_url=payload["broker_url"],
+        enroll_url=enroll_url,
+        expires_at=payload["expires_at"],
+        key_path=key_path,
+        cert_path=cert_path,
+        ca_path=ca_path,
+    )
+
+
+def load_identity(directory: pathlib.Path) -> Identity:
+    """Load a previously stored Identity from ``directory``.
+
+    Raises:
+        FleetNotEnrolledError: if identity.yaml is missing, unparsable, missing a
+            required field, or any of the three PEM files is absent.
+
+    """
+    directory = pathlib.Path(directory)
+    identity_path = directory / "identity.yaml"
+    key_path = directory / "robot.key"
+    cert_path = directory / "robot.crt"
+    ca_path = directory / "ca.crt"
+
+    try:
+        text = identity_path.read_text()
+    except OSError as exc:
+        raise FleetNotEnrolledError(f"no identity at {directory}: {exc}") from exc
+
+    try:
+        data = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise FleetNotEnrolledError(f"corrupt identity.yaml at {identity_path}: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise FleetNotEnrolledError(f"corrupt identity.yaml at {identity_path}: not a mapping")
+
+    # .get() rather than [] indexing: keeps this loader tolerant of unknown/future
+    # optional keys (e.g. a later last_renewal_attempt_at) -- only these five are
+    # required today.
+    tenant = data.get("tenant")
+    robot_id = data.get("robot_id")
+    broker_url = data.get("broker_url")
+    enroll_url = data.get("enroll_url")
+    expires_at = data.get("expires_at")
+    missing = [
+        name
+        for name, value in (
+            ("tenant", tenant),
+            ("robot_id", robot_id),
+            ("broker_url", broker_url),
+            ("enroll_url", enroll_url),
+            ("expires_at", expires_at),
+        )
+        if value is None
+    ]
+    if missing:
+        raise FleetNotEnrolledError(f"identity.yaml at {identity_path} missing: {missing}")
+
+    for path in (key_path, cert_path, ca_path):
+        if not path.is_file():
+            raise FleetNotEnrolledError(f"missing identity file: {path}")
+
+    return Identity(
+        tenant=tenant,
+        robot_id=robot_id,
+        broker_url=broker_url,
+        enroll_url=enroll_url,
+        expires_at=expires_at,
+        key_path=key_path,
+        cert_path=cert_path,
+        ca_path=ca_path,
+    )
+
+
+def is_enrolled(directory: pathlib.Path) -> bool:
+    """Return True iff a complete, parsable identity is stored under ``directory``."""
+    try:
+        load_identity(directory)
+    except FleetNotEnrolledError:
+        return False
+    return True

--- a/src/sink/publish/mqtt.py
+++ b/src/sink/publish/mqtt.py
@@ -150,7 +150,15 @@ class MqttPublisher(Publisher):
         paho = _paho()
         client = paho.Client(
             callback_api_version=paho.CallbackAPIVersion.VERSION2,
-            client_id=f"bagel-{self._tenant}-{self._robot}",
+            # "/" is outside both id charsets (robot ids match
+            # ^[a-z0-9][a-z0-9_-]{0,62}$; tenant ids are Cognito-derived
+            # without "/"), so this delimiter is provably collision-free --
+            # unlike the old "bagel-{tenant}-{robot}" hyphen join, where
+            # ("acme-west", "r7") and ("acme", "west-r7") both produced
+            # "bagel-acme-west-r7" (Codex review). Mirrors the cert CN's
+            # delimiter. Must stay deterministic per (tenant, robot):
+            # reconnect displacement semantics depend on it.
+            client_id=f"bagel/{self._tenant}/{self._robot}",
             protocol=paho.MQTTv5,
         )
         client.will_set(

--- a/src/sink/publish/mqtt.py
+++ b/src/sink/publish/mqtt.py
@@ -96,6 +96,36 @@ class MqttPublisher(Publisher):
         self.reconnects = 0
         self._finalizer = weakref.finalize(self, _finalize, None)
 
+    def set_tls(
+        self,
+        *,
+        tls_ca_certs: str | None,
+        tls_certfile: str | None,
+        tls_keyfile: str | None,
+    ) -> None:
+        """Atomically replace the TLS material used by the NEXT `connect()`.
+
+        Assigns a brand-new dict to `self._tls` rather than mutating the
+        existing one in place -- a single reference assignment is safe
+        against a background thread (e.g. `StreamRouter`'s reconnect loop)
+        reading `self._tls` mid-`connect()`; it always sees either the
+        fully-old or the fully-new dict, never a half-updated mix. This
+        exists for the certificate-renewal path (see `identity.renew()`'s
+        docstring): once a renewal has rotated the cert/key files on disk,
+        this is the seam that tells the LIVE publisher about the new paths
+        before its next reconnect, so it doesn't keep trying (and failing)
+        to load the now-deleted old files.
+
+        Does not itself force a reconnect or touch an already-open
+        connection -- the currently connected client, if any, keeps running
+        on the old material until its own next `connect()` call.
+        """
+        self._tls = {
+            "ca_certs": tls_ca_certs,
+            "certfile": tls_certfile,
+            "keyfile": tls_keyfile,
+        }
+
     def connect(self) -> None:
         """Build the paho client, arm the last-will, and connect.
 

--- a/src/sink/publish/router.py
+++ b/src/sink/publish/router.py
@@ -224,6 +224,12 @@ class StreamRouter(threading.Thread):
         that is merely still offline -- log it, record it as `_fatal_error`,
         and exit the loop so `alive`/`last_error` surface it to
         `FleetService.status()`.
+
+        On a clean exit (the stop signal, not a fatal `_tick` error), this
+        calls `_final_flush()` as the very last thing before returning --
+        see its docstring for why samples the tap already accepted (via
+        `offer()`) but that hadn't yet crossed a flush boundary would
+        otherwise be silently dropped on `stop()` (Codex review).
         """
         while not self._stop_event.is_set():
             try:
@@ -232,6 +238,37 @@ class StreamRouter(threading.Thread):
                 logging.getLogger(__name__).exception("StreamRouter thread died")
                 self._fatal_error = repr(exc)
                 return
+        self._final_flush()
+
+    def _final_flush(self) -> None:
+        """Drain the queue into the core and spool whatever it hands back, once.
+
+        Runs as the last act of `run()`, after the stop signal has been
+        observed and the tick loop has exited -- entirely on this thread, so
+        it never races a concurrent `_tick()` touching the same
+        `_core`/`_queue`/`_spool` (Codex review: `stop()` doing this
+        directly on the CALLER's thread instead would race the router
+        thread's own in-flight `_tick`). Mirrors `_tick`'s own
+        drain-then-offer-then-flush-then-spool path, minus `_pump` --
+        publishing the result is not this method's job, only making sure it
+        is durably spooled for the router's normal replay-on-restart path
+        (or the next `_pump` after a `resume()`) to pick up.
+
+        `pause(discard=True)` is unaffected: it flushes here same as any
+        other stop, then FleetService acks past the newly-spooled batch's
+        seq, same as it always could for anything already in the spool.
+        """
+        while True:
+            samples = self._queue.drain(max_items=500, timeout_s=0.0)
+            if not samples:
+                break
+            for topic, t, msg in samples:
+                self._core.offer(topic, t, msg)
+        batch = self._core.flush(time.time())
+        if batch is not None:
+            seq = self._spool.next_seq("channels")
+            batch["seq"] = seq
+            self._spool.append("channels", seq, batch)
 
     def _tick(self, now: float) -> None:
         """One iteration: drain+offer+maybe-flush-to-spool, then publish.

--- a/src/sink/publish/router.py
+++ b/src/sink/publish/router.py
@@ -151,7 +151,19 @@ class RouterCore:
                 self._pending[key] = (t, value)
 
     def flush(self, t_batch: float) -> dict | None:
-        """Pop all pending slot-winners, ordered by t, into a batch (or None)."""
+        """Pop up to `max_samples` pending slot-winners, ordered by t, into a batch.
+
+        Returns `None` if nothing is pending. `max_samples` caps this call's
+        OWN output, not just a trigger threshold on `should_flush` (Codex
+        review: it used to empty the ENTIRE `_pending` dict into one batch
+        regardless of size, so a wide manifest with many channels
+        distinct-slot-winning in the same interval could produce an
+        arbitrarily large batch). If more than `max_samples` slot-winners are
+        pending, the remainder stays in `_pending`, in the same t-order, for
+        a subsequent `flush()` call to pick up -- the caller (`_tick`) loops
+        calling this until it returns `None`, giving each chunk its own seq
+        and spool append.
+        """
         self._last_flush = t_batch
         if not self._pending:
             return None
@@ -159,12 +171,13 @@ class RouterCore:
             ((chan_name, slot, t, v) for (chan_name, slot), (t, v) in self._pending.items()),
             key=lambda item: item[2],
         )
-        for chan_name, slot, _t, _v in items:
+        chunk = items[: self.max_samples]
+        for chan_name, slot, _t, _v in chunk:
             prev = self._last_emitted_slot.get(chan_name)
             if prev is None or slot > prev:
                 self._last_emitted_slot[chan_name] = slot
-        self._pending.clear()
-        samples = [{"c": chan_name, "t": t, "v": v} for chan_name, _slot, t, v in items]
+            del self._pending[(chan_name, slot)]
+        samples = [{"c": chan_name, "t": t, "v": v} for chan_name, _slot, t, v in chunk]
         return {"v": 1, "t_batch": t_batch, "samples": samples}
 
     def should_flush(self, now: float, pending_count: int) -> bool:
@@ -264,8 +277,8 @@ class StreamRouter(threading.Thread):
                 break
             for topic, t, msg in samples:
                 self._core.offer(topic, t, msg)
-        batch = self._core.flush(time.time())
-        if batch is not None:
+        now = time.time()
+        while (batch := self._core.flush(now)) is not None:
             seq = self._spool.next_seq("channels")
             batch["seq"] = seq
             self._spool.append("channels", seq, batch)
@@ -276,14 +289,20 @@ class StreamRouter(threading.Thread):
         Unit tests drive this directly with controlled `now` values instead
         of sleeping; `queue.drain`'s bounded timeout is what paces the real
         thread loop in `run()`.
+
+        `core.flush(now)` caps its own output at `max_samples` (Codex
+        review), so a should_flush-triggered flush loops here until it
+        returns `None` -- every chunk gets its own seq and its own spool
+        append, so a wide manifest's oversized batch is fully drained and
+        durably spooled within this one tick rather than trickling out over
+        several.
         """
         timeout_s = min(0.2, self._core.flush_interval_s)
         samples = self._queue.drain(max_items=500, timeout_s=timeout_s)
         for topic, t, msg in samples:
             self._core.offer(topic, t, msg)
         if self._core.should_flush(now, self._core.pending_count):
-            batch = self._core.flush(now)
-            if batch is not None:
+            while (batch := self._core.flush(now)) is not None:
                 seq = self._spool.next_seq("channels")
                 batch["seq"] = seq
                 self._spool.append("channels", seq, batch)

--- a/src/sink/publish/router.py
+++ b/src/sink/publish/router.py
@@ -308,9 +308,25 @@ class StreamRouter(threading.Thread):
         self._next_attempt = now + random.uniform(0, self._backoff)  # noqa: S311 -- jitter, not crypto
 
     def stop(self) -> None:
-        """Signal the loop to stop and join with a bounded timeout."""
+        """Signal the loop to stop and join with a bounded timeout.
+
+        The join timeout (12s) is deliberately longer than the 10s
+        `wait_for_publish` bound inside `MqttPublisher.publish` (Codex
+        review): a 5s join could return while `_pump` was still blocked
+        inside a QoS-1 publish call, so termination wasn't actually
+        guaranteed before a caller (e.g. `pause()`/`resume()`) proceeded. If
+        the thread is somehow still alive after this longer join, that is
+        logged rather than silently ignored.
+
+        `_online` is reset to False here too (Codex review): it used to
+        survive a clean stop unchanged, so `FleetService.status()` kept
+        reporting `online: true` for a router that had already stopped.
+        """
         self._stop_event.set()
-        self.join(timeout=5)
+        self.join(timeout=12.0)
+        if self.is_alive():
+            logging.getLogger(__name__).warning("router thread did not terminate")
+        self._online = False
 
     @property
     def online(self) -> bool:

--- a/src/sink/publish/service.py
+++ b/src/sink/publish/service.py
@@ -30,6 +30,7 @@ from settings import settings
 from src.sink.publish import require_fleet
 from src.sink.publish.config import StreamsConfig
 from src.sink.publish.heartbeat import HeartbeatThread, build_heartbeat, disk_free
+from src.sink.publish.identity import Identity, renew, should_attempt_renewal
 from src.sink.publish.publisher import Publisher
 from src.sink.publish.router import RouterCore, SampleQueue, StreamRouter
 from src.sink.publish.spool import Spool
@@ -39,13 +40,39 @@ class FleetService:
     """Owns one robot's fleet-streaming runtime: tap wiring + router + heartbeat."""
 
     def __init__(
-        self, *, sink: object, streams: StreamsConfig, publisher: Publisher, spool: Spool
+        self,
+        *,
+        sink: object,
+        streams: StreamsConfig,
+        publisher: Publisher,
+        spool: Spool,
+        identity: Identity | None = None,
     ) -> None:
-        """Store the collaborators; does not touch the sink, publisher, or spool yet."""
+        """Store the collaborators; does not touch the sink, publisher, or spool yet.
+
+        ``identity``, when given, is this robot's enrolled fleet identity
+        (spec §6). It is optional -- most tests and a dev-insecure,
+        unenrolled robot construct this service with none -- but when
+        present it does two things: `status()`/the heartbeat payload carry
+        `cert_expires_at`, and a certificate-renewal closure
+        (`should_attempt_renewal`/`renew`) is wired into the
+        `HeartbeatThread`'s `renewal_check` hook so renewal is attempted
+        automatically, once per heartbeat tick, when it's due. See
+        `_renewal_check`.
+        """
         self._sink = sink
         self._streams = streams
         self._publisher = publisher
         self._spool = spool
+        self._identity = identity
+        # In-memory only: this service's lifetime is the process's lifetime
+        # (see module docstring, ruling B), so there is no cross-restart
+        # state to recover here. `renew()` itself persists
+        # `last_renewal_attempt_at` to identity.yaml regardless of outcome;
+        # a fresh process simply doesn't consult that on-disk value and
+        # starts as if no attempt has been made, which is safe (worst case:
+        # one avoidable extra attempt right after a restart).
+        self._last_renewal_attempt_at: float | None = None
 
         self._resolved: list = []
         self._schema_payload: dict = {"v": 1, "channels": []}
@@ -194,6 +221,7 @@ class FleetService:
             ),
             "heartbeat_alive": self._heartbeat.alive if self._heartbeat is not None else False,
             "heartbeat_error": self._heartbeat.last_error if self._heartbeat is not None else None,
+            "cert_expires_at": self._identity.expires_at if self._identity is not None else None,
         }
 
     # -- internals ---------------------------------------------------------------
@@ -210,7 +238,10 @@ class FleetService:
             writer.set_tap(tap)
         self._started_at = time.time()
         self._heartbeat = HeartbeatThread(
-            self._publisher, self._heartbeat_payload, spool=self._spool
+            self._publisher,
+            self._heartbeat_payload,
+            spool=self._spool,
+            renewal_check=self._renewal_check if self._identity is not None else None,
         )
         self._router.start()
         self._heartbeat.start()
@@ -232,4 +263,32 @@ class FleetService:
             spool_stats=self._spool.stats(),
             disk_free_bytes=disk_free(settings.CACHE_DIRECTORY),
             reconnects=getattr(self._publisher, "reconnects", 0),
+            cert_expires_at=self._identity.expires_at if self._identity is not None else None,
         )
+
+    def _renewal_check(self) -> None:
+        """Renew `self._identity`'s certificate if it's due (wired as the heartbeat's hook).
+
+        Only ever installed on the `HeartbeatThread` when this service was
+        constructed with an `identity` (see `_launch_runtime`), so
+        `self._identity` is never `None` here. On a successful renewal,
+        `self._identity` is swapped to the new `Identity` `renew()` returns
+        -- but the LIVE publisher connection keeps authenticating with the
+        OLD cert until its own next reconnect; this does not force one (see
+        `identity.renew`'s docstring).
+
+        Exceptions are deliberately NOT caught here: `HeartbeatThread._tick`
+        already runs `renewal_check` inside its own try/except, and `renew()`
+        itself never raises -- so there is nothing left for this method to
+        guard against beyond what those two already cover.
+        """
+        if self._identity is None:  # pragma: no cover -- guarded by _launch_runtime's wiring
+            return
+        now = time.time()
+        due = should_attempt_renewal(now, self._identity.expires_at, self._last_renewal_attempt_at)
+        if not due:
+            return
+        self._last_renewal_attempt_at = now
+        new_identity = renew(self._identity)
+        if new_identity is not None:
+            self._identity = new_identity

--- a/src/sink/publish/service.py
+++ b/src/sink/publish/service.py
@@ -65,14 +65,17 @@ class FleetService:
         self._publisher = publisher
         self._spool = spool
         self._identity = identity
-        # In-memory only: this service's lifetime is the process's lifetime
-        # (see module docstring, ruling B), so there is no cross-restart
-        # state to recover here. `renew()` itself persists
-        # `last_renewal_attempt_at` to identity.yaml regardless of outcome;
-        # a fresh process simply doesn't consult that on-disk value and
-        # starts as if no attempt has been made, which is safe (worst case:
-        # one avoidable extra attempt right after a restart).
-        self._last_renewal_attempt_at: float | None = None
+        # Seeded from identity.yaml's on-disk `last_renewal_attempt_at` (via
+        # `load_identity`), not always `None`: this service's own lifetime is
+        # the process's lifetime (see module docstring, ruling B), so this
+        # field is never itself persisted again mid-run -- but the ON-DISK
+        # value it started from must still be honored on a fresh process, or
+        # a crashlooping robot inside the 30-day renewal window would fire a
+        # fresh renewal attempt on every restart, ignoring the daily rate
+        # limit (`_RENEWAL_MIN_INTERVAL_S`) entirely.
+        self._last_renewal_attempt_at: float | None = (
+            identity.last_renewal_attempt_at if identity is not None else None
+        )
 
         self._resolved: list = []
         self._schema_payload: dict = {"v": 1, "channels": []}
@@ -281,6 +284,13 @@ class FleetService:
         already runs `renewal_check` inside its own try/except, and `renew()`
         itself never raises -- so there is nothing left for this method to
         guard against beyond what those two already cover.
+
+        NOTE: `renew()` does a real mTLS POST with a 30s `urlopen` timeout,
+        and this runs synchronously on the heartbeat thread (it IS the
+        thread's `renewal_check` hook) -- so a slow/hanging renewal endpoint
+        can delay one heartbeat tick by up to a full interval. This happens
+        at most ~once/day (`_RENEWAL_MIN_INTERVAL_S`) and only in the last 30
+        days before cert expiry; accepted trade-off, not a bug.
         """
         if self._identity is None:  # pragma: no cover -- guarded by _launch_runtime's wiring
             return
@@ -291,4 +301,18 @@ class FleetService:
         self._last_renewal_attempt_at = now
         new_identity = renew(self._identity)
         if new_identity is not None:
+            # CRITICAL: point the LIVE publisher at the new cert/key BEFORE
+            # (or atomically with) swapping self._identity -- renew()'s
+            # pointer-commit already unlinked the old files, so the very
+            # next reconnect must not still be holding their paths (see
+            # MqttPublisher.set_tls's docstring). Not every Publisher
+            # implementation has this seam (e.g. tests' FakePublisher), so
+            # it's called only when present.
+            set_tls = getattr(self._publisher, "set_tls", None)
+            if set_tls is not None:
+                set_tls(
+                    tls_ca_certs=str(new_identity.ca_path),
+                    tls_certfile=str(new_identity.cert_path),
+                    tls_keyfile=str(new_identity.key_path),
+                )
             self._identity = new_identity

--- a/src/sink/publish/spool.py
+++ b/src/sink/publish/spool.py
@@ -14,6 +14,7 @@ lock (one lock per spool root, like the sink buffer's per-topic locks).
 
 import dataclasses
 import json
+import logging
 import os
 import pathlib
 import tempfile
@@ -235,6 +236,29 @@ class Spool:
                     f"seq must be monotonic: got {seq}, last was {self._last_seq[lane]}"
                 )
             line = json.dumps({"seq": seq, "payload": payload}) + "\n"
+            # Drop-oldest semantics extend to drop-oversized (Codex review):
+            # _evict() only ever unlinks while more than one segment exists,
+            # so a single record whose own serialized size alone exceeds
+            # SEGMENT_MAX_BYTES becomes its own sole/newest segment and can
+            # never be evicted -- unboundedly blowing past a capped lane's
+            # byte cap. Refuse to write it instead: consume the seq (so the
+            # caller's sequencing stays monotonic and no retry re-attempts
+            # the same doomed record) and count it as evicted. EXCEPTION:
+            # never drop on the never-drop "heartbeat" lane -- its payloads
+            # are tiny, so this is in practice unreachable, but the
+            # never-drop ruling still applies if it somehow were.
+            if lane != "heartbeat" and len(line.encode("utf-8")) > SEGMENT_MAX_BYTES:
+                self._evicted[lane] = self._evicted.get(lane, 0) + 1
+                logging.getLogger(__name__).warning(
+                    "lane '%s': dropping oversized record seq=%d (%d bytes > "
+                    "SEGMENT_MAX_BYTES=%d)",
+                    lane,
+                    seq,
+                    len(line.encode("utf-8")),
+                    SEGMENT_MAX_BYTES,
+                )
+                self._last_seq[lane] = seq
+                return
             segments = self._segments(lane)
             active = segments[-1] if segments else None
             rolled = False
@@ -259,11 +283,21 @@ class Spool:
 
         Advance-to semantics: any ``seq`` above the watermark becomes the new
         watermark (skipped seqs are treated as acked — the publisher sends and
-        acks in order); ``seq`` at or below it is an idempotent no-op.
+        acks in order); ``seq`` at or below it is an idempotent no-op on the
+        watermark itself, but still retries ``_prune`` (see below).
+
+        The idempotent (``seq`` at or below the watermark) path still calls
+        ``_prune`` against the persisted watermark before returning: if a
+        prior process died after ``_write_watermarks`` committed but before
+        ``_prune`` ran, the watermark is already at (or beyond) ``seq`` while
+        the segments it covers were never actually pruned — a repeated ack
+        for that same seq is exactly the retry that must finish the job, or
+        those segments are never pruned (Codex review).
         """
         with self._lock:
             marks = self._watermarks()
             if seq <= marks.get(lane, 0):
+                self._prune(lane, marks.get(lane, 0))
                 return
             marks[lane] = seq
             self._write_watermarks(marks)
@@ -323,9 +357,14 @@ class Spool:
         with self._lock:
             marks = self._watermarks()
             out: dict[str, LaneStats] = {}
-            lanes = {p.name for p in self._root.iterdir() if p.is_dir()}
+            # A lane whose every append so far was an oversized-and-dropped
+            # record (see `append()`) never gets a directory -- union in
+            # `self._evicted`'s lanes too, or that lane's evicted count would
+            # be invisible here even though it's real (Codex review: the
+            # counter must actually be observable, not just incremented).
+            lanes = {p.name for p in self._root.iterdir() if p.is_dir()} | set(self._evicted)
             for lane in sorted(lanes):
-                segments = self._segments(lane)
+                segments = self._segments(lane, create=False)
                 acked = marks.get(lane, 0)
                 last = self._last_seq.get(lane) or self._scan_last_seq(lane)
                 pending = sum(1 for _ in self.pending(lane))

--- a/src/sink/publish/spool.py
+++ b/src/sink/publish/spool.py
@@ -435,14 +435,21 @@ class Spool:
             yielded record may arrive on the publisher's callback thread only after
             that record has been yielded here; the segment list is captured once, at
             the start of iteration, so segments rolled or pruned mid-iteration by a
-            concurrent ack do not change what this call sees.
+            concurrent ack do not change what this call sees. A segment that
+            existed at snapshot time but is unlinked by a concurrent
+            eviction before this loop reaches it (Codex review) is treated
+            as "already gone" and skipped, rather than raising
+            FileNotFoundError and aborting the rest of the replay.
 
         """
         watermark = self._watermark(lane)
         segments = self._segments(lane, create=False)
         for i, segment in enumerate(segments):
             is_final = i == len(segments) - 1
-            records, _, _ = _scan_segment(segment, lane=lane, tolerate_torn_tail=is_final)
+            try:
+                records, _, _ = _scan_segment(segment, lane=lane, tolerate_torn_tail=is_final)
+            except FileNotFoundError:
+                continue  # concurrently evicted between the snapshot and this read
             for record in records:
                 if record["seq"] > watermark:
                     yield record["seq"], record["payload"]

--- a/src/sink/startup.py
+++ b/src/sink/startup.py
@@ -1,4 +1,4 @@
-"""Standing pipelines: subscribe to live topics with attached pipelines, at boot.
+r"""Standing pipelines: subscribe to live topics with attached pipelines, at boot.
 
 Two entry points share the same logic:
 
@@ -25,6 +25,42 @@ Manifest format::
           tasks: [{module: src.pipeline.tasks.write_topics_to_file, ...}]
 
 The pipeline's ``path`` defaults to the sink directory, so tasks read the live buffer.
+
+A manifest may also carry a top-level ``streams:`` section (fleet streaming,
+spec §2-§6; shape validated by ``src.sink.publish.config.load_streams``)::
+
+    streams:
+      broker: mqtts://fleet.example.com:8883   # optional; defaults to the
+                                                # enrolled identity's broker_url
+      flush_interval_s: 1.0                    # optional; default 1.0
+      channels:
+        - topic: "robot/telemetry"
+          fields: ["speed", "battery.percent"]
+          rate_hz: 5
+      events:
+        - name: low_battery
+          topic: "robot/telemetry"
+          predicate: "\"robot/telemetry\"['battery']['percent'] < 10"
+
+After the ``subscriptions:`` loop above runs, ``start()`` starts fleet
+streaming from this section, if present, gated on ``settings.FLEET_ENABLED``
+and on a viable broker (an enrolled fleet identity, or an explicit
+``mqtt://`` ``broker:`` eligible under ``settings.FLEET_DEV_INSECURE`` -- see
+``src/sink/publish/connect.py``). RULING A (v1 limitation, binding): every
+topic referenced by ``streams.channels``/``streams.events`` must be
+subscribed within a SINGLE ``subscriptions:`` entry -- ``FleetService``
+taps one sink's topic buffers, and each entry's sink is a fresh instance
+(``module.provide`` never shares one across entries), so a ``streams:``
+block whose topics span two different subscription entries cannot be
+served; it produces a failed fleet report entry naming the limitation
+instead. RULING B (v1, binding): there is no ``TopicSink.close()`` ->
+``FleetService.stop()`` coupling -- the fleet service, once started, runs
+for the process's lifetime (daemon threads, a publisher LWT, and its
+finalizer cover process exit; see ``src/sink/publish/service.py``).
+
+The result is one additional report entry, ``{"fleet": "started" | "disabled"
+| "failed", ...}``, alongside the per-subscription ones -- or none at all
+when the manifest has no ``streams:`` section.
 """
 
 import logging
@@ -33,10 +69,22 @@ from typing import Any
 
 import yaml
 
+from settings import settings
 from src.di import module
 from src.di.types.base_module import BaseModule
 from src.di.types.topic_sink import TopicSink, guess_host, guess_port
 from src.pipeline import base
+from src.sink.publish import StreamConfigError
+from src.sink.publish import identity as identity_mod
+from src.sink.publish.config import StreamsConfig, load_streams
+from src.sink.publish.connect import resolve_publisher_kwargs
+from src.sink.publish.mqtt import MqttPublisher
+from src.sink.publish.service import FleetService
+from src.sink.publish.spool import Spool
+
+# Step 7's fleet status/control tools read and (for tests) stop this; None
+# until/unless a manifest's `streams:` section successfully starts one.
+_FLEET_SERVICE: FleetService | None = None
 
 
 def subscribe_with_pipeline(
@@ -107,7 +155,10 @@ def start(manifest_file: str | pathlib.Path) -> list[dict[str, Any]]:
         manifest_file: Path to the YAML manifest (see module docstring for the format).
 
     Returns:
-        One report per subscription entry: `{"sink", "status", "topics" | "error"}`.
+        One report per subscription entry: `{"sink", "status", "topics" | "error"}`,
+        plus (when the manifest has a `streams:` section) one trailing fleet
+        report entry: `{"fleet": "started" | "disabled" | "failed", ...}` --
+        see the module docstring.
 
     """
     try:
@@ -124,6 +175,7 @@ def start(manifest_file: str | pathlib.Path) -> list[dict[str, Any]]:
         return []
 
     reports: list[dict[str, Any]] = []
+    subscribed: list[tuple[object, list[str]]] = []
     for entry in manifest.get("subscriptions", []):
         try:
             sink_type = TopicSink(entry["sink"])
@@ -151,9 +203,104 @@ def start(manifest_file: str | pathlib.Path) -> list[dict[str, Any]]:
                 },
             )
             topics = subscribe_with_pipeline(sink, entry.get("topics"), entry.get("pipeline"))
+            subscribed.append((sink, topics))
             reports.append({"sink": sink_type.value, "status": "subscribed", "topics": topics})
             logging.info("Startup subscription active: %s -> %s", sink_type.value, topics)
         except Exception as error:
             logging.error("Startup subscription failed for sink '%s': %s", sink_type.value, error)
             reports.append({"sink": sink_type.value, "status": "failed", "error": str(error)})
+
+    fleet_report = _start_fleet(manifest, subscribed)
+    if fleet_report is not None:
+        reports.append(fleet_report)
     return reports
+
+
+def _fleet_source_topics(streams: StreamsConfig) -> set[str]:
+    """All topics `streams.channels`/`streams.events` reference (RULING A's coverage set)."""
+    return {rule.topic for rule in streams.channels} | {rule.topic for rule in streams.events}
+
+
+def _find_covering_sink(
+    source_topics: set[str], subscribed: list[tuple[object, list[str]]]
+) -> object | None:
+    """Return the first subscribed sink whose topics cover every `source_topic`.
+
+    RULING A (v1 limitation, binding -- see module docstring): fleet
+    streaming taps a single sink's topic buffers, and each `subscriptions:`
+    entry gets its own fresh sink instance, so a `streams:` block whose
+    source topics span two different entries can never be served. `None`
+    (never raised) signals "no single entry covers them all" -- for the
+    caller to turn into one actionable report entry, whether that is because
+    no entry subscribes to any of them, only some of them, or they are split
+    across more than one entry's topics.
+    """
+    for sink, topics in subscribed:
+        if source_topics <= set(topics):
+            return sink
+    return None
+
+
+def _start_fleet(
+    manifest: dict[str, Any], subscribed: list[tuple[object, list[str]]]
+) -> dict[str, Any] | None:
+    """Start fleet streaming from the manifest's `streams:` section, if present.
+
+    Mirrors the per-subscription isolation above: every failure here --
+    manifest shape, `FLEET_ENABLED`, topic coverage (RULING A), missing
+    identity, a broker that fails `resolve_publisher_kwargs`'s dev-insecure
+    check, or anything `FleetService.start()` raises -- is caught and turned
+    into `{"fleet": "failed", "error": str(exc)}` rather than raised, so a
+    fleet misconfiguration never prevents the server (or the rest of the
+    manifest's subscriptions) from starting.
+
+    Returns:
+        `None` when the manifest has no `streams:` section at all (no report
+        entry is added in that case); otherwise the fleet report entry.
+
+    """
+    global _FLEET_SERVICE  # noqa: PLW0603 -- the module-level holder step 7's tools read/stop
+    try:
+        streams = load_streams(manifest)
+        if streams is None:
+            return None
+        if not settings.FLEET_ENABLED:
+            logging.info(
+                "Startup manifest declares 'streams:' but fleet streaming is disabled "
+                "(FLEET_ENABLED=0); ignoring it"
+            )
+            return {"fleet": "disabled"}
+
+        source_topics = _fleet_source_topics(streams)
+        sink = _find_covering_sink(source_topics, subscribed)
+        if sink is None:
+            raise StreamConfigError(
+                "streams",
+                "all streams: source topics "
+                f"{sorted(source_topics)} must be subscribed within a SINGLE "
+                "startup manifest 'subscriptions:' entry -- fleet streaming "
+                "(v1) cannot span multiple subscription entries' sinks; list "
+                "every one of these topics under one entry's 'topics:'",
+            )
+
+        directory = settings.FLEET_IDENTITY_DIRECTORY
+        identity = (
+            identity_mod.load_identity(directory) if identity_mod.is_enrolled(directory) else None
+        )
+        publisher_kwargs = resolve_publisher_kwargs(streams, identity)
+        publisher = MqttPublisher(**publisher_kwargs)
+        spool = Spool.for_robot(identity.robot if identity is not None else "dev/robot")
+        service = FleetService(
+            sink=sink, streams=streams, publisher=publisher, spool=spool, identity=identity
+        )
+        service.start()
+        _FLEET_SERVICE = service
+        logging.info(
+            "Fleet streaming started: tenant=%s robot=%s",
+            identity.tenant if identity is not None else "dev",
+            identity.robot_id if identity is not None else "robot",
+        )
+        return {"fleet": "started"}
+    except Exception as error:
+        logging.error("Fleet streaming failed to start: %s", error)
+        return {"fleet": "failed", "error": str(error)}

--- a/src/sink/startup.py
+++ b/src/sink/startup.py
@@ -299,6 +299,12 @@ def _start_fleet(
                     "Failed to stop the previous FleetService before replacing it: %s",
                     stop_error,
                 )
+            # Clear the holder immediately, whether or not stop() itself
+            # succeeded -- if the NEW service below fails to start, the
+            # holder must not keep pointing at this now-stopped instance as
+            # if it were still the live one (a caller reading it -- step 7's
+            # status/control tools -- would see a dead service as live).
+            _FLEET_SERVICE = None
 
         directory = settings.FLEET_IDENTITY_DIRECTORY
         identity = (

--- a/src/sink/startup.py
+++ b/src/sink/startup.py
@@ -234,9 +234,25 @@ def _find_covering_sink(
     caller to turn into one actionable report entry, whether that is because
     no entry subscribes to any of them, only some of them, or they are split
     across more than one entry's topics.
+
+    RULING A's premise ("each entry's sink is a fresh instance") does NOT
+    hold when two entries share the same (host, port): `TopicSink.__new__`
+    is a singleton keyed on that pair, so they get the SAME sink object,
+    each entry's `topics` list naming only what THAT entry itself
+    subscribed. Testing each `(sink, topics)` tuple in isolation would
+    therefore wrongly reject a manifest split across two same-sink entries
+    even though the singleton is actually subscribed to their union (Codex
+    review) -- so entries are grouped by sink identity (`id(sink)`) first,
+    and coverage is tested against each group's UNIONED topics.
     """
+    topics_by_sink_id: dict[int, tuple[object, set[str]]] = {}
     for sink, topics in subscribed:
-        if source_topics <= set(topics):
+        sink_id = id(sink)
+        if sink_id not in topics_by_sink_id:
+            topics_by_sink_id[sink_id] = (sink, set())
+        topics_by_sink_id[sink_id][1].update(topics)
+    for sink, topics in topics_by_sink_id.values():
+        if source_topics <= topics:
             return sink
     return None
 

--- a/src/sink/startup.py
+++ b/src/sink/startup.py
@@ -283,6 +283,23 @@ def _start_fleet(
                 "every one of these topics under one entry's 'topics:'",
             )
 
+        if _FLEET_SERVICE is not None:
+            # A second startup.start() in the same process is about to
+            # replace the holder: FleetService.start()'s double-start guard
+            # is per-instance, so nothing else would ever stop the PREVIOUS
+            # service's daemon threads, MQTT connection, or tap wiring once
+            # this reassigns it -- stop it first, before the new one is even
+            # built, so its taps are cleared before the new service (which
+            # may tap the very same sink/buffers) wires its own. Best-effort:
+            # a broken old service must not block the new one from starting.
+            try:
+                _FLEET_SERVICE.stop()
+            except Exception as stop_error:
+                logging.warning(
+                    "Failed to stop the previous FleetService before replacing it: %s",
+                    stop_error,
+                )
+
         directory = settings.FLEET_IDENTITY_DIRECTORY
         identity = (
             identity_mod.load_identity(directory) if identity_mod.is_enrolled(directory) else None

--- a/test/sink/publish/test_config.py
+++ b/test/sink/publish/test_config.py
@@ -68,7 +68,9 @@ class TestResolvePath:
 
 class TestFieldUnit:
     def test_metadata_unit_is_returned(self) -> None:
-        struct = pa.struct([pa.field("temp", pa.float64(), metadata={"unit": "celsius"})])
+        # Canonical key is "units" (plural) -- src/topic/base.py's UNITS_KEY,
+        # the only key any registry (ArduPilot) actually writes.
+        struct = pa.struct([pa.field("temp", pa.float64(), metadata={"units": "celsius"})])
         assert config.field_unit(struct, "temp") == "celsius"
 
     def test_nested_metadata_unit_is_returned(self) -> None:
@@ -76,7 +78,7 @@ class TestFieldUnit:
             [
                 pa.field(
                     "outer",
-                    pa.struct([pa.field("temp", pa.float64(), metadata={"unit": "celsius"})]),
+                    pa.struct([pa.field("temp", pa.float64(), metadata={"units": "celsius"})]),
                 )
             ]
         )
@@ -87,6 +89,15 @@ class TestFieldUnit:
 
     def test_unresolvable_path_is_none(self) -> None:
         assert config.field_unit(IMU, "nope") is None
+
+    def test_singular_unit_key_is_not_read(self) -> None:
+        # Codex review (3909410560): field_unit() used to read the wrong key
+        # (b"unit", singular) -- src/topic/base.py's UNITS_KEY is "units"
+        # (plural), and no registry writes the singular form, so it is not
+        # kept as a fallback. A field carrying only the singular key must not
+        # resolve a unit.
+        struct = pa.struct([pa.field("temp", pa.float64(), metadata={"unit": "celsius"})])
+        assert config.field_unit(struct, "temp") is None
 
 
 class TestClassify:
@@ -257,6 +268,23 @@ class TestStreamsConfigBuild:
         with pytest.raises(StreamConfigError, match="broker"):
             config.StreamsConfig.build({"broker": url, "channels": []})
 
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "mqtt://host:notaport",
+            "mqtt://host:70000",
+            "mqtt://[",
+        ],
+    )
+    def test_malformed_broker_authority_raises_typed(self, url: str) -> None:
+        # Codex review (3909410567): urlparse() itself raises a raw ValueError
+        # on a bad port/authority, and StreamsConfig.build never accessed
+        # .port at all -- so a malformed broker URL either crashed with an
+        # untyped ValueError or passed validation silently. Both must now
+        # raise a typed StreamConfigError naming streams.broker.
+        with pytest.raises(StreamConfigError, match="broker"):
+            config.StreamsConfig.build({"broker": url, "channels": []})
+
     def test_plain_mqtt_scheme_is_syntactically_ok(self) -> None:
         # Whether mqtt:// is *allowed* is enrollment's dev-mode rule (step 6);
         # here it only has to parse.
@@ -307,6 +335,26 @@ class TestStreamsConfigBuild:
         with pytest.raises(StreamConfigError, match="streams.events"):
             config.StreamsConfig.build({"channels": [], "events": {"a": 1}})
 
+    def test_unknown_top_level_key_raises(self) -> None:
+        # Codex review (3909410575): a typo'd top-level key (e.g. "channnels")
+        # used to silently fall back to the default empty list instead of
+        # erroring -- mirror ChannelRule.build/EventRule.build's unknown-key
+        # style so a typo'd streams: section is never a silent no-op.
+        with pytest.raises(StreamConfigError, match=r"unknown keys \['channnels'\]"):
+            config.StreamsConfig.build(
+                {"channnels": [{"topic": "/t", "fields": ["a"], "rate_hz": 1}]}
+            )
+
+    def test_all_known_top_level_keys_are_accepted(self) -> None:
+        config.StreamsConfig.build(
+            {
+                "broker": "mqtts://fleet.example.com",
+                "flush_interval_s": 2,
+                "channels": [],
+                "events": [],
+            }
+        )
+
 
 class TestResolve:
     def _cfg(self, channels: list) -> config.StreamsConfig:
@@ -350,7 +398,7 @@ class TestResolve:
         assert c.unit is None
 
     def test_scalar_channel_picks_up_arrow_unit_metadata(self) -> None:
-        struct = pa.struct([pa.field("temp", pa.float64(), metadata={"unit": "celsius"})])
+        struct = pa.struct([pa.field("temp", pa.float64(), metadata={"units": "celsius"})])
         cfg = self._cfg([{"topic": "/env", "fields": ["temp"], "rate_hz": 1}])
         (c,) = cfg.resolve({"/env": struct})
         assert c.unit == "celsius"

--- a/test/sink/publish/test_connect.py
+++ b/test/sink/publish/test_connect.py
@@ -1,0 +1,271 @@
+"""Connection policy: identity + streams config -> MqttPublisher kwargs.
+
+``resolve_publisher_kwargs`` picks a broker (streams.broker wins over
+identity.broker_url), then enforces the transport policy: ``mqtts://``
+requires an enrolled identity (TLS material comes from its cert paths);
+``mqtt://`` (plaintext) requires both ``settings.FLEET_DEV_INSECURE`` and a
+loopback/private host, so a misconfigured production robot can never fall
+back to an unauthenticated, unencrypted broker.
+
+``_is_local_or_private`` never does real DNS in these tests --
+``socket.getaddrinfo`` is monkeypatched for every non-literal hostname case.
+"""
+
+import importlib
+import pathlib
+import socket
+import sys
+from inspect import Parameter, signature
+
+import pytest
+
+from settings import settings
+from src.sink.publish import FleetNotEnrolledError, StreamConfigError
+from src.sink.publish import connect as connect_mod
+from src.sink.publish.config import StreamsConfig
+from src.sink.publish.identity import Identity
+from src.sink.publish.mqtt import MqttPublisher
+
+
+def _identity(*, broker_url: str = "mqtts://fleet.example.com") -> Identity:
+    return Identity(
+        tenant="acme",
+        robot_id="r2d2",
+        broker_url=broker_url,
+        enroll_url="https://enroll.example.com",
+        expires_at="2027-01-01T00:00:00Z",
+        key_path=pathlib.Path("/identity/robot.key"),
+        cert_path=pathlib.Path("/identity/robot.crt"),
+        ca_path=pathlib.Path("/identity/ca.crt"),
+    )
+
+
+def _streams(broker: str | None = None) -> StreamsConfig:
+    return StreamsConfig(broker=broker)
+
+
+def _mqtt_publisher_param_names() -> set[str]:
+    params = signature(MqttPublisher.__init__).parameters
+    return {name for name in params if name != "self"}
+
+
+class TestMqttsHappyPath:
+    def test_mqtts_with_identity_returns_tls_kwargs(self) -> None:
+        identity = _identity(broker_url="mqtts://ignored.example.com")
+        streams = _streams(broker="mqtts://fleet.example.com")
+        kwargs = connect_mod.resolve_publisher_kwargs(streams, identity)
+        assert kwargs == {
+            "broker_url": "mqtts://fleet.example.com",
+            "tenant": "acme",
+            "robot": "r2d2",
+            "tls_ca_certs": "/identity/ca.crt",
+            "tls_certfile": "/identity/robot.crt",
+            "tls_keyfile": "/identity/robot.key",
+        }
+
+    def test_mqtts_broker_falls_back_to_identity_broker_url(self) -> None:
+        identity = _identity(broker_url="mqtts://from-identity.example.com")
+        streams = _streams(broker=None)
+        kwargs = connect_mod.resolve_publisher_kwargs(streams, identity)
+        assert kwargs["broker_url"] == "mqtts://from-identity.example.com"
+        assert kwargs["tenant"] == "acme"
+        assert kwargs["robot"] == "r2d2"
+
+
+class TestMqttsRequiresIdentity:
+    def test_mqtts_without_identity_raises_not_enrolled(self) -> None:
+        streams = _streams(broker="mqtts://fleet.example.com")
+        with pytest.raises(FleetNotEnrolledError, match="mqtts"):
+            connect_mod.resolve_publisher_kwargs(streams, None)
+
+
+class TestNoBrokerAnywhere:
+    def test_neither_streams_nor_identity_broker_raises_naming_both_paths(self) -> None:
+        streams = _streams(broker=None)
+        with pytest.raises(FleetNotEnrolledError, match="streams.broker") as excinfo:
+            connect_mod.resolve_publisher_kwargs(streams, None)
+        assert "enroll" in str(excinfo.value).lower()
+
+    def test_neither_with_identity_missing_broker_url_also_raises(self) -> None:
+        # identity.broker_url is required non-empty by load_identity/enroll, but the
+        # policy layer must not assume that -- an empty string is "unset" too.
+        identity = _identity(broker_url="")
+        streams = _streams(broker=None)
+        with pytest.raises(FleetNotEnrolledError, match="streams.broker"):
+            connect_mod.resolve_publisher_kwargs(streams, identity)
+
+
+class TestMqttRequiresDevInsecure:
+    def test_mqtt_without_dev_flag_raises_naming_setting(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(settings, "FLEET_DEV_INSECURE", False)
+        streams = _streams(broker="mqtt://localhost")
+        with pytest.raises(StreamConfigError, match="FLEET_DEV_INSECURE"):
+            connect_mod.resolve_publisher_kwargs(streams, None)
+
+
+class TestMqttDevInsecureHostPolicy:
+    def test_localhost_literal_ok(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(settings, "FLEET_DEV_INSECURE", True)
+        streams = _streams(broker="mqtt://localhost")
+        kwargs = connect_mod.resolve_publisher_kwargs(streams, None)
+        assert kwargs["broker_url"] == "mqtt://localhost"
+        assert kwargs["tenant"] == "dev"
+        assert kwargs["robot"] == "robot"
+
+    def test_private_ip_literal_ok(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(settings, "FLEET_DEV_INSECURE", True)
+        streams = _streams(broker="mqtt://192.168.1.5")
+        kwargs = connect_mod.resolve_publisher_kwargs(streams, None)
+        assert kwargs["broker_url"] == "mqtt://192.168.1.5"
+
+    def test_public_ip_literal_raises_naming_host(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(settings, "FLEET_DEV_INSECURE", True)
+        streams = _streams(broker="mqtt://8.8.8.8")
+        with pytest.raises(StreamConfigError, match="8.8.8.8"):
+            connect_mod.resolve_publisher_kwargs(streams, None)
+
+    def test_hostname_resolving_public_raises_via_fake_getaddrinfo(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(settings, "FLEET_DEV_INSECURE", True)
+
+        def fake_getaddrinfo(host: str, port: object, *args: object, **kwargs: object) -> list:
+            assert host == "broker.example.com"
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("8.8.8.8", 0))]
+
+        monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+        streams = _streams(broker="mqtt://broker.example.com")
+        with pytest.raises(StreamConfigError, match="broker.example.com"):
+            connect_mod.resolve_publisher_kwargs(streams, None)
+
+    def test_hostname_resolving_private_ok_via_fake_getaddrinfo(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(settings, "FLEET_DEV_INSECURE", True)
+
+        def fake_getaddrinfo(host: str, port: object, *args: object, **kwargs: object) -> list:
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("10.0.0.7", 0))]
+
+        monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+        streams = _streams(broker="mqtt://broker.internal")
+        kwargs = connect_mod.resolve_publisher_kwargs(streams, None)
+        assert kwargs["broker_url"] == "mqtt://broker.internal"
+
+    def test_mqtt_with_identity_uses_identity_tenant_and_robot(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(settings, "FLEET_DEV_INSECURE", True)
+        identity = _identity(broker_url="mqtts://unused.example.com")
+        streams = _streams(broker="mqtt://localhost")
+        kwargs = connect_mod.resolve_publisher_kwargs(streams, identity)
+        assert kwargs == {
+            "broker_url": "mqtt://localhost",
+            "tenant": "acme",
+            "robot": "r2d2",
+        }
+
+
+class TestIsLocalOrPrivate:
+    def test_localhost_literal(self) -> None:
+        assert connect_mod._is_local_or_private("localhost") is True
+
+    def test_loopback_ip_literal(self) -> None:
+        assert connect_mod._is_local_or_private("127.0.0.1") is True
+
+    def test_private_ipv4_literal(self) -> None:
+        assert connect_mod._is_local_or_private("10.1.2.3") is True
+        assert connect_mod._is_local_or_private("192.168.0.1") is True
+
+    def test_public_ip_literal(self) -> None:
+        assert connect_mod._is_local_or_private("8.8.8.8") is False
+
+    def test_hostname_all_private_via_fake_getaddrinfo(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def fake_getaddrinfo(host: str, port: object, *args: object, **kwargs: object) -> list:
+            return [
+                (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("10.0.0.1", 0)),
+                (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("10.0.0.2", 0)),
+            ]
+
+        monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+        assert connect_mod._is_local_or_private("multi.internal") is True
+
+    def test_hostname_mixed_private_and_public_rejected(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def fake_getaddrinfo(host: str, port: object, *args: object, **kwargs: object) -> list:
+            return [
+                (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("10.0.0.1", 0)),
+                (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("8.8.8.8", 0)),
+            ]
+
+        monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+        assert connect_mod._is_local_or_private("mixed.internal") is False
+
+    def test_resolution_failure_returns_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def fake_getaddrinfo(host: str, port: object, *args: object, **kwargs: object) -> list:
+            raise socket.gaierror("nope")
+
+        monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+        assert connect_mod._is_local_or_private("nowhere.example.com") is False
+
+    def test_empty_resolution_returns_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(socket, "getaddrinfo", lambda *a, **k: [])
+        assert connect_mod._is_local_or_private("empty.example.com") is False
+
+
+class TestKwargShapeMatchesMqttPublisher:
+    def test_mqtts_kwargs_are_subset_of_real_signature(self) -> None:
+        allowed = _mqtt_publisher_param_names()
+        identity = _identity()
+        streams = _streams(broker="mqtts://fleet.example.com")
+        kwargs = connect_mod.resolve_publisher_kwargs(streams, identity)
+        assert set(kwargs) <= allowed
+        # broker_url, tenant, robot are positional-or-keyword in MqttPublisher;
+        # confirm none of our keys were dropped from its actual signature.
+        params = signature(MqttPublisher.__init__).parameters
+        for name in kwargs:
+            assert params[name].kind in (
+                Parameter.POSITIONAL_OR_KEYWORD,
+                Parameter.KEYWORD_ONLY,
+            )
+
+    def test_mqtt_dev_kwargs_are_subset_of_real_signature(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(settings, "FLEET_DEV_INSECURE", True)
+        allowed = _mqtt_publisher_param_names()
+        streams = _streams(broker="mqtt://localhost")
+        kwargs = connect_mod.resolve_publisher_kwargs(streams, None)
+        assert set(kwargs) <= allowed
+
+    def test_kwargs_construct_a_real_mqttpublisher(self) -> None:
+        identity = _identity()
+        streams = _streams(broker="mqtts://fleet.example.com")
+        kwargs = connect_mod.resolve_publisher_kwargs(streams, identity)
+        # Not connecting -- just proving the returned dict is accepted as-is.
+        publisher = MqttPublisher(**kwargs)
+        assert publisher is not None
+
+
+def test_connect_module_does_not_import_paho_or_cryptography_eagerly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for name in [
+        m
+        for m in sys.modules
+        if m == "paho"
+        or m.startswith("paho.")
+        or m == "cryptography"
+        or m.startswith("cryptography.")
+    ]:
+        monkeypatch.delitem(sys.modules, name)
+    monkeypatch.delitem(sys.modules, "src.sink.publish.connect", raising=False)
+    importlib.import_module("src.sink.publish.connect")
+    assert not any(
+        m == "paho" or m.startswith("paho.") or m == "cryptography" or m.startswith("cryptography.")
+        for m in sys.modules
+    )

--- a/test/sink/publish/test_connect.py
+++ b/test/sink/publish/test_connect.py
@@ -104,6 +104,23 @@ class TestMqttRequiresDevInsecure:
         with pytest.raises(StreamConfigError, match="FLEET_DEV_INSECURE"):
             connect_mod.resolve_publisher_kwargs(streams, None)
 
+    def test_identity_sourced_mqtt_scheme_still_gated_by_dev_flag(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Compromised/misbehaving enroll server scenario: streams.broker is
+        # unset, and identity.broker_url (assigned by the enrollment server,
+        # not validated by load_identity) is a plaintext mqtt:// URL pointed
+        # at an arbitrary host. The dev-insecure gate must still apply to a
+        # broker sourced from identity, not just one sourced from the
+        # manifest -- the scheme check runs after streams/identity are
+        # merged into a single broker_url, so there is no separate path
+        # around it.
+        monkeypatch.setattr(settings, "FLEET_DEV_INSECURE", False)
+        identity = _identity(broker_url="mqtt://attacker.example.com")
+        streams = _streams(broker=None)
+        with pytest.raises(StreamConfigError, match="FLEET_DEV_INSECURE"):
+            connect_mod.resolve_publisher_kwargs(streams, identity)
+
 
 class TestMqttDevInsecureHostPolicy:
     def test_localhost_literal_ok(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -166,6 +183,28 @@ class TestMqttDevInsecureHostPolicy:
             "robot": "r2d2",
         }
 
+    def test_bracketed_ipv6_literal_loopback_url_ok(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(settings, "FLEET_DEV_INSECURE", True)
+        streams = _streams(broker="mqtt://[::1]:1883")
+        kwargs = connect_mod.resolve_publisher_kwargs(streams, None)
+        assert kwargs["broker_url"] == "mqtt://[::1]:1883"
+        assert kwargs["tenant"] == "dev"
+        assert kwargs["robot"] == "robot"
+
+
+class TestUnsupportedScheme:
+    def test_identity_sourced_unvalidated_scheme_raises_naming_it(self) -> None:
+        # load_identity/enroll never validate broker_url's scheme (unlike
+        # StreamsConfig.build, which constrains streams.broker to
+        # mqtt/mqtts), so a compromised enroll server or a hand-edited
+        # identity.yaml can hand back any scheme at all. This branch is the
+        # last-line-of-defense guard against that -- reachable, not dead code.
+        identity = _identity(broker_url="ws://fleet.example.com")
+        streams = _streams(broker=None)
+        with pytest.raises(StreamConfigError, match="ws") as excinfo:
+            connect_mod.resolve_publisher_kwargs(streams, identity)
+        assert "ws" in str(excinfo.value)
+
 
 class TestIsLocalOrPrivate:
     def test_localhost_literal(self) -> None:
@@ -180,6 +219,17 @@ class TestIsLocalOrPrivate:
 
     def test_public_ip_literal(self) -> None:
         assert connect_mod._is_local_or_private("8.8.8.8") is False
+
+    def test_loopback_ipv6_literal(self) -> None:
+        assert connect_mod._is_local_or_private("::1") is True
+
+    def test_private_ipv6_literal(self) -> None:
+        # fd00::/8 is the IPv6 unique-local range (RFC4193), the v6 analog
+        # of RFC1918.
+        assert connect_mod._is_local_or_private("fd00::1") is True
+
+    def test_public_ipv6_literal(self) -> None:
+        assert connect_mod._is_local_or_private("2001:4860:4860::8888") is False
 
     def test_hostname_all_private_via_fake_getaddrinfo(
         self, monkeypatch: pytest.MonkeyPatch

--- a/test/sink/publish/test_enroll_e2e.py
+++ b/test/sink/publish/test_enroll_e2e.py
@@ -1,0 +1,570 @@
+"""First-boot enroll-to-stream end-to-end (spec S6, step 6).
+
+Gated on MQTT_TEST_BROKER (a real mosquitto broker), like
+test_mqtt_integration.py and test_stream_e2e.py. Proves the full loop with NO
+real cloud:
+
+1. An in-thread fake enrollment server (``http.server``) backed by a REAL
+   throwaway CA (``cryptography``) signs the robot's actual CSR -- the PEMs
+   ``enroll()`` writes to disk are real, parseable certs, not string
+   fixtures (``_build_ca_and_robot_cert`` below is adapted from
+   test_identity.py's helper of the same name). Its response's
+   ``broker_url`` is the dev-insecure path (``mqtt://<broker
+   host>:<port>`` of the very MQTT_TEST_BROKER this suite already
+   requires) so no second, TLS-terminating fake broker is needed to prove
+   the loop end-to-end.
+2. ``maybe_enroll_on_first_boot()`` (settings monkeypatched:
+   FLEET_ENROLL_TOKEN/URL, FLEET_IDENTITY_DIRECTORY=tmp,
+   FLEET_DEV_INSECURE=1) writes the identity to disk (0600 key) exactly as
+   server.py's boot sequence does, before any manifest wiring runs.
+3. Manifest-driven startup: ``startup._start_fleet`` is driven DIRECTLY
+   with a manually built ``subscribed`` list -- not ``startup.start()``'s
+   full ``subscriptions:`` loop -- because none of this repo's
+   host-runnable ``TopicSink`` types (``ros1.bridge``, ``ros2.bridge``,
+   ``mqtt``) can be stood up here without extra infrastructure this suite
+   doesn't have: the two ROS bridges need an actual bridge process, and the
+   ``mqtt`` sink's own ``#``-wildcard topic discovery is time-boxed and
+   would race the deterministic sample-append assertions below instead of
+   proving anything extra. Step 5's own e2e (test_stream_e2e.py)
+   established the same real-``TopicBufferWriter``-backed ``FakeSink``
+   double as the standard way to drive the tap -> RouterCore ->
+   StreamRouter -> Spool -> MqttPublisher pipeline for real without a real
+   upstream sink -- ``_start_fleet`` cannot itself tell a real sink from
+   this one; it only ever touches ``sink.subscribed_topics`` and
+   ``sink._buffers``, which this double provides identically to a real
+   ``TopicSink``. This is the plan's explicitly authorized fallback: the
+   enrolled identity, its on-disk files, and the MQTT broker/wire traffic
+   are all real -- only the "who feeds the buffer" side is a double.
+4. Appending samples to that writer and reading them back off the SAME
+   real broker's ``bagel/v1/<tenant>/<robot>/channels`` topic proves the
+   fresh identity's broker_url/tenant/robot_id actually drive a live
+   MqttPublisher; the retained heartbeat's non-null ``cert_expires_at`` is
+   the first e2e in this repo where that value isn't None (step 5's e2e
+   never had an identity to carry one).
+5. Renewal-501-grace (a separate test): ``identity.renew()`` against a fake
+   renew server that always answers 501 (server does not offer renewal
+   yet) returns None, records the attempt, and never raises -- and proves
+   the enroll response's OPTIONAL ``renew_url`` field (see identity.py's
+   module docstring) is the URL ``renew()`` actually targets, by pointing
+   it at a DIFFERENT host than the enroll server.
+
+Locally:
+    docker run -d -p 1883:1883 eclipse-mosquitto:2 mosquitto -c /mosquitto-no-auth.conf
+    MQTT_TEST_BROKER=mqtt://localhost:1883 uv run pytest test/sink/publish/test_enroll_e2e.py
+"""
+
+import datetime
+import functools
+import http.server
+import json
+import os
+import pathlib
+import queue
+import stat
+import threading
+import time
+import uuid
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+from urllib.parse import urlparse
+
+import pyarrow as pa
+import pytest
+import yaml
+
+from settings import settings
+from src.sink import startup
+from src.sink.publish import identity as identity_mod
+from src.sink.publish.publisher import wire_topic
+
+if TYPE_CHECKING:
+    from src.sink.buffer import TopicBufferWriter
+
+BROKER = os.environ.get("MQTT_TEST_BROKER")
+
+pytestmark = pytest.mark.skipif(not BROKER, reason="MQTT_TEST_BROKER not set")
+
+ENROLL_TOKEN = "e2e-first-boot-token"  # noqa: S105 -- test fixture, not a real secret
+IMU_STRUCT = pa.struct([pa.field("x", pa.float64())])
+EXPIRES_AT = "2027-06-15T00:00:00Z"
+
+Inbox = "queue.Queue[tuple[str, bytes, bool]]"
+
+
+# -- small helpers (adapted from test_stream_e2e.py: no bare sleeps, deadline polling) --
+
+
+def _wait_until(predicate: Callable[[], bool], timeout_s: float, interval_s: float = 0.02) -> bool:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval_s)
+    return predicate()
+
+
+def _drain(inbox: Inbox, topic: str, timeout_s: float = 10.0) -> tuple[str, bytes, bool] | None:
+    """Pull from `inbox` until `topic` matches or the deadline passes."""
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        try:
+            got = inbox.get(timeout=deadline - time.time())
+        except queue.Empty:
+            return None
+        if got[0] == topic:
+            return got
+    return None
+
+
+class FakeSink:
+    """Minimal TopicSink double: the `_buffers`/`subscribed_topics` seam FleetService uses.
+
+    Adapted from test_stream_e2e.py's double of the same name -- duplicated
+    rather than imported across test modules (no existing precedent for
+    that in this package; see this module's docstring, point 3).
+    """
+
+    def __init__(self, buffers: dict[str, "TopicBufferWriter"]) -> None:
+        self._buffers = buffers
+
+    @property
+    def subscribed_topics(self) -> list[str]:
+        return list(self._buffers)
+
+
+def _real_writer(tmp_path: pathlib.Path, topic: str = "/imu") -> "TopicBufferWriter":
+    """A real TopicBufferWriter (not a fake) backed by a tmp cache."""
+    from src.sink.buffer import TopicBufferWriter
+
+    return TopicBufferWriter(
+        path=tmp_path / "buffer",
+        topic=topic,
+        type_name="test/Imu",
+        definition="float64 x",
+        struct=IMU_STRUCT,
+        buffer_size_bytes=None,
+        overwrite=False,
+        pipeline=None,
+        extract_timestamp=lambda msg: msg["timestamp_seconds"],
+    )
+
+
+class _Subscriber:
+    """One paho client subscribed to a robot's whole `bagel/v1/<tenant>/<robot>/#` tree.
+
+    A trimmed adaptation of test_stream_e2e.py's `_Subscriber` -- this file
+    has no chaos scenario, so the outage/reconnect machinery there is
+    dropped; connect/drain-via-inbox/close is all this test needs.
+    """
+
+    def __init__(self, host: str, port: int, tenant: str, robot: str) -> None:
+        import paho.mqtt.client as paho
+
+        self.inbox: Inbox = queue.Queue()
+        self._host = host
+        self._port = port
+        self._topic = f"bagel/v1/{tenant}/{robot}/#"
+        self._subscribed = threading.Event()
+        self._client = paho.Client(
+            callback_api_version=paho.CallbackAPIVersion.VERSION2,
+            client_id=f"sub-{uuid.uuid4().hex[:8]}",
+            protocol=paho.MQTTv5,
+        )
+        self._client.on_connect = self._on_connect
+        self._client.on_subscribe = self._on_subscribe
+        self._client.on_message = lambda cl, ud, msg: self.inbox.put(
+            (msg.topic, msg.payload, msg.retain)
+        )
+
+    def _on_connect(
+        self, client: object, userdata: object, flags: object, reason_code: object, *_a: object
+    ) -> None:
+        self._subscribed.clear()
+        client.subscribe(self._topic, qos=1)  # `client` is paho's Client (duck-typed as object)
+
+    def _on_subscribe(self, *_a: object) -> None:
+        self._subscribed.set()
+
+    def connect(self, timeout_s: float = 10.0) -> None:
+        self._client.connect(self._host, self._port, 30)
+        self._client.loop_start()
+        assert _wait_until(self._subscribed.is_set, timeout_s=timeout_s), (
+            "subscriber never subscribed"
+        )
+
+    def close(self) -> None:
+        self._client.loop_stop()
+        self._client.disconnect()
+
+
+def _build_ca_and_robot_cert(common_name: str, robot_public_key: object) -> tuple[bytes, bytes]:
+    """Build a throwaway self-signed CA and a robot cert it signs, both as PEM.
+
+    Adapted from test_identity.py's helper of the same name (see this
+    module's docstring, point 1) -- returns (robot_cert_pem, ca_cert_pem).
+    """
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import ec
+    from cryptography.x509.oid import NameOID
+
+    ca_key = ec.generate_private_key(ec.SECP256R1())
+    ca_name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "e2e test fleet CA")])
+    now = datetime.datetime.now(datetime.UTC)
+    ca_cert = (
+        x509.CertificateBuilder()
+        .subject_name(ca_name)
+        .issuer_name(ca_name)
+        .public_key(ca_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - datetime.timedelta(days=1))
+        .not_valid_after(now + datetime.timedelta(days=365))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        .sign(ca_key, hashes.SHA256())
+    )
+
+    robot_name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, common_name)])
+    robot_cert = (
+        x509.CertificateBuilder()
+        .subject_name(robot_name)
+        .issuer_name(ca_name)
+        .public_key(robot_public_key)
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - datetime.timedelta(days=1))
+        .not_valid_after(now + datetime.timedelta(days=90))
+        .sign(ca_key, hashes.SHA256())
+    )
+
+    return (
+        robot_cert.public_bytes(serialization.Encoding.PEM),
+        ca_cert.public_bytes(serialization.Encoding.PEM),
+    )
+
+
+def _make_enroll_handler(
+    *,
+    broker_url: str,
+    renew_url: str,
+    tenant: str,
+    robot_id: str,
+    expires_at: str,
+) -> type[http.server.BaseHTTPRequestHandler]:
+    """Build a fake `POST /v1/enroll` handler that signs the REAL posted CSR.
+
+    Every field of the closure is fixed per test scenario -- unlike
+    test_identity.py's fake server (which switches canned responses off the
+    request token), this e2e only ever needs one always-succeeds shape, with
+    the response fields the test cares about (broker_url/renew_url/tenant/
+    robot_id/expires_at) parameterized per call.
+    """
+
+    class _Handler(http.server.BaseHTTPRequestHandler):
+        def log_message(self, fmt: str, *args: object) -> None:
+            pass  # silence the default stderr access log during tests
+
+        def do_POST(self) -> None:
+            length = int(self.headers.get("Content-Length", "0"))
+            raw = self.rfile.read(length)
+            payload = json.loads(raw)
+            csr_pem = payload["csr_pem"].encode()
+
+            from cryptography import x509
+
+            csr = x509.load_pem_x509_csr(csr_pem)
+            robot_cert_pem, ca_cert_pem = _build_ca_and_robot_cert(
+                f"{tenant}-{robot_id}", csr.public_key()
+            )
+            body = json.dumps(
+                {
+                    "cert_pem": robot_cert_pem.decode(),
+                    "ca_pem": ca_cert_pem.decode(),
+                    "broker_url": broker_url,
+                    "tenant": tenant,
+                    "robot_id": robot_id,
+                    "expires_at": expires_at,
+                    "renew_url": renew_url,
+                }
+            ).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+    return _Handler
+
+
+class _AlwaysRenewUnavailableHandler(http.server.BaseHTTPRequestHandler):
+    """POST /v1/renew -- always 501 (server does not offer renewal on this deployment)."""
+
+    def log_message(self, fmt: str, *args: object) -> None:
+        pass  # silence the default stderr access log during tests
+
+    def do_POST(self) -> None:
+        length = int(self.headers.get("Content-Length", "0"))
+        self.rfile.read(length)  # drain the request body
+        body = b"renewal not enabled on this deployment"
+        self.send_response(501)
+        self.send_header("Content-Type", "text/plain")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def _start_http_server(
+    handler_cls: type[http.server.BaseHTTPRequestHandler],
+) -> tuple[http.server.HTTPServer, threading.Thread]:
+    server = http.server.HTTPServer(("127.0.0.1", 0), handler_cls)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, thread
+
+
+def _stop_http_server(server: http.server.HTTPServer, thread: threading.Thread) -> None:
+    server.shutdown()
+    thread.join(timeout=5)
+    server.server_close()
+
+
+def _speed_up_heartbeat(monkeypatch: pytest.MonkeyPatch, interval_s: float) -> None:
+    """Make FleetService's heartbeat tick every `interval_s` instead of the 30s default.
+
+    Adapted from test_stream_e2e.py's helper of the same name/purpose: the
+    FIRST heartbeat tick fires immediately but races StreamRouter's own
+    connect, so against a real broker it is usually spooled rather than
+    published live -- and the heartbeat lane is never replayed (a known
+    step-4 design gap). Without this, the retained heartbeat this test's
+    late subscriber waits on wouldn't land until the next tick, 30 real
+    seconds away. `_start_fleet` builds its own `FleetService` internally
+    (this test never constructs one directly), but `FleetService`'s module
+    namespace is what actually gets patched here, so it applies regardless
+    of which caller builds the instance.
+    """
+    import importlib
+
+    heartbeat_module = importlib.import_module("src.sink.publish.heartbeat")
+    service_module = importlib.import_module("src.sink.publish.service")
+
+    monkeypatch.setattr(
+        service_module,
+        "HeartbeatThread",
+        functools.partial(heartbeat_module.HeartbeatThread, interval_s=interval_s),
+    )
+
+
+# -- 1. full first-boot loop: enroll (real CA/CSR) -> identity on disk -> stream ---------
+
+
+@pytest.fixture(autouse=True)
+def _isolated_fleet_service() -> None:
+    """Clear the module-level FleetService holder before/after every test here.
+
+    Mirrors test_startup_streams.py's fixture of the same purpose: a leaked,
+    still-running FleetService from a prior test (or a failed one) must
+    never bleed into the next.
+    """
+    startup._FLEET_SERVICE = None
+    yield
+    if startup._FLEET_SERVICE is not None:
+        startup._FLEET_SERVICE.stop()
+        startup._FLEET_SERVICE = None
+
+
+def _first_boot_enroll(  # noqa: PLR0913 -- one field per scenario input, kept explicit for the caller
+    *,
+    identity_directory: pathlib.Path,
+    enroll_url: str,
+    tenant: str,
+    robot_id: str,
+    broker_url: str,
+    renew_url: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> identity_mod.Identity:
+    """Run step 1: monkeypatch settings, call `maybe_enroll_on_first_boot()`, assert on disk."""
+    monkeypatch.setattr(settings, "FLEET_ENROLL_TOKEN", ENROLL_TOKEN)
+    monkeypatch.setattr(settings, "FLEET_ENROLL_URL", enroll_url)
+    monkeypatch.setattr(settings, "FLEET_IDENTITY_DIRECTORY", str(identity_directory))
+    monkeypatch.setattr(settings, "FLEET_DEV_INSECURE", True)
+    monkeypatch.setattr(settings, "FLEET_ENABLED", True)
+
+    identity_mod.maybe_enroll_on_first_boot()
+
+    assert identity_mod.is_enrolled(identity_directory) is True
+    key_mode = stat.S_IMODE((identity_directory / "robot.key").stat().st_mode)
+    assert key_mode == 0o600
+
+    doc = yaml.safe_load((identity_directory / "identity.yaml").read_text())
+    assert doc["broker_url"] == broker_url
+    assert doc["expires_at"] == EXPIRES_AT
+    assert doc["renew_url"] == renew_url  # the enroll response's renew_url landed on disk
+
+    enrolled = identity_mod.load_identity(identity_directory)
+    assert enrolled.tenant == tenant
+    assert enrolled.robot_id == robot_id
+    assert enrolled.renew_url == renew_url
+    return enrolled
+
+
+def _assert_batch_and_heartbeat(
+    broker_host: str, broker_port: int, tenant: str, robot_id: str, writer: "TopicBufferWriter"
+) -> None:
+    """Run steps 3-4: append a sample, prove a live batch and a retained heartbeat arrive.
+
+    The heartbeat is drained via `sub` FIRST (a live "online" delivery,
+    retain=0 on the wire per MQTT semantics: it arrives because `sub` was
+    already subscribed) -- ONLY once that has actually landed is it
+    guaranteed to also be the broker's retained value for the topic, so
+    `late`, connecting strictly after, is guaranteed a fresh SUBSCRIBE-time
+    retained delivery (retain=1) rather than possibly racing the FIRST
+    heartbeat tick, which can be spooled (not published) if it beats
+    StreamRouter's own connect -- see `_speed_up_heartbeat`'s docstring.
+    """
+    channels_topic = wire_topic(tenant, robot_id, "channels")
+    heartbeat_topic = wire_topic(tenant, robot_id, "heartbeat")
+
+    sub = _Subscriber(broker_host, broker_port, tenant, robot_id)
+    sub.connect()
+    try:
+        writer.append({"x": 1.0, "timestamp_seconds": 1_000.0})
+        batch = _drain(sub.inbox, channels_topic, timeout_s=30.0)
+        assert batch is not None, "channels batch never arrived"
+        body = json.loads(batch[1])
+        assert body["samples"][0]["c"] == "imu.x"
+        assert body["samples"][0]["v"] == 1.0
+
+        online = _drain(sub.inbox, heartbeat_topic, timeout_s=15.0)
+        assert online is not None, "heartbeat never arrived"
+        assert json.loads(online[1])["online"] is True
+    finally:
+        sub.close()
+
+    # The retained heartbeat carries the enrolled cert's real expiry -- the
+    # first e2e in this repo where cert_expires_at is non-null.
+    late = _Subscriber(broker_host, broker_port, tenant, robot_id)
+    late.connect()
+    try:
+        heartbeat = _drain(late.inbox, heartbeat_topic, timeout_s=15.0)
+        assert heartbeat is not None and heartbeat[2] is True
+        hb = json.loads(heartbeat[1])
+        assert hb["online"] is True
+        assert hb["cert_expires_at"] == EXPIRES_AT
+    finally:
+        late.close()
+
+
+def test_first_boot_enroll_to_stream(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    parsed = urlparse(BROKER)
+    broker_host = parsed.hostname or "localhost"
+    broker_port = parsed.port or 1883
+    tenant = "e2e"
+    robot_id = f"robot-{uuid.uuid4().hex[:8]}"
+    broker_url = f"mqtt://{broker_host}:{broker_port}"
+
+    renew_server, renew_thread = _start_http_server(_AlwaysRenewUnavailableHandler)
+    enroll_server, enroll_thread = None, None
+    try:
+        renew_url = f"http://127.0.0.1:{renew_server.server_port}"
+        enroll_handler_cls = _make_enroll_handler(
+            broker_url=broker_url,
+            renew_url=renew_url,
+            tenant=tenant,
+            robot_id=robot_id,
+            expires_at=EXPIRES_AT,
+        )
+        enroll_server, enroll_thread = _start_http_server(enroll_handler_cls)
+
+        _speed_up_heartbeat(monkeypatch, interval_s=0.5)
+
+        # 1. First-boot enrollment: no real cloud, a real signed CSR.
+        _first_boot_enroll(
+            identity_directory=tmp_path / "identity",
+            enroll_url=f"http://127.0.0.1:{enroll_server.server_port}",
+            tenant=tenant,
+            robot_id=robot_id,
+            broker_url=broker_url,
+            renew_url=renew_url,
+            monkeypatch=monkeypatch,
+        )
+
+        # 2. Manifest-driven startup, real _start_fleet -- see module
+        # docstring point 3 for why this drives _start_fleet directly
+        # rather than startup.start()'s subscriptions: loop.
+        writer = _real_writer(tmp_path)
+        sink = FakeSink({"/imu": writer})
+        manifest = {
+            "streams": {
+                "flush_interval_s": 0.3,
+                "channels": [{"topic": "/imu", "fields": ["x"], "rate_hz": 5}],
+            }
+        }
+
+        report = startup._start_fleet(manifest, [(sink, ["/imu"])])
+
+        assert report == {"fleet": "started"}
+        service = startup._FLEET_SERVICE
+        assert service is not None
+        assert service._identity is not None
+        assert service._identity.robot_id == robot_id
+
+        # 3-4. Append a sample; a live batch and a retained heartbeat with a
+        # non-null cert_expires_at both arrive on the same real broker.
+        _assert_batch_and_heartbeat(broker_host, broker_port, tenant, robot_id, writer)
+
+        assert _wait_until(
+            lambda: service._spool.stats()["channels"].pending == 0, timeout_s=15.0
+        ), "spool never drained the acked batch"
+    finally:
+        if startup._FLEET_SERVICE is not None:
+            startup._FLEET_SERVICE.stop()
+            startup._FLEET_SERVICE = None
+        if enroll_server is not None:
+            _stop_http_server(enroll_server, enroll_thread)
+        _stop_http_server(renew_server, renew_thread)
+
+
+# -- 2. renewal-501-grace: cloud ships renewal disabled behind a flag -------------------
+
+
+def test_renewal_against_server_without_renewal_offered_returns_none_with_no_crash(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Points the enrolled identity's OWN renew_url at a fake server that always 501s.
+
+    Proves two things at once: (a) `renew()` honors an enroll response's
+    OPTIONAL `renew_url` (a DIFFERENT host than the enroll server here,
+    exactly like production's split enroll/renew topology -- see
+    identity.py's module docstring), and (b) the default "renewal not
+    offered yet" (501) grace path: no exception, the attempt is recorded,
+    and the existing identity is left completely unchanged.
+    """
+    renew_server, renew_thread = _start_http_server(_AlwaysRenewUnavailableHandler)
+    enroll_server, enroll_thread = None, None
+    try:
+        renew_url = f"http://127.0.0.1:{renew_server.server_port}"
+        enroll_handler_cls = _make_enroll_handler(
+            broker_url="mqtt://localhost:1",  # never dialed in this test
+            renew_url=renew_url,
+            tenant="e2e-renew",
+            robot_id="robot-renew",
+            expires_at=EXPIRES_AT,
+        )
+        enroll_server, enroll_thread = _start_http_server(enroll_handler_cls)
+        enroll_url = f"http://127.0.0.1:{enroll_server.server_port}"
+
+        directory = tmp_path / "identity"
+        identity = identity_mod.enroll(ENROLL_TOKEN, enroll_url, directory)
+        assert identity.renew_url == renew_url
+
+        result = identity_mod.renew(identity)  # must not raise
+
+        assert result is None
+        doc = yaml.safe_load((directory / "identity.yaml").read_text())
+        assert "last_renewal_attempt_at" in doc  # attempt recorded
+        assert doc["expires_at"] == identity.expires_at  # unchanged -- not a success
+        assert doc["key_file"] == identity.key_path.name  # pointer never moved
+    finally:
+        if enroll_server is not None:
+            _stop_http_server(enroll_server, enroll_thread)
+        _stop_http_server(renew_server, renew_thread)

--- a/test/sink/publish/test_gate.py
+++ b/test/sink/publish/test_gate.py
@@ -44,13 +44,31 @@ def test_gate_passes_when_installed_and_enabled(monkeypatch: pytest.MonkeyPatch)
     assert publish.require_fleet() is None
 
 
-def test_publish_package_does_not_import_paho_eagerly(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Importing src.sink.publish must not pull paho in; only require_fleet() does."""
-    for name in [m for m in sys.modules if m == "paho" or m.startswith("paho.")]:
+def test_publish_package_does_not_import_paho_or_cryptography_eagerly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Importing src.sink.publish must not pull paho or cryptography in.
+
+    Only require_fleet() imports paho; only identity.py's functions import
+    cryptography (see identity.py's module docstring) -- so importing the
+    package itself must stay light regardless of which submodule a caller
+    reaches for next.
+    """
+    for name in [
+        m
+        for m in sys.modules
+        if m == "paho"
+        or m.startswith("paho.")
+        or m == "cryptography"
+        or m.startswith("cryptography.")
+    ]:
         monkeypatch.delitem(sys.modules, name)
     monkeypatch.delitem(sys.modules, "src.sink.publish", raising=False)
     importlib.import_module("src.sink.publish")
-    assert not any(m == "paho" or m.startswith("paho.") for m in sys.modules)
+    assert not any(
+        m == "paho" or m.startswith("paho.") or m == "cryptography" or m.startswith("cryptography.")
+        for m in sys.modules
+    )
 
 
 def test_setting_default_is_enabled() -> None:

--- a/test/sink/publish/test_heartbeat.py
+++ b/test/sink/publish/test_heartbeat.py
@@ -98,6 +98,35 @@ class TestBuildHeartbeat:
         )
         assert payload["spool"] == {"bytes": 0, "pending": 0, "evicted": 0}
 
+    def test_cert_expires_at_defaults_to_none(self) -> None:
+        payload = build_heartbeat(
+            started_at=0.0,
+            subscriptions=[],
+            channels_active=0,
+            queue_depth=0,
+            queue_dropped=0,
+            spool_stats={},
+            disk_free_bytes=0,
+            reconnects=0,
+            now=1.0,
+        )
+        assert payload["cert_expires_at"] is None
+
+    def test_cert_expires_at_passed_through_when_given(self) -> None:
+        payload = build_heartbeat(
+            started_at=0.0,
+            subscriptions=[],
+            channels_active=0,
+            queue_depth=0,
+            queue_dropped=0,
+            spool_stats={},
+            disk_free_bytes=0,
+            reconnects=0,
+            now=1.0,
+            cert_expires_at="2027-01-01T00:00:00Z",
+        )
+        assert payload["cert_expires_at"] == "2027-01-01T00:00:00Z"
+
     def test_accepts_lanestats_like_objects_with_attributes(self) -> None:
         class FakeLaneStats:
             def __init__(self, bytes_: int, pending: int, evicted: int) -> None:
@@ -360,3 +389,79 @@ class TestHeartbeatThread:
 
     def test_module_constant_is_thirty_seconds(self) -> None:
         assert HEARTBEAT_INTERVAL_S == 30.0
+
+
+class TestRenewalCheckHook:
+    def test_synchronous_tick_invokes_renewal_check(self) -> None:
+        pub = FakePublisher()
+        calls = []
+        thread = HeartbeatThread(
+            pub, lambda: {"v": 1}, interval_s=10.0, renewal_check=lambda: calls.append(1)
+        )
+
+        thread._tick()
+
+        assert calls == [1]
+        assert pub.heartbeat_calls == [{"v": 1}]
+
+    def test_no_renewal_check_is_a_safe_default(self) -> None:
+        pub = FakePublisher()
+        thread = HeartbeatThread(pub, lambda: {"v": 1}, interval_s=10.0)
+
+        thread._tick()  # must not raise -- renewal_check defaults to None
+
+        assert pub.heartbeat_calls == [{"v": 1}]
+
+    def test_renewal_check_exception_is_swallowed_and_logged(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        pub = FakePublisher()
+
+        def boom() -> None:
+            raise RuntimeError("renewal exploded")
+
+        thread = HeartbeatThread(pub, lambda: {"v": 1}, interval_s=10.0, renewal_check=boom)
+
+        with caplog.at_level(logging.WARNING):
+            thread._tick()  # must not raise
+
+        # The payload still gets built and published -- the hook's failure
+        # has no bearing on the rest of this tick.
+        assert pub.heartbeat_calls == [{"v": 1}]
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("renewal_check" in r.getMessage() for r in warnings)
+
+    def test_renewal_check_exception_never_kills_the_thread(self) -> None:
+        pub = FakePublisher()
+        ticks = {"n": 0}
+
+        def boom() -> None:
+            ticks["n"] += 1
+            raise RuntimeError("renewal exploded")
+
+        thread = HeartbeatThread(pub, lambda: {"v": 1}, interval_s=0.01, renewal_check=boom)
+        thread.start()
+        try:
+            deadline = time.monotonic() + 2.0
+            while ticks["n"] < 3 and time.monotonic() < deadline:
+                time.sleep(0.01)
+            assert thread.is_alive()
+            assert ticks["n"] >= 3
+        finally:
+            thread.stop()
+        assert not thread.is_alive()  # stop() still joins cleanly afterward
+
+    def test_renewal_check_runs_every_tick(self) -> None:
+        pub = FakePublisher()
+        calls = []
+        thread = HeartbeatThread(
+            pub, lambda: {"v": 1}, interval_s=0.01, renewal_check=lambda: calls.append(1)
+        )
+        thread.start()
+        try:
+            deadline = time.monotonic() + 2.0
+            while len(calls) < 3 and time.monotonic() < deadline:
+                time.sleep(0.01)
+        finally:
+            thread.stop()
+        assert len(calls) >= 3

--- a/test/sink/publish/test_heartbeat.py
+++ b/test/sink/publish/test_heartbeat.py
@@ -181,6 +181,87 @@ class TestBagelVersion:
         assert heartbeat_mod.bagel_version() == "unknown"
 
 
+class TestPyprojectVersionRegexFallback:
+    """CI P0 (Codex review): heartbeat.py's module-level `import tomllib` broke the
+    ros2-humble/iron Docker images (Python 3.10 -- tomllib is stdlib only on
+    3.11+), redding out CI's image import-probe on PR 210. `_pyproject_version()`
+    now parses `[project].version` with a zero-dependency regex instead.
+    """
+
+    def test_parses_version_via_regex_zero_deps(self, tmp_path: pathlib.Path) -> None:
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "bagel"\nversion = "9.9.9"\ndescription = "x"\n'
+        )
+        assert heartbeat_mod._pyproject_version(root=tmp_path) == "9.9.9"
+
+    def test_finds_the_version_line_among_surrounding_content(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "bagel"\nversion = "2.3.0"\n\n[tool.other]\nfoo = "bar"\n'
+        )
+        assert heartbeat_mod._pyproject_version(root=tmp_path) == "2.3.0"
+
+    def test_raises_when_no_version_line_present(self, tmp_path: pathlib.Path) -> None:
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "bagel"\n')
+        with pytest.raises(Exception):  # noqa: B017 -- bagel_version() catches broadly
+            heartbeat_mod._pyproject_version(root=tmp_path)
+
+    def test_raises_when_pyproject_missing(self, tmp_path: pathlib.Path) -> None:
+        with pytest.raises(Exception):  # noqa: B017 -- bagel_version() catches broadly
+            heartbeat_mod._pyproject_version(root=tmp_path)
+
+    def test_bagel_version_falls_back_to_regex_parsed_pyproject_version(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import importlib.metadata
+
+        (tmp_path / "pyproject.toml").write_text('[project]\nversion = "7.7.7"\n')
+        real_pyproject_version = heartbeat_mod._pyproject_version
+
+        def raise_not_found(_name: str) -> str:
+            raise importlib.metadata.PackageNotFoundError("bagel")
+
+        monkeypatch.setattr(heartbeat_mod.importlib.metadata, "version", raise_not_found)
+        monkeypatch.setattr(
+            heartbeat_mod, "_pyproject_version", lambda: real_pyproject_version(tmp_path)
+        )
+
+        assert heartbeat_mod.bagel_version() == "7.7.7"
+
+    def test_bagel_version_returns_unknown_when_pyproject_has_no_version_line(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import importlib.metadata
+
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "bagel"\n')  # no version
+        real_pyproject_version = heartbeat_mod._pyproject_version
+
+        def raise_not_found(_name: str) -> str:
+            raise importlib.metadata.PackageNotFoundError("bagel")
+
+        monkeypatch.setattr(heartbeat_mod.importlib.metadata, "version", raise_not_found)
+        monkeypatch.setattr(
+            heartbeat_mod, "_pyproject_version", lambda: real_pyproject_version(tmp_path)
+        )
+
+        assert heartbeat_mod.bagel_version() == "unknown"
+
+    def test_tomllib_is_not_imported_by_this_module(self) -> None:
+        # The whole point: tomllib is 3.11+ stdlib only, and this module must
+        # import cleanly on the 3.10-based ros2-humble/iron images.
+        assert not hasattr(heartbeat_mod, "tomllib")
+
+    def test_heartbeat_module_does_not_import_tomllib_eagerly(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        for name in [m for m in sys.modules if m == "tomllib" or m.startswith("tomllib.")]:
+            monkeypatch.delitem(sys.modules, name)
+        monkeypatch.delitem(sys.modules, "src.sink.publish.heartbeat", raising=False)
+        importlib.import_module("src.sink.publish.heartbeat")
+        assert not any(m == "tomllib" or m.startswith("tomllib.") for m in sys.modules)
+
+
 class TestDiskFree:
     def test_matches_shutil_disk_usage(self, tmp_path: pathlib.Path) -> None:
         import shutil

--- a/test/sink/publish/test_identity.py
+++ b/test/sink/publish/test_identity.py
@@ -12,6 +12,7 @@ import http.server
 import importlib
 import json
 import logging
+import pathlib
 import ssl
 import stat
 import sys
@@ -116,16 +117,23 @@ class _FakeEnrollHandler(http.server.BaseHTTPRequestHandler):
         robot_cert_pem, ca_cert_pem = _build_ca_and_robot_cert(
             "forced-cn-by-server", csr.public_key()
         )
-        body = json.dumps(
-            {
-                "cert_pem": robot_cert_pem.decode(),
-                "ca_pem": ca_cert_pem.decode(),
-                "broker_url": "mqtts://fleet.example.com:8883",
-                "tenant": "acme",
-                "robot_id": "robot-42",
-                "expires_at": "2027-01-01T00:00:00Z",
-            }
-        ).encode()
+        response_fields = {
+            "cert_pem": robot_cert_pem.decode(),
+            "ca_pem": ca_cert_pem.decode(),
+            "broker_url": "mqtts://fleet.example.com:8883",
+            "tenant": "acme",
+            "robot_id": "robot-42",
+            "expires_at": "2027-01-01T00:00:00Z",
+        }
+        # A "renew-url:<base>" token asks the fake server to additionally
+        # return that as `renew_url` -- proves enroll() stores an OPTIONAL,
+        # server-supplied renew endpoint distinct from its own base (see
+        # TestRenewUrl, which points this at a fake renew server on a
+        # different port than the enroll server, mirroring the real
+        # split-host topology).
+        if token is not None and token.startswith("renew-url:"):
+            response_fields["renew_url"] = token[len("renew-url:") :]
+        body = json.dumps(response_fields).encode()
         self._respond(200, body)
 
     def _respond(self, status: int, body: bytes) -> None:
@@ -301,6 +309,11 @@ class TestEnrollHappyPath:
             "broker_url": "mqtts://fleet.example.com:8883",
             "enroll_url": fake_server,
             "expires_at": "2027-01-01T00:00:00Z",
+            # Pointer fields (see the module docstring): enroll() always
+            # writes them explicitly, equal to load_identity's own defaults.
+            "key_file": "robot.key",
+            "cert_file": "robot.crt",
+            "ca_file": "ca.crt",
         }
         assert result.tenant == on_disk["tenant"]
 
@@ -451,6 +464,51 @@ class TestLoadIdentity:
         loaded = identity_mod.load_identity(directory)
         assert loaded.tenant == "acme"
 
+    def test_legacy_identity_yaml_without_pointer_fields_still_loads(
+        self, fake_server: str, tmp_path: object
+    ) -> None:
+        # Simulates an identity.yaml written before the key_file/cert_file/
+        # ca_file pointer scheme existed: enroll() always writes them now
+        # (see TestEnrollHappyPath.test_identity_yaml_round_trips), so this
+        # strips them back out to exercise load_identity's fallback defaults.
+        directory = tmp_path / "identity"
+        enrolled = identity_mod.enroll(VALID_TOKEN, fake_server, directory)
+        doc = yaml.safe_load((directory / "identity.yaml").read_text())
+        for key in ("key_file", "cert_file", "ca_file", "renew_url"):
+            doc.pop(key, None)
+        (directory / "identity.yaml").write_text(yaml.safe_dump(doc))
+
+        loaded = identity_mod.load_identity(directory)
+
+        assert loaded.key_path == directory / "robot.key"
+        assert loaded.cert_path == directory / "robot.crt"
+        assert loaded.ca_path == directory / "ca.crt"
+        assert loaded.renew_url is None
+        assert loaded.tenant == enrolled.tenant
+        assert loaded.expires_at == enrolled.expires_at
+
+    def test_legacy_identity_without_pointer_fields_is_still_renewable(
+        self, fake_server: str, fake_renew_server: str, tmp_path: object
+    ) -> None:
+        # A legacy identity must not just load -- it must also be usable as
+        # the input to a real renewal (mTLS context built from its resolved
+        # fixed-name paths, then rotated onto the new pointer scheme).
+        directory = tmp_path / "identity"
+        identity_mod.enroll(VALID_TOKEN, fake_server, directory)
+        doc = yaml.safe_load((directory / "identity.yaml").read_text())
+        for key in ("key_file", "cert_file", "ca_file"):
+            doc.pop(key, None)
+        doc["enroll_url"] = fake_renew_server
+        doc["robot_id"] = "renew-ok"
+        (directory / "identity.yaml").write_text(yaml.safe_dump(doc))
+        legacy = identity_mod.load_identity(directory)
+
+        result = identity_mod.renew(legacy)
+
+        assert result is not None
+        assert result.key_path != legacy.key_path  # rotated onto the pointer scheme
+        assert not legacy.key_path.exists()  # old fixed-name file unlinked
+
 
 class TestIsEnrolled:
     def test_true_after_enroll(self, fake_server: str, tmp_path: object) -> None:
@@ -460,6 +518,107 @@ class TestIsEnrolled:
 
     def test_false_on_empty_dir(self, tmp_path: object) -> None:
         assert identity_mod.is_enrolled(tmp_path / "nope") is False
+
+
+class TestRenewUrl:
+    """enroll_url and renew_url are separate BASES -- enroll (path-routed HTTPS)
+    and renew (an mTLS listener on the broker) commonly live on different
+    hosts entirely. See the module docstring.
+    """
+
+    def test_enroll_stores_renew_url_when_response_carries_one(
+        self, fake_server: str, tmp_path: object
+    ) -> None:
+        directory = tmp_path / "identity"
+        token = "renew-url:https://renew.example.com:9443"  # noqa: S105 -- test token, not a secret
+        result = identity_mod.enroll(token, fake_server, directory)
+
+        assert result.renew_url == "https://renew.example.com:9443"
+        doc = yaml.safe_load((directory / "identity.yaml").read_text())
+        assert doc["renew_url"] == "https://renew.example.com:9443"
+
+    def test_enroll_leaves_renew_url_absent_when_response_omits_it(
+        self, fake_server: str, tmp_path: object
+    ) -> None:
+        directory = tmp_path / "identity"
+        result = identity_mod.enroll(VALID_TOKEN, fake_server, directory)
+
+        assert result.renew_url is None
+        doc = yaml.safe_load((directory / "identity.yaml").read_text())
+        assert "renew_url" not in doc
+
+    def test_load_identity_round_trips_renew_url(self, fake_server: str, tmp_path: object) -> None:
+        directory = tmp_path / "identity"
+        token = "renew-url:https://renew.example.com:9443"  # noqa: S105
+        identity_mod.enroll(token, fake_server, directory)
+
+        loaded = identity_mod.load_identity(directory)
+
+        assert loaded.renew_url == "https://renew.example.com:9443"
+
+    def test_load_identity_defaults_renew_url_to_none_when_field_absent(
+        self, fake_server: str, tmp_path: object
+    ) -> None:
+        directory = tmp_path / "identity"
+        identity_mod.enroll(VALID_TOKEN, fake_server, directory)
+
+        loaded = identity_mod.load_identity(directory)
+
+        assert loaded.renew_url is None
+
+    def test_renew_targets_renew_url_not_enroll_url_when_present(
+        self, fake_server: str, fake_renew_server: str, tmp_path: object
+    ) -> None:
+        # The split-host topology proof: the enroll server and the renew
+        # server are two independent fake HTTP servers on two independent
+        # ephemeral ports. enroll_url is deliberately left pointing at a
+        # dead port (nothing listens there) -- if renew() derived its
+        # target from enroll_url instead of renew_url, this would fail with
+        # a connection-refused EnrollmentError-shaped None, not a success.
+        import socket
+
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.bind(("127.0.0.1", 0))
+        dead_port = sock.getsockname()[1]
+        sock.close()
+        dead_enroll_url = f"http://127.0.0.1:{dead_port}"
+
+        directory = tmp_path / "identity"
+        token = f"renew-url:{fake_renew_server}"
+        enrolled = identity_mod.enroll(token, fake_server, directory)
+        identity = dataclasses.replace(enrolled, robot_id="renew-ok", enroll_url=dead_enroll_url)
+        assert identity.renew_url == fake_renew_server
+
+        result = identity_mod.renew(identity)
+
+        assert result is not None  # reached the renew server, not the dead enroll_url
+
+    def test_renew_falls_back_to_enroll_url_when_renew_url_absent(
+        self, fake_server: str, fake_renew_server: str, tmp_path: object
+    ) -> None:
+        # Today's behavior, preserved: no renew_url on the identity means
+        # renew() must still target enroll_url/v1/renew.
+        identity = _identity_for_renew(fake_server, fake_renew_server, tmp_path, "renew-ok")
+        assert identity.renew_url is None
+
+        result = identity_mod.renew(identity)
+
+        assert result is not None
+
+    def test_renew_url_survives_a_renewal_rewrite(
+        self, fake_server: str, fake_renew_server: str, tmp_path: object
+    ) -> None:
+        directory = tmp_path / "identity"
+        token = f"renew-url:{fake_renew_server}"
+        enrolled = identity_mod.enroll(token, fake_server, directory)
+        identity = dataclasses.replace(enrolled, robot_id="renew-ok")
+
+        result = identity_mod.renew(identity)
+
+        assert result is not None
+        assert result.renew_url == fake_renew_server
+        doc = yaml.safe_load((directory / "identity.yaml").read_text())
+        assert doc["renew_url"] == fake_renew_server
 
 
 def test_identity_module_does_not_import_paho_or_cryptography_eagerly(
@@ -544,44 +703,91 @@ class TestShouldAttemptRenewal:
 
 
 class TestRenewHappyPath:
-    def test_replaces_key_and_cert_and_updates_identity_yaml(
+    def test_writes_new_files_under_fresh_basenames_and_repoints_identity_yaml(
         self, fake_server: str, fake_renew_server: str, tmp_path: object
     ) -> None:
         identity = _identity_for_renew(fake_server, fake_renew_server, tmp_path, "renew-ok")
         old_key_bytes = identity.key_path.read_bytes()
         old_cert_bytes = identity.cert_path.read_bytes()
+        old_key_path, old_cert_path = identity.key_path, identity.cert_path
 
         result = identity_mod.renew(identity)
 
         assert result is not None
         assert result.expires_at == "2028-01-01T00:00:00Z"
-        assert result.key_path == identity.key_path
-        assert result.cert_path == identity.cert_path
-        assert result.ca_path == identity.ca_path
         assert result.tenant == identity.tenant
         assert result.broker_url == identity.broker_url
 
-        # New key bytes on disk differ from the old ones -- a fresh key was
-        # generated, not the old one re-used (spec §6, read strictly).
-        assert identity.key_path.read_bytes() != old_key_bytes
-        assert identity.cert_path.read_bytes() != old_cert_bytes
+        # The pointer scheme: renew() never overwrites the old paths in
+        # place -- the new files live under fresh basenames.
+        assert result.key_path != old_key_path
+        assert result.cert_path != old_cert_path
+        assert result.key_path.parent == old_key_path.parent
 
-        mode = stat.S_IMODE(identity.key_path.stat().st_mode)
+        # New key/cert bytes differ from the old ones -- a fresh key was
+        # generated, not the old one re-used (spec §6, read strictly).
+        assert result.key_path.read_bytes() != old_key_bytes
+        assert result.cert_path.read_bytes() != old_cert_bytes
+
+        mode = stat.S_IMODE(result.key_path.stat().st_mode)
         assert mode == 0o600
 
-        doc = yaml.safe_load((identity.key_path.parent / "identity.yaml").read_text())
+        # The old files are unlinked (best-effort cleanup) once the pointer
+        # swap has committed.
+        assert not old_key_path.exists()
+        assert not old_cert_path.exists()
+
+        doc = yaml.safe_load((result.key_path.parent / "identity.yaml").read_text())
         assert doc["expires_at"] == "2028-01-01T00:00:00Z"
+        assert doc["key_file"] == result.key_path.name
+        assert doc["cert_file"] == result.cert_path.name
+        assert doc["ca_file"] == result.ca_path.name
         assert "last_renewal_attempt_at" in doc
 
-    def test_ca_replaced_when_response_includes_ca_pem(
+    def test_ca_replaced_under_a_fresh_basename_when_response_includes_ca_pem(
         self, fake_server: str, fake_renew_server: str, tmp_path: object
     ) -> None:
         identity = _identity_for_renew(fake_server, fake_renew_server, tmp_path, "renew-ok")
         old_ca_bytes = identity.ca_path.read_bytes()
+        old_ca_path = identity.ca_path
 
-        identity_mod.renew(identity)
+        result = identity_mod.renew(identity)
 
-        assert identity.ca_path.read_bytes() != old_ca_bytes
+        assert result is not None
+        assert result.ca_path != old_ca_path
+        assert result.ca_path.read_bytes() != old_ca_bytes
+        assert not old_ca_path.exists()  # unlinked once the swap committed
+
+    def test_ca_pointer_unchanged_when_response_omits_ca_pem(
+        self,
+        fake_server: str,
+        fake_renew_server: str,
+        tmp_path: object,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # The default "renew-ok" scenario's response always carries ca_pem;
+        # this drives the "server didn't re-issue the CA" branch by
+        # stripping it out of the parsed response before renew() inspects it.
+        identity = _identity_for_renew(fake_server, fake_renew_server, tmp_path, "renew-ok")
+        old_ca_path = identity.ca_path
+        old_ca_bytes = old_ca_path.read_bytes()
+
+        real_loads = json.loads
+
+        def strip_ca_pem(raw: object) -> object:
+            payload = real_loads(raw)
+            if isinstance(payload, dict):
+                payload.pop("ca_pem", None)
+            return payload
+
+        monkeypatch.setattr(identity_mod.json, "loads", strip_ca_pem)
+
+        result = identity_mod.renew(identity)
+
+        assert result is not None
+        assert result.ca_path == old_ca_path  # pointer untouched
+        assert result.ca_path.read_bytes() == old_ca_bytes  # never rewritten
+        assert old_ca_path.exists()  # never unlinked either
 
     def test_new_key_is_a_valid_matching_pair_with_new_cert(
         self, fake_server: str, fake_renew_server: str, tmp_path: object
@@ -607,6 +813,137 @@ class TestRenewHappyPath:
         assert result is not None
         loaded = identity_mod.load_identity(identity.key_path.parent)
         assert loaded.expires_at == result.expires_at
+
+
+class TestRenewPointerCommitCrashSemantics:
+    """CRITICAL fix: identity.yaml is the single atomic commit point.
+
+    A crash anywhere before the identity.yaml swap must leave the pointer
+    resolving to the old, complete, matched, USABLE pair (new files are
+    orphans); a crash at/after the swap means the pointer already names a
+    complete new pair (all its files were fully written before the swap).
+    There is no reachable state where the pointer names a mismatched pair.
+    """
+
+    def test_crash_before_the_yaml_swap_leaves_the_old_pair_pointed_at_and_usable(
+        self,
+        fake_server: str,
+        fake_renew_server: str,
+        tmp_path: object,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        identity = _identity_for_renew(fake_server, fake_renew_server, tmp_path, "renew-ok")
+        directory = identity.key_path.parent
+        old_key_path, old_cert_path, old_ca_path = (
+            identity.key_path,
+            identity.cert_path,
+            identity.ca_path,
+        )
+        files_before = {p.name for p in directory.iterdir()}
+
+        real_write_identity_yaml = identity_mod._write_identity_yaml
+
+        def crash_on_pointer_swap(
+            renewed_identity: "identity_mod.Identity", *, key_file: str, **kwargs: object
+        ) -> None:
+            if key_file != renewed_identity.key_path.name:
+                # This IS the success-path pointer swap (a fresh, "robot-"
+                # versioned basename, never the identity's current one) --
+                # simulate a crash exactly here, before os.replace commits it.
+                raise RuntimeError("simulated crash during the identity.yaml swap")
+            # Otherwise it's the failure-path _record_renewal_attempt call
+            # (identity's own CURRENT basenames) -- let that one through so
+            # the attempt still gets recorded, same as a real process would
+            # manage on its next tick.
+            return real_write_identity_yaml(renewed_identity, key_file=key_file, **kwargs)
+
+        monkeypatch.setattr(identity_mod, "_write_identity_yaml", crash_on_pointer_swap)
+
+        result = identity_mod.renew(identity)
+
+        assert result is None  # renew() caught the simulated crash; never raised
+
+        # New versioned files WERE written before the simulated crash (step
+        # 1 of the pointer-commit scheme) -- they exist on disk as orphans,
+        # but nothing points at them yet.
+        files_after = {p.name for p in directory.iterdir()}
+        new_orphans = files_after - files_before
+        assert new_orphans  # step 1's writes landed
+
+        # The old pointer is untouched: load_identity still resolves to the
+        # OLD, complete pair.
+        loaded = identity_mod.load_identity(directory)
+        assert loaded.key_path == old_key_path
+        assert loaded.cert_path == old_cert_path
+        assert loaded.ca_path == old_ca_path
+        assert old_key_path.exists()
+        assert old_cert_path.exists()
+        assert old_ca_path.exists()
+
+        # And that old pair is still genuinely USABLE -- building the mTLS
+        # context over it (load_cert_chain/load_verify_locations) succeeds,
+        # proving it's a matched pair, not the mismatched hazard this scheme
+        # exists to make unreachable.
+        identity_mod._build_mtls_context(loaded)  # must not raise
+
+        doc = yaml.safe_load((directory / "identity.yaml").read_text())
+        assert "last_renewal_attempt_at" in doc  # the fallback attempt-record got through
+        assert doc["key_file"] == old_key_path.name  # pointer never moved
+
+    def test_crash_after_the_yaml_swap_the_new_pair_is_complete_and_usable(
+        self, fake_server: str, fake_renew_server: str, tmp_path: object
+    ) -> None:
+        # There's no code between the yaml swap and the return that can
+        # meaningfully "crash" (best-effort unlinks swallow their own
+        # errors) -- so this documents the postcondition directly: once the
+        # swap has happened at all, everything it points at was already
+        # fully written by step 1, so the new pair is immediately complete
+        # and independently usable, exactly like the old pair was pre-swap.
+        identity = _identity_for_renew(fake_server, fake_renew_server, tmp_path, "renew-ok")
+        directory = identity.key_path.parent
+
+        result = identity_mod.renew(identity)
+
+        assert result is not None
+        loaded = identity_mod.load_identity(directory)
+        assert loaded.key_path == result.key_path
+        assert loaded.cert_path == result.cert_path
+        assert loaded.ca_path == result.ca_path
+        identity_mod._build_mtls_context(loaded)  # must not raise: a matched pair
+
+        doc = yaml.safe_load((directory / "identity.yaml").read_text())
+        assert doc["key_file"] == result.key_path.name
+        assert doc["cert_file"] == result.cert_path.name
+        assert doc["ca_file"] == result.ca_path.name
+
+    def test_unlink_failure_during_cleanup_does_not_fail_the_renewal(
+        self,
+        fake_server: str,
+        fake_renew_server: str,
+        tmp_path: object,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Step 3 (best-effort cleanup) is disk hygiene, not correctness: the
+        # swap already committed in step 2, so a failure removing the
+        # now-orphaned old files must not turn a successful renewal into a
+        # failed one.
+        identity = _identity_for_renew(fake_server, fake_renew_server, tmp_path, "renew-ok")
+        old_key_path = identity.key_path
+
+        real_unlink = pathlib.Path.unlink
+
+        def flaky_unlink(self: pathlib.Path, *args: object, **kwargs: object) -> None:
+            if self == old_key_path:
+                raise OSError("simulated permission denied")
+            return real_unlink(self, *args, **kwargs)
+
+        monkeypatch.setattr(pathlib.Path, "unlink", flaky_unlink)
+
+        result = identity_mod.renew(identity)
+
+        assert result is not None  # the swap succeeded; cleanup failure is swallowed
+        assert result.key_path.exists()
+        assert old_key_path.exists()  # the failed-to-unlink orphan is simply left behind
 
 
 class TestRenewMtlsContext:

--- a/test/sink/publish/test_identity.py
+++ b/test/sink/publish/test_identity.py
@@ -22,6 +22,7 @@ import time
 import pytest
 import yaml
 
+from settings import settings
 from src.sink.publish import EnrollmentError, FleetNotEnrolledError
 from src.sink.publish import identity as identity_mod
 
@@ -510,6 +511,192 @@ class TestLoadIdentity:
         assert not legacy.key_path.exists()  # old fixed-name file unlinked
 
 
+class TestLoadIdentityPointerFieldTypeValidation:
+    """IMPORTANT fix: a hand-edited identity.yaml with a null pointer field must
+    never raise a raw TypeError -- that would brick server boot through
+    ``maybe_enroll_on_first_boot`` (whose contract is "never raises").
+    ``load_identity`` used to do ``directory / data.get("key_file", "robot.key")``,
+    where ``.get``'s default only applies when the key is ABSENT -- an explicit
+    ``key_file: null`` still resolves to ``None`` and blows up the ``/`` operator.
+    """
+
+    def test_null_key_file_is_treated_as_not_enrolled(
+        self, fake_server: str, tmp_path: object
+    ) -> None:
+        directory = tmp_path / "identity"
+        identity_mod.enroll(VALID_TOKEN, fake_server, directory)
+        doc = yaml.safe_load((directory / "identity.yaml").read_text())
+        doc["key_file"] = None
+        (directory / "identity.yaml").write_text(yaml.safe_dump(doc))
+
+        with pytest.raises(FleetNotEnrolledError):
+            identity_mod.load_identity(directory)
+        assert identity_mod.is_enrolled(directory) is False
+
+    def test_null_cert_file_is_treated_as_not_enrolled(
+        self, fake_server: str, tmp_path: object
+    ) -> None:
+        directory = tmp_path / "identity"
+        identity_mod.enroll(VALID_TOKEN, fake_server, directory)
+        doc = yaml.safe_load((directory / "identity.yaml").read_text())
+        doc["cert_file"] = None
+        (directory / "identity.yaml").write_text(yaml.safe_dump(doc))
+
+        with pytest.raises(FleetNotEnrolledError):
+            identity_mod.load_identity(directory)
+
+    def test_null_ca_file_is_treated_as_not_enrolled(
+        self, fake_server: str, tmp_path: object
+    ) -> None:
+        directory = tmp_path / "identity"
+        identity_mod.enroll(VALID_TOKEN, fake_server, directory)
+        doc = yaml.safe_load((directory / "identity.yaml").read_text())
+        doc["ca_file"] = None
+        (directory / "identity.yaml").write_text(yaml.safe_dump(doc))
+
+        with pytest.raises(FleetNotEnrolledError):
+            identity_mod.load_identity(directory)
+
+    def test_non_string_key_file_is_treated_as_not_enrolled(
+        self, fake_server: str, tmp_path: object
+    ) -> None:
+        directory = tmp_path / "identity"
+        identity_mod.enroll(VALID_TOKEN, fake_server, directory)
+        doc = yaml.safe_load((directory / "identity.yaml").read_text())
+        doc["key_file"] = 42
+        (directory / "identity.yaml").write_text(yaml.safe_dump(doc))
+
+        with pytest.raises(FleetNotEnrolledError):
+            identity_mod.load_identity(directory)
+
+    def test_unquoted_expires_at_timestamp_is_treated_as_not_enrolled(
+        self, fake_server: str, tmp_path: object
+    ) -> None:
+        # A hand-edited identity.yaml with an unquoted timestamp: YAML's
+        # implicit resolver parses it as a datetime object, not a string --
+        # should_attempt_renewal's `expires_at.replace("Z", ...)` would then
+        # blow up (or silently misbehave) instead of being treated as the
+        # corrupt/not-enrolled document it actually is.
+        directory = tmp_path / "identity"
+        identity_mod.enroll(VALID_TOKEN, fake_server, directory)
+        text = (directory / "identity.yaml").read_text()
+        text = text.replace(
+            "expires_at: '2027-01-01T00:00:00Z'", "expires_at: 2027-01-01T00:00:00Z"
+        )
+        (directory / "identity.yaml").write_text(text)
+        # Sanity check the edit actually triggers YAML's auto-datetime edge.
+        parsed = yaml.safe_load(text)
+        assert isinstance(parsed["expires_at"], datetime.datetime)
+
+        with pytest.raises(FleetNotEnrolledError):
+            identity_mod.load_identity(directory)
+
+    def test_legacy_absent_pointer_fields_still_default_correctly(
+        self, fake_server: str, tmp_path: object
+    ) -> None:
+        # Regression guard: the null-vs-absent distinction must not break the
+        # existing legacy-loading behavior (see
+        # TestLoadIdentity.test_legacy_identity_yaml_without_pointer_fields_still_loads) --
+        # an ABSENT field still means "use the historical fixed name", only an
+        # EXPLICIT null is corrupt.
+        directory = tmp_path / "identity"
+        identity_mod.enroll(VALID_TOKEN, fake_server, directory)
+        doc = yaml.safe_load((directory / "identity.yaml").read_text())
+        for key in ("key_file", "cert_file", "ca_file"):
+            doc.pop(key, None)
+        (directory / "identity.yaml").write_text(yaml.safe_dump(doc))
+
+        loaded = identity_mod.load_identity(directory)
+
+        assert loaded.key_path == directory / "robot.key"
+        assert loaded.cert_path == directory / "robot.crt"
+        assert loaded.ca_path == directory / "ca.crt"
+
+
+class TestMaybeEnrollOnFirstBootNeverRaisesOnCorruptIdentity:
+    def test_survives_a_null_key_file_in_an_existing_identity_yaml(
+        self, fake_server: str, tmp_path: object, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        directory = tmp_path / "identity"
+        identity_mod.enroll(VALID_TOKEN, fake_server, directory)
+        doc = yaml.safe_load((directory / "identity.yaml").read_text())
+        doc["key_file"] = None
+        (directory / "identity.yaml").write_text(yaml.safe_dump(doc))
+
+        monkeypatch.setattr(settings, "FLEET_ENROLL_TOKEN", VALID_TOKEN)
+        monkeypatch.setattr(settings, "FLEET_ENROLL_URL", fake_server)
+        monkeypatch.setattr(settings, "FLEET_IDENTITY_DIRECTORY", str(directory))
+
+        identity_mod.maybe_enroll_on_first_boot()  # must not raise
+
+        # is_enrolled() saw the corrupt doc as not-enrolled, so this re-enrolled.
+        assert identity_mod.is_enrolled(directory) is True
+
+
+class TestLastRenewalAttemptAtPersistence:
+    """IMPORTANT fix: `last_renewal_attempt_at` must survive a process restart.
+
+    `_write_identity_yaml` already persists it, but `load_identity` never
+    read it back -- a crashlooping robot inside the 30-day renewal window
+    would re-fire a renewal POST on every restart, ignoring the daily rate
+    limit entirely.
+    """
+
+    def test_load_identity_reads_last_renewal_attempt_at(
+        self, fake_server: str, tmp_path: object
+    ) -> None:
+        directory = tmp_path / "identity"
+        identity_mod.enroll(VALID_TOKEN, fake_server, directory)
+        doc = yaml.safe_load((directory / "identity.yaml").read_text())
+        doc["last_renewal_attempt_at"] = 1735689600.5
+        (directory / "identity.yaml").write_text(yaml.safe_dump(doc))
+
+        loaded = identity_mod.load_identity(directory)
+
+        assert loaded.last_renewal_attempt_at == 1735689600.5
+
+    def test_load_identity_defaults_to_none_when_field_absent(
+        self, fake_server: str, tmp_path: object
+    ) -> None:
+        directory = tmp_path / "identity"
+        identity_mod.enroll(VALID_TOKEN, fake_server, directory)  # never writes the field
+
+        loaded = identity_mod.load_identity(directory)
+
+        assert loaded.last_renewal_attempt_at is None
+
+    def test_load_identity_tolerates_a_wrong_typed_value(
+        self, fake_server: str, tmp_path: object
+    ) -> None:
+        directory = tmp_path / "identity"
+        identity_mod.enroll(VALID_TOKEN, fake_server, directory)
+        doc = yaml.safe_load((directory / "identity.yaml").read_text())
+        doc["last_renewal_attempt_at"] = "not-a-number"
+        (directory / "identity.yaml").write_text(yaml.safe_dump(doc))
+
+        loaded = identity_mod.load_identity(directory)
+
+        assert loaded.last_renewal_attempt_at is None
+
+
+class TestIdentityDirectoryPermissions:
+    """MINOR fix: a freshly created identity directory should be 0700, not the
+    default (umask-dependent, typically 0755) mkdir mode -- it holds a
+    private key plus mTLS material.
+    """
+
+    def test_freshly_created_directory_is_mode_0700(
+        self, fake_server: str, tmp_path: object
+    ) -> None:
+        directory = tmp_path / "identity"
+        assert not directory.exists()  # sanity: enroll() must create it
+
+        identity_mod.enroll(VALID_TOKEN, fake_server, directory)
+
+        mode = stat.S_IMODE(directory.stat().st_mode)
+        assert mode == 0o700
+
+
 class TestIsEnrolled:
     def test_true_after_enroll(self, fake_server: str, tmp_path: object) -> None:
         directory = tmp_path / "identity"
@@ -619,6 +806,61 @@ class TestRenewUrl:
         assert result.renew_url == fake_renew_server
         doc = yaml.safe_load((directory / "identity.yaml").read_text())
         assert doc["renew_url"] == fake_renew_server
+
+
+class TestBaseUrlTrailingSlash:
+    """MINOR fix: a trailing slash on the configured base URL must not produce
+    a double slash before the appended path (``FLEET_ENROLL_URL=https://x/``
+    must hit ``.../v1/enroll``, not ``...//v1/enroll``). The stored BASE
+    value itself (``identity.yaml``'s ``enroll_url``) is untouched --
+    trailing slash and all -- only the REQUEST url is stripped.
+    """
+
+    def test_enroll_strips_trailing_slash_before_appending_the_path(
+        self, fake_server: str, tmp_path: object, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured_urls: list[str] = []
+        real_request = identity_mod.urllib.request.Request
+
+        def spy_request(url: str, *args: object, **kwargs: object) -> object:
+            captured_urls.append(url)
+            return real_request(url, *args, **kwargs)
+
+        monkeypatch.setattr(identity_mod.urllib.request, "Request", spy_request)
+
+        directory = tmp_path / "identity"
+        result = identity_mod.enroll(VALID_TOKEN, f"{fake_server}/", directory)
+
+        assert captured_urls == [f"{fake_server}/v1/enroll"]  # no double slash
+        # BASE semantics unchanged: the stored/returned enroll_url is exactly
+        # what was passed in, trailing slash and all.
+        assert result.enroll_url == f"{fake_server}/"
+
+    def test_renew_strips_trailing_slash_before_appending_the_path(
+        self,
+        fake_server: str,
+        fake_renew_server: str,
+        tmp_path: object,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        identity = _identity_for_renew(
+            fake_server, f"{fake_renew_server}/", tmp_path, "renew-ok"
+        )
+        assert identity.enroll_url == f"{fake_renew_server}/"  # renew_url absent -> falls back
+
+        captured_urls: list[str] = []
+        real_request = identity_mod.urllib.request.Request
+
+        def spy_request(url: str, *args: object, **kwargs: object) -> object:
+            captured_urls.append(url)
+            return real_request(url, *args, **kwargs)
+
+        monkeypatch.setattr(identity_mod.urllib.request, "Request", spy_request)
+
+        result = identity_mod.renew(identity)
+
+        assert result is not None
+        assert captured_urls == [f"{fake_renew_server}/v1/renew"]  # no double slash
 
 
 def test_identity_module_does_not_import_paho_or_cryptography_eagerly(

--- a/test/sink/publish/test_identity.py
+++ b/test/sink/publish/test_identity.py
@@ -25,6 +25,9 @@ UNKNOWN_TOKEN = "unknown-token"  # noqa: S105
 USED_TOKEN = "used-token"  # noqa: S105
 MALFORMED_TOKEN = "malformed-token"  # noqa: S105
 SERVER_ERROR_TOKEN = "server-error-token"  # noqa: S105
+# A 500 whose body echoes this token verbatim (debug-mode server / reflecting
+# proxy / malicious endpoint) -- the redaction regression test's token.
+ECHOING_ERROR_TOKEN = "echoing-error-token-secret-xyz"  # noqa: S105
 
 
 def _build_ca_and_robot_cert(common_name: str, robot_public_key: object) -> tuple[bytes, bytes]:
@@ -93,6 +96,11 @@ class _FakeEnrollHandler(http.server.BaseHTTPRequestHandler):
             return
         if token == SERVER_ERROR_TOKEN:
             self._respond(500, b"internal error")
+            return
+        if token == ECHOING_ERROR_TOKEN:
+            # Simulates a debug-mode server (or a reflecting proxy/WAF) that
+            # echoes the failed request back in its error body, token included.
+            self._respond(500, f"internal error, request was: {raw.decode()}".encode())
             return
         if token == MALFORMED_TOKEN:
             self._respond(200, json.dumps({"cert_pem": "not enough fields"}).encode())
@@ -295,6 +303,22 @@ class TestTokenHygiene:
         assert UNKNOWN_TOKEN not in excinfo.value.reason
         for record in caplog.records:
             assert UNKNOWN_TOKEN not in record.getMessage()
+
+    def test_token_is_redacted_from_an_echoing_server_error_body(
+        self, fake_server: str, tmp_path: object, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # The 401/410 branches use hardcoded reason strings, so they can't leak
+        # the token even by accident -- this covers the general (other-status)
+        # branch, which forwards a snippet of the server's actual body.
+        with caplog.at_level(logging.DEBUG):
+            with pytest.raises(EnrollmentError) as excinfo:
+                identity_mod.enroll(ECHOING_ERROR_TOKEN, fake_server, tmp_path / "identity")
+        assert excinfo.value.status == 500
+        assert ECHOING_ERROR_TOKEN not in excinfo.value.reason
+        assert ECHOING_ERROR_TOKEN not in str(excinfo.value)
+        assert "***REDACTED***" in excinfo.value.reason
+        for record in caplog.records:
+            assert ECHOING_ERROR_TOKEN not in record.getMessage()
 
 
 class TestLoadIdentity:

--- a/test/sink/publish/test_identity.py
+++ b/test/sink/publish/test_identity.py
@@ -13,6 +13,7 @@ import importlib
 import json
 import logging
 import pathlib
+import socket
 import ssl
 import stat
 import sys
@@ -855,6 +856,111 @@ class TestRenewUrl:
         assert result.renew_url == fake_renew_server
         doc = yaml.safe_load((directory / "identity.yaml").read_text())
         assert doc["renew_url"] == fake_renew_server
+
+
+class TestEnrollUrlSchemeGate:
+    """Codex review (3909074259): enroll() only checked that enroll_url was
+    http(s) at all -- any nonlocal http:// host was accepted, POSTing the
+    one-time token in cleartext. Now requires https:// unless the host is
+    loopback/private (`connect._is_local_or_private`, reused not duplicated)
+    or `settings.FLEET_DEV_INSECURE` is set -- mirrors the broker's own
+    plaintext-transport policy exactly.
+    """
+
+    def test_nonlocal_http_raises_typed_insecure_error(
+        self, tmp_path: object, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def fake_getaddrinfo(host: str, *_a: object, **_kw: object) -> list:
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("8.8.8.8", 0))]
+
+        monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+
+        request_calls: list[str] = []
+        monkeypatch.setattr(
+            identity_mod.urllib.request,
+            "Request",
+            lambda url, *a, **kw: request_calls.append(url),
+        )
+
+        with pytest.raises(EnrollmentError) as excinfo:
+            identity_mod.enroll(VALID_TOKEN, "http://enroll.example.com", tmp_path / "identity")
+
+        assert excinfo.value.status == 0
+        assert excinfo.value.reason == "insecure enroll_url"
+        assert request_calls == []  # rejected before any network call
+
+    def test_localhost_http_is_ok(self, fake_server: str, tmp_path: object) -> None:
+        # fake_server binds 127.0.0.1 -- a loopback literal -- which the gate
+        # must allow over plain http with no FLEET_DEV_INSECURE needed.
+        assert fake_server.startswith("http://127.0.0.1")
+        result = identity_mod.enroll(VALID_TOKEN, fake_server, tmp_path / "identity")
+        assert result.tenant == "acme"
+
+    def test_https_is_always_ok(self, tmp_path: object, monkeypatch: pytest.MonkeyPatch) -> None:
+        def fake_getaddrinfo(host: str, *_a: object, **_kw: object) -> list:
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("8.8.8.8", 0))]
+
+        monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+
+        # No real server needed -- prove the gate itself doesn't reject this
+        # URL by checking the shared helper directly, since a real https
+        # POST needs a TLS listener out of scope here (covered by
+        # test_mqtt_integration.py-style real-TLS tests elsewhere).
+        assert identity_mod._url_passes_scheme_gate("https://enroll.example.com") is True
+
+    def test_dev_insecure_allows_nonlocal_http(
+        self, tmp_path: object, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def fake_getaddrinfo(host: str, *_a: object, **_kw: object) -> list:
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("8.8.8.8", 0))]
+
+        monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+        monkeypatch.setattr(settings, "FLEET_DEV_INSECURE", True)
+
+        assert identity_mod._url_passes_scheme_gate("http://enroll.example.com") is True
+
+
+class TestRenewUrlSchemeGate:
+    """Same gate applied to the renew URL at use time -- renew() never
+    raises (per its contract), so an insecure target is treated the same as
+    the existing "not http(s)" branch: logged, the attempt recorded, None
+    returned.
+    """
+
+    def test_insecure_renew_target_is_skipped_not_attempted(
+        self, fake_server: str, tmp_path: object, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Enroll for real (against fake_server's real loopback listener)
+        # BEFORE faking getaddrinfo -- urlopen's own connection setup also
+        # goes through socket.getaddrinfo, so faking it globally during the
+        # enroll() call would break that real connection too, not just the
+        # _is_local_or_private check this test cares about.
+        directory = tmp_path / "identity"
+        enrolled = identity_mod.enroll(VALID_TOKEN, fake_server, directory)
+        identity = dataclasses.replace(
+            enrolled, robot_id="renew-ok", enroll_url="http://renew.example.com"
+        )
+
+        def fake_getaddrinfo(host: str, *_a: object, **_kw: object) -> list:
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("8.8.8.8", 0))]
+
+        monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+
+        request_calls: list[str] = []
+        real_request = identity_mod.urllib.request.Request
+
+        def spy_request(url: str, *a: object, **kw: object) -> object:
+            request_calls.append(url)
+            return real_request(url, *a, **kw)
+
+        monkeypatch.setattr(identity_mod.urllib.request, "Request", spy_request)
+
+        result = identity_mod.renew(identity)
+
+        assert result is None
+        assert request_calls == []  # never attempted the POST
+        doc = yaml.safe_load((directory / "identity.yaml").read_text())
+        assert "last_renewal_attempt_at" in doc  # attempt still recorded
 
 
 class TestBaseUrlTrailingSlash:

--- a/test/sink/publish/test_identity.py
+++ b/test/sink/publish/test_identity.py
@@ -613,6 +613,55 @@ class TestLoadIdentityPointerFieldTypeValidation:
         assert loaded.ca_path == directory / "ca.crt"
 
 
+class TestMaybeEnrollOnFirstBootKillSwitch:
+    """Codex review: FLEET_ENABLED=0 must make maybe_enroll_on_first_boot() a
+    no-op even when a one-time token+URL are configured -- the kill switch's
+    documented "makes the subsystem inert" contract previously had no guard
+    in this call path (server.py's __main__ calls it unconditionally).
+    """
+
+    def test_fleet_disabled_skips_enrollment_even_with_token_and_url_set(
+        self, tmp_path: object, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        directory = tmp_path / "identity"
+        monkeypatch.setattr(settings, "FLEET_ENABLED", False)
+        monkeypatch.setattr(settings, "FLEET_ENROLL_TOKEN", "some-token")
+        monkeypatch.setattr(settings, "FLEET_ENROLL_URL", "https://enroll.example.com")
+        monkeypatch.setattr(settings, "FLEET_IDENTITY_DIRECTORY", str(directory))
+
+        calls = []
+
+        def spy_enroll(*a: object, **kw: object) -> None:
+            calls.append((a, kw))
+            raise AssertionError("enroll() must not be called when FLEET_ENABLED=0")
+
+        monkeypatch.setattr(identity_mod, "enroll", spy_enroll)
+
+        identity_mod.maybe_enroll_on_first_boot()  # must not raise, must not enroll
+
+        assert calls == []  # enroll() itself was never invoked -- not just its raise swallowed
+        assert identity_mod.is_enrolled(directory) is False
+
+    def test_fleet_disabled_logs_skip_reason(
+        self,
+        tmp_path: object,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        directory = tmp_path / "identity"
+        monkeypatch.setattr(settings, "FLEET_ENABLED", False)
+        monkeypatch.setattr(settings, "FLEET_ENROLL_TOKEN", "some-token")
+        monkeypatch.setattr(settings, "FLEET_ENROLL_URL", "https://enroll.example.com")
+        monkeypatch.setattr(settings, "FLEET_IDENTITY_DIRECTORY", str(directory))
+
+        with caplog.at_level(logging.DEBUG):
+            identity_mod.maybe_enroll_on_first_boot()
+
+        assert any(
+            "FLEET_ENABLED" in record.getMessage() for record in caplog.records
+        )
+
+
 class TestMaybeEnrollOnFirstBootNeverRaisesOnCorruptIdentity:
     def test_survives_a_null_key_file_in_an_existing_identity_yaml(
         self, fake_server: str, tmp_path: object, monkeypatch: pytest.MonkeyPatch

--- a/test/sink/publish/test_identity.py
+++ b/test/sink/publish/test_identity.py
@@ -6,13 +6,17 @@ cryptography right here in the test -- so the PEMs written to disk by
 ``enroll()`` are real, parseable certs, not string fixtures.
 """
 
+import dataclasses
+import datetime
 import http.server
 import importlib
 import json
 import logging
+import ssl
 import stat
 import sys
 import threading
+import time
 
 import pytest
 import yaml
@@ -144,6 +148,92 @@ def fake_server() -> str:
         server.shutdown()
         thread.join(timeout=5)
         server.server_close()
+
+
+class _FakeRenewHandler(http.server.BaseHTTPRequestHandler):
+    """POST /v1/renew -- canned responses keyed off the CSR's common name.
+
+    renew()'s request carries no token to key a scenario off (unlike
+    enroll's fake server), so these tests instead set `identity.robot_id` to
+    a scenario name before calling `renew()` -- `renew()` uses `robot_id` as
+    the CSR's advisory common name, so this handler reads it back off the
+    CSR it receives.
+    """
+
+    def log_message(self, fmt: str, *args: object) -> None:
+        pass  # Silence the default stderr access log during tests.
+
+    def do_POST(self) -> None:
+        length = int(self.headers.get("Content-Length", "0"))
+        raw = self.rfile.read(length)
+        payload = json.loads(raw)
+        csr_pem = payload["csr_pem"].encode()
+
+        from cryptography import x509
+        from cryptography.x509.oid import NameOID
+
+        csr = x509.load_pem_x509_csr(csr_pem)
+        scenario = csr.subject.get_attributes_for_oid(NameOID.COMMON_NAME)[0].value
+
+        if scenario == "renew-501":
+            self._respond(501, b"renewal not enabled on this deployment")
+            return
+        if scenario == "renew-404":
+            self._respond(404, b"not found")
+            return
+        if scenario == "renew-500":
+            self._respond(500, b"internal error")
+            return
+        if scenario == "renew-malformed":
+            self._respond(200, json.dumps({"cert_pem": "only-this-field"}).encode())
+            return
+        if scenario == "renew-not-json":
+            self._respond(200, b"not json at all")
+            return
+
+        robot_cert_pem, ca_cert_pem = _build_ca_and_robot_cert("renewed-cn", csr.public_key())
+        body = json.dumps(
+            {
+                "cert_pem": robot_cert_pem.decode(),
+                "ca_pem": ca_cert_pem.decode(),
+                "expires_at": "2028-01-01T00:00:00Z",
+            }
+        ).encode()
+        self._respond(200, body)
+
+    def _respond(self, status: int, body: bytes) -> None:
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+@pytest.fixture
+def fake_renew_server() -> str:
+    """Start the fake renew server on an ephemeral port; yield its base URL."""
+    server = http.server.HTTPServer(("127.0.0.1", 0), _FakeRenewHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
+
+
+def _identity_for_renew(
+    fake_server: str, fake_renew_server: str, tmp_path: object, scenario: str
+) -> "identity_mod.Identity":
+    """Enroll for real key/cert/ca files, then point at the renew server with a scenario CN.
+
+    `_FakeRenewHandler` reads `scenario` back off the CSR's common name (see
+    its docstring) to pick a canned response.
+    """
+    directory = tmp_path / "identity"
+    enrolled = identity_mod.enroll(VALID_TOKEN, fake_server, directory)
+    return dataclasses.replace(enrolled, robot_id=scenario, enroll_url=fake_renew_server)
 
 
 class TestGenerateKeyAndCsr:
@@ -390,3 +480,319 @@ def test_identity_module_does_not_import_paho_or_cryptography_eagerly(
         m == "paho" or m.startswith("paho.") or m == "cryptography" or m.startswith("cryptography.")
         for m in sys.modules
     )
+
+
+def _iso_in(now_epoch: float, days: float) -> str:
+    """An ISO-8601 "Z" timestamp `days` (may be negative/fractional) from `now_epoch`."""
+    dt = datetime.datetime.fromtimestamp(now_epoch, tz=datetime.UTC) + datetime.timedelta(days=days)
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+class TestShouldAttemptRenewal:
+    def test_29_days_out_no_prior_attempt_is_due(self) -> None:
+        now = time.time()
+        assert identity_mod.should_attempt_renewal(now, _iso_in(now, 29), None) is True
+
+    def test_30_days_out_boundary_is_due(self) -> None:
+        now = time.time()
+        assert identity_mod.should_attempt_renewal(now, _iso_in(now, 30), None) is True
+
+    def test_31_days_out_is_not_due(self) -> None:
+        now = time.time()
+        assert identity_mod.should_attempt_renewal(now, _iso_in(now, 31), None) is False
+
+    def test_already_past_expiry_is_due(self) -> None:
+        now = time.time()
+        assert identity_mod.should_attempt_renewal(now, _iso_in(now, -5), None) is True
+
+    def test_23h_since_last_attempt_is_not_due(self) -> None:
+        now = time.time()
+        last_attempt = now - 23 * 3600
+        assert identity_mod.should_attempt_renewal(now, _iso_in(now, 5), last_attempt) is False
+
+    def test_25h_since_last_attempt_is_due(self) -> None:
+        now = time.time()
+        last_attempt = now - 25 * 3600
+        assert identity_mod.should_attempt_renewal(now, _iso_in(now, 5), last_attempt) is True
+
+    def test_exactly_86400s_since_last_attempt_boundary_is_due(self) -> None:
+        now = time.time()
+        last_attempt = now - 86400
+        assert identity_mod.should_attempt_renewal(now, _iso_in(now, 5), last_attempt) is True
+
+    def test_no_prior_attempt_within_window_is_due(self) -> None:
+        now = time.time()
+        assert identity_mod.should_attempt_renewal(now, _iso_in(now, 1), None) is True
+
+    def test_outside_window_ignores_last_attempt_recency(self) -> None:
+        # Even a last attempt from a second ago doesn't make this due --
+        # the expiry window gates first, independent of rate limiting.
+        now = time.time()
+        last_attempt = now - 1
+        assert identity_mod.should_attempt_renewal(now, _iso_in(now, 60), last_attempt) is False
+
+    def test_accepts_a_non_z_utc_offset(self) -> None:
+        now = time.time()
+        expires_dt = datetime.datetime.fromtimestamp(
+            now, tz=datetime.timezone(datetime.timedelta(hours=5))
+        ) + datetime.timedelta(days=1)
+        assert identity_mod.should_attempt_renewal(now, expires_dt.isoformat(), None) is True
+
+    def test_naive_timestamp_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="timezone"):
+            identity_mod.should_attempt_renewal(time.time(), "2027-01-01T00:00:00", None)
+
+
+class TestRenewHappyPath:
+    def test_replaces_key_and_cert_and_updates_identity_yaml(
+        self, fake_server: str, fake_renew_server: str, tmp_path: object
+    ) -> None:
+        identity = _identity_for_renew(fake_server, fake_renew_server, tmp_path, "renew-ok")
+        old_key_bytes = identity.key_path.read_bytes()
+        old_cert_bytes = identity.cert_path.read_bytes()
+
+        result = identity_mod.renew(identity)
+
+        assert result is not None
+        assert result.expires_at == "2028-01-01T00:00:00Z"
+        assert result.key_path == identity.key_path
+        assert result.cert_path == identity.cert_path
+        assert result.ca_path == identity.ca_path
+        assert result.tenant == identity.tenant
+        assert result.broker_url == identity.broker_url
+
+        # New key bytes on disk differ from the old ones -- a fresh key was
+        # generated, not the old one re-used (spec §6, read strictly).
+        assert identity.key_path.read_bytes() != old_key_bytes
+        assert identity.cert_path.read_bytes() != old_cert_bytes
+
+        mode = stat.S_IMODE(identity.key_path.stat().st_mode)
+        assert mode == 0o600
+
+        doc = yaml.safe_load((identity.key_path.parent / "identity.yaml").read_text())
+        assert doc["expires_at"] == "2028-01-01T00:00:00Z"
+        assert "last_renewal_attempt_at" in doc
+
+    def test_ca_replaced_when_response_includes_ca_pem(
+        self, fake_server: str, fake_renew_server: str, tmp_path: object
+    ) -> None:
+        identity = _identity_for_renew(fake_server, fake_renew_server, tmp_path, "renew-ok")
+        old_ca_bytes = identity.ca_path.read_bytes()
+
+        identity_mod.renew(identity)
+
+        assert identity.ca_path.read_bytes() != old_ca_bytes
+
+    def test_new_key_is_a_valid_matching_pair_with_new_cert(
+        self, fake_server: str, fake_renew_server: str, tmp_path: object
+    ) -> None:
+        from cryptography import x509
+        from cryptography.hazmat.primitives import serialization
+
+        identity = _identity_for_renew(fake_server, fake_renew_server, tmp_path, "renew-ok")
+        result = identity_mod.renew(identity)
+        assert result is not None
+
+        private_key = serialization.load_pem_private_key(
+            result.key_path.read_bytes(), password=None
+        )
+        cert = x509.load_pem_x509_certificate(result.cert_path.read_bytes())
+        assert cert.public_key().public_numbers() == private_key.public_key().public_numbers()
+
+    def test_returned_identity_round_trips_through_load_identity(
+        self, fake_server: str, fake_renew_server: str, tmp_path: object
+    ) -> None:
+        identity = _identity_for_renew(fake_server, fake_renew_server, tmp_path, "renew-ok")
+        result = identity_mod.renew(identity)
+        assert result is not None
+        loaded = identity_mod.load_identity(identity.key_path.parent)
+        assert loaded.expires_at == result.expires_at
+
+
+class TestRenewMtlsContext:
+    def test_load_cert_chain_and_verify_locations_called_with_identity_paths(
+        self,
+        fake_server: str,
+        fake_renew_server: str,
+        tmp_path: object,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Spy on the real ssl.SSLContext methods (still calling through to
+        # the real implementation) rather than faking the transport -- the
+        # POST itself still goes out for real, just over plain HTTP to the
+        # fake server (urlopen ignores context= for an http:// URL); this
+        # only asserts the mTLS context was BUILT with the right material.
+        identity = _identity_for_renew(fake_server, fake_renew_server, tmp_path, "renew-ok")
+        cert_chain_calls: list[tuple] = []
+        verify_calls: list[tuple] = []
+        original_load_cert_chain = ssl.SSLContext.load_cert_chain
+        original_load_verify_locations = ssl.SSLContext.load_verify_locations
+
+        def spy_load_cert_chain(self: ssl.SSLContext, *args: object, **kwargs: object) -> None:
+            cert_chain_calls.append((args, kwargs))
+            return original_load_cert_chain(self, *args, **kwargs)
+
+        def spy_load_verify_locations(
+            self: ssl.SSLContext, *args: object, **kwargs: object
+        ) -> None:
+            verify_calls.append((args, kwargs))
+            return original_load_verify_locations(self, *args, **kwargs)
+
+        monkeypatch.setattr(ssl.SSLContext, "load_cert_chain", spy_load_cert_chain)
+        monkeypatch.setattr(ssl.SSLContext, "load_verify_locations", spy_load_verify_locations)
+
+        result = identity_mod.renew(identity)
+
+        assert result is not None  # the real POST against the fake server still succeeded
+        assert len(cert_chain_calls) == 1
+        _, cert_chain_kwargs = cert_chain_calls[0]
+        assert cert_chain_kwargs["certfile"] == str(identity.cert_path)
+        assert cert_chain_kwargs["keyfile"] == str(identity.key_path)
+        assert len(verify_calls) == 1
+        _, verify_kwargs = verify_calls[0]
+        assert verify_kwargs["cafile"] == str(identity.ca_path)
+
+
+class TestRenewUnavailable:
+    def test_501_returns_none_records_attempt_and_logs_info(
+        self,
+        fake_server: str,
+        fake_renew_server: str,
+        tmp_path: object,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        identity = _identity_for_renew(fake_server, fake_renew_server, tmp_path, "renew-501")
+        old_expires_at = identity.expires_at
+
+        with caplog.at_level(logging.INFO):
+            result = identity_mod.renew(identity)
+
+        assert result is None
+        doc = yaml.safe_load((identity.key_path.parent / "identity.yaml").read_text())
+        assert doc["expires_at"] == old_expires_at  # unchanged -- not a success
+        assert "last_renewal_attempt_at" in doc  # attempt still recorded
+        infos = [r for r in caplog.records if r.levelno == logging.INFO]
+        assert any("renewal" in r.getMessage().lower() for r in infos)
+        warnings_ = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert warnings_ == []  # 501 is expected/quiet, not a warning
+
+    def test_404_returns_none_records_attempt_and_logs_info(
+        self,
+        fake_server: str,
+        fake_renew_server: str,
+        tmp_path: object,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        identity = _identity_for_renew(fake_server, fake_renew_server, tmp_path, "renew-404")
+
+        with caplog.at_level(logging.INFO):
+            result = identity_mod.renew(identity)
+
+        assert result is None
+        doc = yaml.safe_load((identity.key_path.parent / "identity.yaml").read_text())
+        assert "last_renewal_attempt_at" in doc
+        infos = [r for r in caplog.records if r.levelno == logging.INFO]
+        assert any("renewal" in r.getMessage().lower() for r in infos)
+
+
+class TestRenewOtherFailures:
+    def test_server_error_returns_none_records_attempt_and_logs_warning(
+        self,
+        fake_server: str,
+        fake_renew_server: str,
+        tmp_path: object,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        identity = _identity_for_renew(fake_server, fake_renew_server, tmp_path, "renew-500")
+
+        with caplog.at_level(logging.WARNING):
+            result = identity_mod.renew(identity)
+
+        assert result is None
+        doc = yaml.safe_load((identity.key_path.parent / "identity.yaml").read_text())
+        assert "last_renewal_attempt_at" in doc
+        warnings_ = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert warnings_
+
+    def test_malformed_200_response_returns_none(
+        self, fake_server: str, fake_renew_server: str, tmp_path: object
+    ) -> None:
+        identity = _identity_for_renew(fake_server, fake_renew_server, tmp_path, "renew-malformed")
+        assert identity_mod.renew(identity) is None
+
+    def test_non_json_200_response_returns_none(
+        self, fake_server: str, fake_renew_server: str, tmp_path: object
+    ) -> None:
+        identity = _identity_for_renew(fake_server, fake_renew_server, tmp_path, "renew-not-json")
+        assert identity_mod.renew(identity) is None
+
+    def test_connection_refused_returns_none_and_records_attempt(
+        self, fake_server: str, tmp_path: object
+    ) -> None:
+        import socket
+
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.bind(("127.0.0.1", 0))
+        port = sock.getsockname()[1]
+        sock.close()
+
+        identity = _identity_for_renew(
+            fake_server, f"http://127.0.0.1:{port}", tmp_path, "renew-ok"
+        )
+        result = identity_mod.renew(identity)
+
+        assert result is None
+        doc = yaml.safe_load((identity.key_path.parent / "identity.yaml").read_text())
+        assert "last_renewal_attempt_at" in doc
+
+
+class TestRenewNeverRaises:
+    def test_unexpected_exception_is_caught_logged_and_returns_none(
+        self,
+        fake_server: str,
+        fake_renew_server: str,
+        tmp_path: object,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        identity = _identity_for_renew(fake_server, fake_renew_server, tmp_path, "renew-ok")
+
+        def boom(*_a: object, **_kw: object) -> tuple:
+            raise RuntimeError("keygen exploded")
+
+        monkeypatch.setattr(identity_mod, "generate_key_and_csr", boom)
+
+        with caplog.at_level(logging.WARNING):
+            result = identity_mod.renew(identity)  # must not raise
+
+        assert result is None
+        doc = yaml.safe_load((identity.key_path.parent / "identity.yaml").read_text())
+        assert "last_renewal_attempt_at" in doc  # even an unexpected failure records the attempt
+        warnings_ = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert warnings_
+
+
+class TestFailedRenewalLeavesIdentityIntact:
+    """Self-review requirement: a failed renewal deletes nothing and changes no old bytes."""
+
+    @pytest.mark.parametrize(
+        "scenario", ["renew-501", "renew-404", "renew-500", "renew-malformed", "renew-not-json"]
+    )
+    def test_all_files_present_and_byte_identical_except_the_attempt_timestamp(
+        self, fake_server: str, fake_renew_server: str, tmp_path: object, scenario: str
+    ) -> None:
+        identity = _identity_for_renew(fake_server, fake_renew_server, tmp_path, scenario)
+        directory = identity.key_path.parent
+        before = {p.name: p.read_bytes() for p in directory.iterdir()}
+
+        result = identity_mod.renew(identity)
+
+        assert result is None
+        after_names = {p.name for p in directory.iterdir()}
+        assert after_names == set(before)  # nothing deleted, nothing extra created
+        for name, data in before.items():
+            if name == "identity.yaml":
+                continue  # last_renewal_attempt_at legitimately changes on every attempt
+            assert directory.joinpath(name).read_bytes() == data, (
+                f"{name} changed on a failed renewal -- old identity must stay intact"
+            )

--- a/test/sink/publish/test_identity.py
+++ b/test/sink/publish/test_identity.py
@@ -1,0 +1,368 @@
+"""Enrollment client: keygen, CSR, enroll/store/load identity (spec §6).
+
+The fake enroll server is a real stdlib http.server, started on 127.0.0.1:0 in
+a background thread, backed by a throwaway CA + signed robot cert built with
+cryptography right here in the test -- so the PEMs written to disk by
+``enroll()`` are real, parseable certs, not string fixtures.
+"""
+
+import http.server
+import importlib
+import json
+import logging
+import stat
+import sys
+import threading
+
+import pytest
+import yaml
+
+from src.sink.publish import EnrollmentError, FleetNotEnrolledError
+from src.sink.publish import identity as identity_mod
+
+VALID_TOKEN = "valid-token"  # noqa: S105 -- test fixture token, not a real secret
+UNKNOWN_TOKEN = "unknown-token"  # noqa: S105
+USED_TOKEN = "used-token"  # noqa: S105
+MALFORMED_TOKEN = "malformed-token"  # noqa: S105
+SERVER_ERROR_TOKEN = "server-error-token"  # noqa: S105
+
+
+def _build_ca_and_robot_cert(common_name: str, robot_public_key: object) -> tuple[bytes, bytes]:
+    """Build a throwaway self-signed CA and a robot cert it signs, both as PEM.
+
+    Returns (robot_cert_pem, ca_cert_pem).
+    """
+    import datetime
+
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import ec
+    from cryptography.x509.oid import NameOID
+
+    ca_key = ec.generate_private_key(ec.SECP256R1())
+    ca_name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "test fleet CA")])
+    now = datetime.datetime.now(datetime.UTC)
+    ca_cert = (
+        x509.CertificateBuilder()
+        .subject_name(ca_name)
+        .issuer_name(ca_name)
+        .public_key(ca_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - datetime.timedelta(days=1))
+        .not_valid_after(now + datetime.timedelta(days=365))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        .sign(ca_key, hashes.SHA256())
+    )
+
+    robot_name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, common_name)])
+    robot_cert = (
+        x509.CertificateBuilder()
+        .subject_name(robot_name)
+        .issuer_name(ca_name)
+        .public_key(robot_public_key)
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - datetime.timedelta(days=1))
+        .not_valid_after(now + datetime.timedelta(days=90))
+        .sign(ca_key, hashes.SHA256())
+    )
+
+    return (
+        robot_cert.public_bytes(serialization.Encoding.PEM),
+        ca_cert.public_bytes(serialization.Encoding.PEM),
+    )
+
+
+class _FakeEnrollHandler(http.server.BaseHTTPRequestHandler):
+    """POST /v1/enroll -- canned responses keyed off the request's token."""
+
+    def log_message(self, fmt: str, *args: object) -> None:
+        pass  # Silence the default stderr access log during tests.
+
+    def do_POST(self) -> None:
+        length = int(self.headers.get("Content-Length", "0"))
+        raw = self.rfile.read(length)
+        payload = json.loads(raw)
+        token = payload.get("token")
+        csr_pem = payload["csr_pem"].encode()
+
+        if token == UNKNOWN_TOKEN:
+            self._respond(401, b"unknown token")
+            return
+        if token == USED_TOKEN:
+            self._respond(410, b"token already used")
+            return
+        if token == SERVER_ERROR_TOKEN:
+            self._respond(500, b"internal error")
+            return
+        if token == MALFORMED_TOKEN:
+            self._respond(200, json.dumps({"cert_pem": "not enough fields"}).encode())
+            return
+
+        from cryptography import x509
+
+        csr = x509.load_pem_x509_csr(csr_pem)
+        robot_cert_pem, ca_cert_pem = _build_ca_and_robot_cert(
+            "forced-cn-by-server", csr.public_key()
+        )
+        body = json.dumps(
+            {
+                "cert_pem": robot_cert_pem.decode(),
+                "ca_pem": ca_cert_pem.decode(),
+                "broker_url": "mqtts://fleet.example.com:8883",
+                "tenant": "acme",
+                "robot_id": "robot-42",
+                "expires_at": "2027-01-01T00:00:00Z",
+            }
+        ).encode()
+        self._respond(200, body)
+
+    def _respond(self, status: int, body: bytes) -> None:
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+@pytest.fixture
+def fake_server() -> str:
+    """Start the fake enroll server on an ephemeral port; yield its base URL."""
+    server = http.server.HTTPServer(("127.0.0.1", 0), _FakeEnrollHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
+
+
+class TestGenerateKeyAndCsr:
+    def test_returns_parseable_ec_key_and_csr(self) -> None:
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric import ec
+        from cryptography.x509 import load_pem_x509_csr
+        from cryptography.x509.oid import NameOID
+
+        key_pem, csr_pem = identity_mod.generate_key_and_csr(common_name="my-robot")
+
+        private_key = serialization.load_pem_private_key(key_pem, password=None)
+        assert isinstance(private_key.curve, ec.SECP256R1)
+
+        csr = load_pem_x509_csr(csr_pem)
+        assert csr.is_signature_valid
+        cn = csr.subject.get_attributes_for_oid(NameOID.COMMON_NAME)
+        assert cn[0].value == "my-robot"
+
+    def test_default_common_name_is_robot(self) -> None:
+        from cryptography.x509 import load_pem_x509_csr
+        from cryptography.x509.oid import NameOID
+
+        _, csr_pem = identity_mod.generate_key_and_csr()
+        csr = load_pem_x509_csr(csr_pem)
+        cn = csr.subject.get_attributes_for_oid(NameOID.COMMON_NAME)
+        assert cn[0].value == "robot"
+
+
+class TestEnrollHappyPath:
+    def test_enroll_writes_files_and_returns_identity(
+        self, fake_server: str, tmp_path: object
+    ) -> None:
+        directory = tmp_path / "identity"
+        result = identity_mod.enroll(VALID_TOKEN, fake_server, directory)
+
+        assert result.tenant == "acme"
+        assert result.robot_id == "robot-42"
+        assert result.robot == "acme/robot-42"
+        assert result.broker_url == "mqtts://fleet.example.com:8883"
+        assert result.enroll_url == fake_server
+        assert result.expires_at == "2027-01-01T00:00:00Z"
+        assert result.key_path == directory / "robot.key"
+        assert result.cert_path == directory / "robot.crt"
+        assert result.ca_path == directory / "ca.crt"
+
+        assert result.key_path.is_file()
+        assert result.cert_path.is_file()
+        assert result.ca_path.is_file()
+        assert (directory / "identity.yaml").is_file()
+
+    def test_key_file_mode_is_0600(self, fake_server: str, tmp_path: object) -> None:
+        directory = tmp_path / "identity"
+        result = identity_mod.enroll(VALID_TOKEN, fake_server, directory)
+        mode = stat.S_IMODE(result.key_path.stat().st_mode)
+        assert mode == 0o600
+
+    def test_identity_yaml_round_trips(self, fake_server: str, tmp_path: object) -> None:
+        directory = tmp_path / "identity"
+        result = identity_mod.enroll(VALID_TOKEN, fake_server, directory)
+        on_disk = yaml.safe_load((directory / "identity.yaml").read_text())
+        assert on_disk == {
+            "tenant": "acme",
+            "robot_id": "robot-42",
+            "broker_url": "mqtts://fleet.example.com:8883",
+            "enroll_url": fake_server,
+            "expires_at": "2027-01-01T00:00:00Z",
+        }
+        assert result.tenant == on_disk["tenant"]
+
+    def test_stored_cert_and_key_are_a_matching_real_pair(
+        self, fake_server: str, tmp_path: object
+    ) -> None:
+        from cryptography import x509
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.x509.oid import NameOID
+
+        directory = tmp_path / "identity"
+        result = identity_mod.enroll(VALID_TOKEN, fake_server, directory)
+
+        private_key = serialization.load_pem_private_key(
+            result.key_path.read_bytes(), password=None
+        )
+        cert = x509.load_pem_x509_certificate(result.cert_path.read_bytes())
+        ca_cert = x509.load_pem_x509_certificate(result.ca_path.read_bytes())
+
+        assert cert.public_key().public_numbers() == private_key.public_key().public_numbers()
+        assert cert.issuer == ca_cert.subject
+        cn = cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)
+        assert cn[0].value == "forced-cn-by-server"
+
+
+class TestEnrollErrors:
+    def test_unknown_token_raises_401_with_no_files_written(
+        self, fake_server: str, tmp_path: object
+    ) -> None:
+        directory = tmp_path / "identity"
+        with pytest.raises(EnrollmentError) as excinfo:
+            identity_mod.enroll(UNKNOWN_TOKEN, fake_server, directory)
+        assert excinfo.value.status == 401
+        assert not directory.exists() or not any(directory.iterdir())
+
+    def test_used_token_raises_410_with_no_files_written(
+        self, fake_server: str, tmp_path: object
+    ) -> None:
+        directory = tmp_path / "identity"
+        with pytest.raises(EnrollmentError) as excinfo:
+            identity_mod.enroll(USED_TOKEN, fake_server, directory)
+        assert excinfo.value.status == 410
+        assert not directory.exists() or not any(directory.iterdir())
+
+    def test_server_error_raises_with_status(self, fake_server: str, tmp_path: object) -> None:
+        with pytest.raises(EnrollmentError) as excinfo:
+            identity_mod.enroll(SERVER_ERROR_TOKEN, fake_server, tmp_path / "identity")
+        assert excinfo.value.status == 500
+
+    def test_malformed_200_response_raises_200(self, fake_server: str, tmp_path: object) -> None:
+        with pytest.raises(EnrollmentError) as excinfo:
+            identity_mod.enroll(MALFORMED_TOKEN, fake_server, tmp_path / "identity")
+        assert excinfo.value.status == 200
+        assert "malformed response" in excinfo.value.reason
+
+    def test_connection_refused_raises_status_zero(self, tmp_path: object) -> None:
+        # Reserve then release a port so nothing is listening on it.
+        import socket
+
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.bind(("127.0.0.1", 0))
+        port = sock.getsockname()[1]
+        sock.close()
+
+        with pytest.raises(EnrollmentError) as excinfo:
+            identity_mod.enroll(VALID_TOKEN, f"http://127.0.0.1:{port}", tmp_path / "identity")
+        assert excinfo.value.status == 0
+
+    def test_bad_scheme_raises_value_error(self, tmp_path: object) -> None:
+        with pytest.raises(ValueError, match="http"):
+            identity_mod.enroll(VALID_TOKEN, "ftp://example.com", tmp_path / "identity")
+
+
+class TestTokenHygiene:
+    def test_token_never_logged_on_success(
+        self, fake_server: str, tmp_path: object, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with caplog.at_level(logging.DEBUG):
+            identity_mod.enroll(VALID_TOKEN, fake_server, tmp_path / "identity")
+        for record in caplog.records:
+            assert VALID_TOKEN not in record.getMessage()
+
+    def test_token_never_logged_or_embedded_in_error_on_failure(
+        self, fake_server: str, tmp_path: object, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with caplog.at_level(logging.DEBUG):
+            with pytest.raises(EnrollmentError) as excinfo:
+                identity_mod.enroll(UNKNOWN_TOKEN, fake_server, tmp_path / "identity")
+        assert UNKNOWN_TOKEN not in str(excinfo.value)
+        assert UNKNOWN_TOKEN not in excinfo.value.reason
+        for record in caplog.records:
+            assert UNKNOWN_TOKEN not in record.getMessage()
+
+
+class TestLoadIdentity:
+    def test_load_after_enroll_returns_equal_identity(
+        self, fake_server: str, tmp_path: object
+    ) -> None:
+        directory = tmp_path / "identity"
+        enrolled = identity_mod.enroll(VALID_TOKEN, fake_server, directory)
+        loaded = identity_mod.load_identity(directory)
+        assert loaded == enrolled
+
+    def test_load_on_empty_dir_raises_not_enrolled(self, tmp_path: object) -> None:
+        with pytest.raises(FleetNotEnrolledError):
+            identity_mod.load_identity(tmp_path / "nope")
+
+    def test_load_with_missing_cert_file_raises_not_enrolled(
+        self, fake_server: str, tmp_path: object
+    ) -> None:
+        directory = tmp_path / "identity"
+        identity_mod.enroll(VALID_TOKEN, fake_server, directory)
+        (directory / "robot.crt").unlink()
+        with pytest.raises(FleetNotEnrolledError):
+            identity_mod.load_identity(directory)
+
+    def test_load_with_corrupt_yaml_raises_not_enrolled(
+        self, fake_server: str, tmp_path: object
+    ) -> None:
+        directory = tmp_path / "identity"
+        identity_mod.enroll(VALID_TOKEN, fake_server, directory)
+        (directory / "identity.yaml").write_text("not: valid: yaml: [")
+        with pytest.raises(FleetNotEnrolledError):
+            identity_mod.load_identity(directory)
+
+    def test_loader_tolerates_unknown_extra_keys(self, fake_server: str, tmp_path: object) -> None:
+        directory = tmp_path / "identity"
+        identity_mod.enroll(VALID_TOKEN, fake_server, directory)
+        doc = yaml.safe_load((directory / "identity.yaml").read_text())
+        doc["last_renewal_attempt_at"] = "2026-06-01T00:00:00Z"
+        (directory / "identity.yaml").write_text(yaml.safe_dump(doc))
+        loaded = identity_mod.load_identity(directory)
+        assert loaded.tenant == "acme"
+
+
+class TestIsEnrolled:
+    def test_true_after_enroll(self, fake_server: str, tmp_path: object) -> None:
+        directory = tmp_path / "identity"
+        identity_mod.enroll(VALID_TOKEN, fake_server, directory)
+        assert identity_mod.is_enrolled(directory) is True
+
+    def test_false_on_empty_dir(self, tmp_path: object) -> None:
+        assert identity_mod.is_enrolled(tmp_path / "nope") is False
+
+
+def test_identity_module_does_not_import_paho_or_cryptography_eagerly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for name in [
+        m
+        for m in sys.modules
+        if m == "paho"
+        or m.startswith("paho.")
+        or m == "cryptography"
+        or m.startswith("cryptography.")
+    ]:
+        monkeypatch.delitem(sys.modules, name)
+    monkeypatch.delitem(sys.modules, "src.sink.publish.identity", raising=False)
+    importlib.import_module("src.sink.publish.identity")
+    assert not any(
+        m == "paho" or m.startswith("paho.") or m == "cryptography" or m.startswith("cryptography.")
+        for m in sys.modules
+    )

--- a/test/sink/publish/test_mqtt_publisher.py
+++ b/test/sink/publish/test_mqtt_publisher.py
@@ -223,6 +223,69 @@ class TestClose:
         p.close()  # must not raise
 
 
+class TestSetTls:
+    """CRITICAL fix: a post-renewal reconnect must pick up the NEW cert/key paths.
+
+    `MqttPublisher` captures `tls_certfile`/`tls_keyfile` at construction and
+    re-reads them from `self._tls` on every `connect()`. Without a seam to
+    replace that dict after a renewal rotates the files on disk, every
+    reconnect after the old files are unlinked fails forever. `set_tls`
+    fixes this by atomically swapping in a NEW dict (never mutating the old
+    one in place, so a router thread reading `self._tls` mid-connect never
+    sees a half-updated mix of old and new paths).
+    """
+
+    def test_set_tls_replaces_the_tls_dict_with_a_new_object(
+        self, fake: dict[str, FakeFleetPaho]
+    ) -> None:
+        p = _publisher(
+            tls_ca_certs="/old-ca.pem", tls_certfile="/old-c.pem", tls_keyfile="/old-k.pem"
+        )
+        old_tls = p._tls
+
+        p.set_tls(
+            tls_ca_certs="/new-ca.pem", tls_certfile="/new-c.pem", tls_keyfile="/new-k.pem"
+        )
+
+        assert p._tls is not old_tls  # a NEW dict, not an in-place mutation
+        assert p._tls == {
+            "ca_certs": "/new-ca.pem",
+            "certfile": "/new-c.pem",
+            "keyfile": "/new-k.pem",
+        }
+        # the old dict object itself is untouched -- a reader still holding
+        # it (e.g. mid-connect on another thread) never sees a partial update
+        assert old_tls == {
+            "ca_certs": "/old-ca.pem",
+            "certfile": "/old-c.pem",
+            "keyfile": "/old-k.pem",
+        }
+
+    def test_reconnect_after_set_tls_uses_the_new_paths(
+        self, fake: dict[str, FakeFleetPaho]
+    ) -> None:
+        p = _publisher(
+            tls_ca_certs="/old-ca.pem", tls_certfile="/old-c.pem", tls_keyfile="/old-k.pem"
+        )
+        p.connect()
+        assert fake["client"].tls == {
+            "ca_certs": "/old-ca.pem",
+            "certfile": "/old-c.pem",
+            "keyfile": "/old-k.pem",
+        }
+
+        p.set_tls(
+            tls_ca_certs="/new-ca.pem", tls_certfile="/new-c.pem", tls_keyfile="/new-k.pem"
+        )
+        p.connect()  # forced reconnect, e.g. after a broker drop
+
+        assert fake["client"].tls == {
+            "ca_certs": "/new-ca.pem",
+            "certfile": "/new-c.pem",
+            "keyfile": "/new-k.pem",
+        }
+
+
 class TestReconnectCounter:
     def test_on_disconnect_is_registered_at_connect(self, fake: dict[str, FakeFleetPaho]) -> None:
         p = _publisher()

--- a/test/sink/publish/test_mqtt_publisher.py
+++ b/test/sink/publish/test_mqtt_publisher.py
@@ -130,7 +130,36 @@ class TestConnect:
 
     def test_client_id_is_deterministic(self, fake: dict[str, FakeFleetPaho]) -> None:
         _publisher().connect()
-        assert fake["client"].kwargs["client_id"] == "bagel-acme-r7"
+        assert fake["client"].kwargs["client_id"] == "bagel/acme/r7"
+
+    def test_client_id_is_deterministic_across_reconnects(
+        self, fake: dict[str, FakeFleetPaho]
+    ) -> None:
+        # Codex review: reconnect displacement semantics depend on the same
+        # (tenant, robot) pair always producing the same client id.
+        p = _publisher()
+        p.connect()
+        first_id = fake["client"].kwargs["client_id"]
+        p.connect()
+        second_id = fake["client"].kwargs["client_id"]
+        assert first_id == second_id == "bagel/acme/r7"
+
+    def test_client_id_does_not_collide_across_tenant_robot_boundary(
+        self, fake: dict[str, FakeFleetPaho], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Codex review (3909409399): the old "bagel-{tenant}-{robot}" format
+        # collided on the hyphen -- ("acme-west", "r7") and ("acme",
+        # "west-r7") both produced "bagel-acme-west-r7". "/" is outside both
+        # id charsets, so the new delimiter is provably collision-free.
+        _publisher(tenant="acme-west", robot="r7").connect()
+        id_a = fake["client"].kwargs["client_id"]
+
+        _publisher(tenant="acme", robot="west-r7").connect()
+        id_b = fake["client"].kwargs["client_id"]
+
+        assert id_a != id_b
+        assert id_a == "bagel/acme-west/r7"
+        assert id_b == "bagel/acme/west-r7"
 
     def test_connect_raises_when_fleet_disabled_before_touching_paho(
         self, fake: dict[str, FakeFleetPaho], monkeypatch: pytest.MonkeyPatch

--- a/test/sink/publish/test_router.py
+++ b/test/sink/publish/test_router.py
@@ -417,6 +417,69 @@ class TestStreamRouterThread:
         assert remaining == list(range(remaining[0], total_records + 1))
 
 
+class TestStreamRouterStopResetsOnline:
+    def test_stop_resets_online_to_false(self, tmp_path: pathlib.Path) -> None:
+        # Codex review (3906982938): StreamRouter._online was never reset on
+        # stop(), so FleetService.status() kept reporting online: true for a
+        # router thread that had already cleanly stopped.
+        router, q, _spool, pub = _router(tmp_path, flush_interval_s=0.01)
+        router.start()
+        q.put(("/imu", 1.0, {"x": 1.0}))
+        deadline = time.monotonic() + 2.0
+        while not router.online and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert router.online  # sanity: actually connected before stop()
+
+        router.stop()
+
+        assert router.online is False
+
+
+class TestStreamRouterStopJoinTimeout:
+    def test_stop_joins_with_timeout_longer_than_publish_wait(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Codex review (3906982943): stop()'s join(timeout=5) can't outlast a
+        # 10s QoS-1 publish wait (wait_for_publish(timeout=10.0) inside
+        # MqttPublisher.publish), so termination wasn't actually guaranteed
+        # before a caller (e.g. pause()/resume()) proceeded. The join timeout
+        # must exceed that 10s bound.
+        router, _q, _spool, _pub = _router(tmp_path, flush_interval_s=1.0)
+
+        join_calls: list[float | None] = []
+        real_join = router.join
+
+        def spy_join(timeout: float | None = None) -> None:
+            join_calls.append(timeout)
+            real_join(timeout)
+
+        monkeypatch.setattr(router, "join", spy_join)
+
+        router.start()
+        router.stop()
+
+        assert join_calls
+        assert join_calls[0] is not None and join_calls[0] > 10.0
+
+    def test_stop_logs_warning_when_thread_does_not_terminate(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        import logging
+
+        router, _q, _spool, _pub = _router(tmp_path, flush_interval_s=1.0)
+        # Don't actually start the thread -- is_alive() is always False for a
+        # never-started Thread, which is the wrong shape for this test. Fake
+        # is_alive() to simulate a stuck thread that survives the join.
+        monkeypatch.setattr(router, "is_alive", lambda: True)
+        monkeypatch.setattr(router, "join", lambda timeout=None: None)
+
+        with caplog.at_level(logging.WARNING):
+            router.stop()
+
+        warnings_ = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("did not terminate" in r.getMessage() for r in warnings_)
+
+
 class TestStreamRouterDeathIsVisible:
     """A bug in core/spool (not a PublishError) must not die silently.
 

--- a/test/sink/publish/test_router.py
+++ b/test/sink/publish/test_router.py
@@ -144,6 +144,44 @@ class TestRateCapAndBatch:
         assert core.should_flush(now=0.5, pending_count=2)
         assert core.should_flush(now=1.6, pending_count=0)
 
+    def test_flush_caps_batch_at_max_samples_leaving_remainder_pending(self) -> None:
+        # Codex review (3909414784): flush() used to empty the entire
+        # `_pending` dict into ONE batch regardless of size -- should_flush()
+        # only used max_samples as a *trigger* threshold, not a cap on
+        # flush()'s output. A wide manifest (many channels distinct-slot-win
+        # in the same interval) could produce an arbitrarily large batch.
+        # flush() now caps its OWN output at max_samples, leaving the
+        # remainder in `_pending` for a subsequent flush() call.
+        core = RouterCore(
+            [_chan(f"c{i}.x", f"/c{i}", ["x"], rate_hz=50.0) for i in range(5)],
+            flush_interval_s=1.0,
+            max_samples=2,
+        )
+        for i in range(5):
+            core.offer(f"/c{i}", float(i) * 0.01, {"x": float(i)})
+        assert core.pending_count == 5
+
+        batch1 = core.flush(t_batch=1.0)
+        assert batch1 is not None and len(batch1["samples"]) == 2
+        assert core.pending_count == 3
+
+        batch2 = core.flush(t_batch=1.0)
+        assert batch2 is not None and len(batch2["samples"]) == 2
+        assert core.pending_count == 1
+
+        batch3 = core.flush(t_batch=1.0)
+        assert batch3 is not None and len(batch3["samples"]) == 1
+        assert core.pending_count == 0
+
+        assert core.flush(t_batch=1.0) is None  # fully drained
+
+        # Global t-order is preserved across chunk boundaries.
+        all_ts = [s["t"] for b in (batch1, batch2, batch3) for s in b["samples"]]
+        assert all_ts == sorted(all_ts)
+        # No sample lost or duplicated across the chunks.
+        all_values = {s["v"] for b in (batch1, batch2, batch3) for s in b["samples"]}
+        assert all_values == {0.0, 1.0, 2.0, 3.0, 4.0}
+
     def test_late_sample_for_already_emitted_slot_is_dropped(self) -> None:
         # Slot-survival: once a (channel, slot) has been popped by flush(), a
         # later-arriving offer() for that same slot -- or an earlier one --
@@ -415,6 +453,36 @@ class TestStreamRouterThread:
         # The unacked tail is a contiguous run up to total_records -- no gaps,
         # no out-of-order acks.
         assert remaining == list(range(remaining[0], total_records + 1))
+
+
+class TestTickChunksOversizedFlush:
+    def test_tick_spools_each_chunk_with_its_own_seq_in_order(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        # Codex review (3909414784): every chunk of a capped flush must get
+        # its own seq and its own spool append within one tick, not just the
+        # first chunk. connect_should_fail keeps _pump from acking anything,
+        # so spool.pending stays the ground truth for what was written.
+        core = RouterCore(
+            [_chan(f"c{i}.x", f"/c{i}", ["x"], rate_hz=50.0) for i in range(5)],
+            flush_interval_s=0.0,
+            max_samples=2,
+        )
+        q = SampleQueue(maxsize=100)
+        spool = Spool(tmp_path / "spool")
+        pub = FakePublisher(connect_should_fail=True)
+        router = StreamRouter(core, q, spool, pub, schema_payload={"v": 1, "channels": []})
+        for i in range(5):
+            q.put((f"/c{i}", float(i) * 0.01, {"x": float(i)}))
+
+        router._tick(now=10.0)
+
+        batches = list(spool.pending("channels"))
+        seqs = [seq for seq, _ in batches]
+        assert seqs == [1, 2, 3]  # ceil(5/2) chunks, in seq order
+        sizes = [len(payload["samples"]) for _, payload in batches]
+        assert sizes == [2, 2, 1] and all(n <= 2 for n in sizes)
+        assert sum(sizes) == 5
 
 
 class TestStreamRouterStopFlushesAcceptedSamples:

--- a/test/sink/publish/test_router.py
+++ b/test/sink/publish/test_router.py
@@ -602,7 +602,10 @@ class TestStreamRouterStopJoinTimeout:
         assert join_calls[0] is not None and join_calls[0] > 10.0
 
     def test_stop_logs_warning_when_thread_does_not_terminate(
-        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+        self,
+        tmp_path: pathlib.Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         import logging
 

--- a/test/sink/publish/test_router.py
+++ b/test/sink/publish/test_router.py
@@ -417,6 +417,78 @@ class TestStreamRouterThread:
         assert remaining == list(range(remaining[0], total_records + 1))
 
 
+class TestStreamRouterStopFlushesAcceptedSamples:
+    def _start_and_let_initial_tick_pass(self, router: StreamRouter) -> None:
+        """Start the router and wait past its first tick.
+
+        `RouterCore._last_flush` starts at 0.0, and `run()` drives `_tick`
+        with a real `time.time()` -- so the very first tick's
+        `should_flush()` is unconditionally True (any real epoch timestamp
+        minus 0.0 dwarfs `flush_interval_s`), flushing an (empty) batch and
+        setting `_last_flush` to a real recent timestamp. Only after that
+        can a *subsequent* sample reliably sit in `_pending` without
+        crossing a long `flush_interval_s`'s boundary.
+        """
+        router.start()
+        time.sleep(0.3)
+
+    def test_stop_spools_samples_offered_but_below_flush_threshold(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        # Codex review (3906982911): stop() used to only set the stop event
+        # and join -- it never forced the queue/core's already-accepted
+        # samples into the spool first, so a sample the tap had accepted
+        # (offer()'d into RouterCore._pending) but that hadn't yet crossed a
+        # flush boundary was silently dropped on stop(). A long
+        # flush_interval_s (10s) guarantees should_flush() would say "not
+        # yet" on any tick that happened to run before stop() lands.
+        router, q, spool, pub = _router(tmp_path, flush_interval_s=10.0)
+        self._start_and_let_initial_tick_pass(router)
+
+        q.put(("/imu", 1.0, {"x": 1.0}))
+        deadline = time.monotonic() + 2.0
+        while router._core.pending_count == 0 and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert router._core.pending_count == 1  # accepted by offer(), not yet flushed
+
+        router.stop()
+
+        assert list(spool.pending("channels"))  # the accepted sample was spooled, not lost
+        batch = next(payload for _seq, payload in spool.pending("channels"))
+        assert [s["v"] for s in batch["samples"]] == [1.0]
+
+    def test_stop_on_an_idle_router_with_nothing_pending_is_a_clean_noop(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        router, _q, spool, _pub = _router(tmp_path, flush_interval_s=10.0)
+        self._start_and_let_initial_tick_pass(router)
+
+        router.stop()  # must not raise even with nothing to flush
+
+        assert list(spool.pending("channels")) == []
+
+    def test_pause_discard_still_discards_after_stop_flushes_pending(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        # pause(discard=True) is FleetService's job (it acks past the
+        # channels lane's last written seq after stop()) -- this just
+        # documents that stop()'s new flush-on-stop doesn't fight that: the
+        # newly-spooled batch is still ack-able/discardable like any other.
+        router, q, spool, _pub = _router(tmp_path, flush_interval_s=10.0)
+        self._start_and_let_initial_tick_pass(router)
+        q.put(("/imu", 1.0, {"x": 1.0}))
+        deadline = time.monotonic() + 2.0
+        while router._core.pending_count == 0 and time.monotonic() < deadline:
+            time.sleep(0.01)
+
+        router.stop()
+        assert list(spool.pending("channels"))  # flushed on stop
+
+        last_seq = spool.next_seq("channels") - 1
+        spool.ack("channels", last_seq)
+        assert list(spool.pending("channels")) == []  # discard still works
+
+
 class TestStreamRouterStopResetsOnline:
     def test_stop_resets_online_to_false(self, tmp_path: pathlib.Path) -> None:
         # Codex review (3906982938): StreamRouter._online was never reset on

--- a/test/sink/publish/test_service.py
+++ b/test/sink/publish/test_service.py
@@ -1,5 +1,6 @@
 """FleetService lifecycle: start/stop/pause/resume/status (fleet streaming spec §2/§5)."""
 
+import dataclasses
 import importlib
 import json
 import pathlib
@@ -10,7 +11,9 @@ import pyarrow as pa
 import pytest
 
 from src.sink.publish import StreamConfigError
+from src.sink.publish import service as service_mod
 from src.sink.publish.config import StreamsConfig
+from src.sink.publish.identity import Identity
 from src.sink.publish.publisher import Publisher, PublishError
 from src.sink.publish.service import FleetService
 from src.sink.publish.spool import Spool
@@ -117,6 +120,27 @@ def _wait_until(predicate: object, timeout_s: float = 2.0) -> bool:
             return True
         time.sleep(0.01)
     return predicate()
+
+
+def _fake_identity(tmp_path: pathlib.Path, expires_at: str = "2027-01-01T00:00:00Z") -> Identity:
+    """A well-formed Identity pointing at files that don't need to exist for these tests.
+
+    Nothing here does a live mTLS POST -- these tests monkeypatch
+    `service_mod.renew`/`service_mod.should_attempt_renewal` directly rather
+    than exercising the real transport (that's `test_identity.py`'s job), so
+    the cert/key/ca paths never actually need to be read.
+    """
+    directory = tmp_path / "identity"
+    return Identity(
+        tenant="acme",
+        robot_id="robot-42",
+        broker_url="mqtts://fleet.example.com:8883",
+        enroll_url="https://enroll.example.com",
+        expires_at=expires_at,
+        key_path=directory / "robot.key",
+        cert_path=directory / "robot.crt",
+        ca_path=directory / "ca.crt",
+    )
 
 
 class TestStart:
@@ -332,6 +356,7 @@ class TestStatus:
                 "heartbeat_spool_failures",
                 "heartbeat_alive",
                 "heartbeat_error",
+                "cert_expires_at",
             }
             assert status["subscriptions"] == ["/imu"]
             assert status["channels_active"] == 1
@@ -342,6 +367,7 @@ class TestStatus:
             assert status["heartbeat_spool_failures"] == 0
             assert status["heartbeat_alive"] is True
             assert status["heartbeat_error"] is None
+            assert status["cert_expires_at"] is None  # no identity wired in this test
         finally:
             service.stop()
 
@@ -382,5 +408,189 @@ class TestStatus:
             json.dumps(status)
             assert status["router_alive"] is False
             assert status["router_error"] is not None and "core exploded" in status["router_error"]
+        finally:
+            service.stop()
+
+
+class TestIdentityWiring:
+    def test_cert_expires_at_none_without_identity(self, tmp_path: pathlib.Path) -> None:
+        writer = FakeWriter(_imu_struct())
+        sink = FakeSink({"/imu": writer})
+        service = FleetService(
+            sink=sink,
+            streams=_imu_streams(),
+            publisher=FakePublisher(),
+            spool=Spool(tmp_path / "spool"),
+        )
+        service.start()
+        try:
+            assert service.status()["cert_expires_at"] is None
+            assert _wait_until(lambda: service._heartbeat.is_alive())
+        finally:
+            service.stop()
+
+    def test_cert_expires_at_flows_into_status_and_heartbeat_with_identity(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        identity = _fake_identity(tmp_path, expires_at="2027-06-01T00:00:00Z")
+        writer = FakeWriter(_imu_struct())
+        sink = FakeSink({"/imu": writer})
+        pub = FakePublisher()
+        service = FleetService(
+            sink=sink,
+            streams=_imu_streams(),
+            publisher=pub,
+            spool=Spool(tmp_path / "spool"),
+            identity=identity,
+        )
+        service.start()
+        try:
+            assert service.status()["cert_expires_at"] == "2027-06-01T00:00:00Z"
+            payload = service._heartbeat_payload()
+            assert payload["cert_expires_at"] == "2027-06-01T00:00:00Z"
+        finally:
+            service.stop()
+
+    def test_no_identity_wires_no_renewal_check_into_heartbeat(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        writer = FakeWriter(_imu_struct())
+        sink = FakeSink({"/imu": writer})
+        service = FleetService(
+            sink=sink,
+            streams=_imu_streams(),
+            publisher=FakePublisher(),
+            spool=Spool(tmp_path / "spool"),
+        )
+        service.start()
+        try:
+            assert service._heartbeat._renewal_check is None
+        finally:
+            service.stop()
+
+    def test_identity_wires_renewal_check_into_heartbeat(self, tmp_path: pathlib.Path) -> None:
+        identity = _fake_identity(tmp_path)
+        writer = FakeWriter(_imu_struct())
+        sink = FakeSink({"/imu": writer})
+        service = FleetService(
+            sink=sink,
+            streams=_imu_streams(),
+            publisher=FakePublisher(),
+            spool=Spool(tmp_path / "spool"),
+            identity=identity,
+        )
+        service.start()
+        try:
+            # Bound methods aren't cached (`obj.meth is obj.meth` is False in
+            # general), so compare the underlying function and the bound
+            # instance rather than object identity of the bound method itself.
+            wired = service._heartbeat._renewal_check
+            assert wired is not None
+            assert wired.__func__ is FleetService._renewal_check
+            assert wired.__self__ is service
+        finally:
+            service.stop()
+
+    def test_renewal_check_calls_renew_when_due_and_updates_identity(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Exercises `_renewal_check` directly rather than via a running
+        # HeartbeatThread -- a live service.start() would tick (and thus
+        # call this same closure through the real thread) immediately and
+        # asynchronously, racing this test's own explicit call.
+        old_identity = _fake_identity(tmp_path, expires_at="2026-09-05T00:00:00Z")  # soon
+        new_identity = dataclasses.replace(old_identity, expires_at="2027-09-05T00:00:00Z")
+        renew_calls: list[Identity] = []
+
+        monkeypatch.setattr(service_mod, "should_attempt_renewal", lambda *a, **kw: True)
+
+        def fake_renew(identity: Identity) -> Identity:
+            renew_calls.append(identity)
+            return new_identity
+
+        monkeypatch.setattr(service_mod, "renew", fake_renew)
+
+        service = FleetService(
+            sink=FakeSink({}),
+            streams=_imu_streams(),
+            publisher=FakePublisher(),
+            spool=Spool(tmp_path / "spool"),
+            identity=old_identity,
+        )
+
+        service._renewal_check()
+
+        assert renew_calls == [old_identity]
+        assert service._identity is new_identity
+        assert service.status()["cert_expires_at"] == "2027-09-05T00:00:00Z"
+        assert service._last_renewal_attempt_at is not None
+
+    def test_renewal_check_skips_when_not_due(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        identity = _fake_identity(tmp_path, expires_at="2030-01-01T00:00:00Z")  # far off
+
+        monkeypatch.setattr(service_mod, "should_attempt_renewal", lambda *a, **kw: False)
+
+        def fail_if_called(identity: Identity) -> Identity:
+            raise AssertionError("renew() must not be called when not due")
+
+        monkeypatch.setattr(service_mod, "renew", fail_if_called)
+
+        service = FleetService(
+            sink=FakeSink({}),
+            streams=_imu_streams(),
+            publisher=FakePublisher(),
+            spool=Spool(tmp_path / "spool"),
+            identity=identity,
+        )
+
+        service._renewal_check()
+
+        assert service._identity is identity
+        assert service._last_renewal_attempt_at is None
+
+    def test_renewal_check_leaves_identity_unchanged_when_renew_returns_none(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        identity = _fake_identity(tmp_path, expires_at="2026-09-05T00:00:00Z")
+
+        monkeypatch.setattr(service_mod, "should_attempt_renewal", lambda *a, **kw: True)
+        monkeypatch.setattr(service_mod, "renew", lambda identity: None)
+
+        service = FleetService(
+            sink=FakeSink({}),
+            streams=_imu_streams(),
+            publisher=FakePublisher(),
+            spool=Spool(tmp_path / "spool"),
+            identity=identity,
+        )
+
+        service._renewal_check()
+
+        assert service._identity is identity  # unchanged: renew() reported no update
+        assert service._last_renewal_attempt_at is not None  # attempt still recorded
+
+    def test_heartbeat_tick_invokes_renewal_check_and_survives_its_exception(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        identity = _fake_identity(tmp_path, expires_at="2030-01-01T00:00:00Z")
+        writer = FakeWriter(_imu_struct())
+        sink = FakeSink({"/imu": writer})
+        pub = FakePublisher()
+        service = FleetService(
+            sink=sink,
+            streams=_imu_streams(),
+            publisher=pub,
+            spool=Spool(tmp_path / "spool"),
+            identity=identity,
+        )
+        service._renewal_check = lambda: (_ for _ in ()).throw(RuntimeError("boom"))  # type: ignore[method-assign]
+        service.start()
+        try:
+            # The hook raises on every tick; the heartbeat thread must stay
+            # alive and keep publishing regardless.
+            assert _wait_until(lambda: bool(pub.heartbeat_calls))
+            assert service._heartbeat.is_alive()
         finally:
             service.stop()

--- a/test/sink/publish/test_service.py
+++ b/test/sink/publish/test_service.py
@@ -6,17 +6,26 @@ import json
 import pathlib
 import sys
 import time
+import types
 
 import pyarrow as pa
 import pytest
 
+from publish.test_identity import VALID_TOKEN, fake_renew_server, fake_server
 from src.sink.publish import StreamConfigError
+from src.sink.publish import identity as identity_mod
+from src.sink.publish import mqtt as publish_mqtt
 from src.sink.publish import service as service_mod
 from src.sink.publish.config import StreamsConfig
 from src.sink.publish.identity import Identity
+from src.sink.publish.mqtt import MqttPublisher
 from src.sink.publish.publisher import Publisher, PublishError
 from src.sink.publish.service import FleetService
 from src.sink.publish.spool import Spool
+
+# Re-exported so pytest picks them up as fixtures in this module too (they're
+# only *used* below via the `fake_server`/`fake_renew_server` parameter names).
+__all__ = ["fake_renew_server", "fake_server"]
 
 
 def test_service_module_does_not_import_paho_eagerly(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -610,3 +619,206 @@ class TestIdentityWiring:
             assert service._heartbeat.is_alive()
         finally:
             service.stop()
+
+
+class TestLastRenewalAttemptSeedsFromIdentity:
+    """IMPORTANT fix: the daily rate limit must survive a process restart.
+
+    `FleetService` used to always start with `_last_renewal_attempt_at =
+    None`, regardless of what `identity.yaml` had on disk -- so a
+    crashlooping robot inside the 30-day renewal window would fire a fresh
+    renewal attempt roughly every restart, ignoring the daily rate limit.
+    """
+
+    def test_recent_on_disk_attempt_blocks_a_renewal_check_right_after_construction(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        identity = _fake_identity(tmp_path, expires_at="2026-09-05T00:00:00Z")  # within window
+        identity = dataclasses.replace(
+            identity, last_renewal_attempt_at=time.time() - 3600
+        )  # 1h ago -- well inside the 1-day rate limit
+
+        service = FleetService(
+            sink=FakeSink({}),
+            streams=_imu_streams(),
+            publisher=FakePublisher(),
+            spool=Spool(tmp_path / "spool"),
+            identity=identity,
+        )
+
+        # Seeded at construction time, not left at None.
+        assert service._last_renewal_attempt_at == identity.last_renewal_attempt_at
+
+        def fail_if_called(identity: Identity) -> Identity:
+            raise AssertionError(
+                "renew() must not be called: rate-limited by the seeded "
+                "last_renewal_attempt_at, even on a freshly constructed service"
+            )
+
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            monkeypatch.setattr(service_mod, "renew", fail_if_called)
+            service._renewal_check()  # real should_attempt_renewal: must see "not due"
+
+    def test_no_on_disk_attempt_allows_an_immediate_renewal_check(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        identity = _fake_identity(tmp_path, expires_at="2026-09-05T00:00:00Z")
+        assert identity.last_renewal_attempt_at is None
+
+        service = FleetService(
+            sink=FakeSink({}),
+            streams=_imu_streams(),
+            publisher=FakePublisher(),
+            spool=Spool(tmp_path / "spool"),
+            identity=identity,
+        )
+        assert service._last_renewal_attempt_at is None
+
+        renew_calls = []
+        monkeypatch.setattr(service_mod, "renew", lambda ident: renew_calls.append(ident) or None)
+
+        service._renewal_check()
+
+        assert renew_calls == [identity]
+
+
+class _FakeTlsCapturingPahoClient:
+    """A minimal fake paho client that just records the kwargs `tls_set` got.
+
+    Module-level (rather than nested in the test) purely to keep the test
+    function's own cyclomatic complexity down -- this class carries no
+    branching logic of its own.
+    """
+
+    def __init__(self) -> None:
+        self.tls: dict[str, object] | None = None
+        self._connected = False
+
+    def will_set(self, *args: object, **kwargs: object) -> None:
+        pass
+
+    def tls_set(self, **kwargs: object) -> None:
+        self.tls = kwargs
+
+    def username_pw_set(self, *args: object, **kwargs: object) -> None:
+        pass
+
+    def connect(self, host: str, port: int, keepalive: int = 60) -> None:
+        self._connected = True
+
+    def loop_start(self) -> None:
+        pass
+
+    def loop_stop(self) -> None:
+        pass
+
+    def disconnect(self) -> None:
+        self._connected = False
+
+    def is_connected(self) -> bool:
+        return self._connected
+
+
+def _install_fake_tls_capturing_paho(monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
+    """Monkeypatch `publish_mqtt._paho` with a fake whose Client is `_FakeTlsCapturingPahoClient`.
+
+    Returns a holder dict populated with the live client under "client" once
+    `MqttPublisher.connect()` builds one -- same pattern as
+    test_mqtt_publisher.py's `fake` fixture.
+    """
+    holder: dict[str, object] = {}
+
+    def fake_client(**kwargs: object) -> _FakeTlsCapturingPahoClient:
+        holder["client"] = _FakeTlsCapturingPahoClient()
+        return holder["client"]
+
+    fake_paho_module = types.SimpleNamespace(
+        Client=fake_client,
+        CallbackAPIVersion=types.SimpleNamespace(VERSION2="v2"),
+        MQTTv5=5,
+    )
+    monkeypatch.setattr(publish_mqtt, "_paho", lambda: fake_paho_module)
+    return holder
+
+
+class TestRenewalReconnectPicksUpNewTlsMaterial:
+    """CRITICAL fix: a live MqttPublisher must reconnect with the RENEWED cert/key.
+
+    Before this fix, `MqttPublisher` captured `tls_certfile`/`tls_keyfile`
+    paths at construction and never learned about a renewal's pointer swap
+    (identity.py's `_commit_renewed_files`, which unlinks the OLD key/cert
+    once the new ones are committed) -- so the first reconnect after a
+    renewal tried to `tls_set()` with paths to files that no longer exist.
+
+    This drives the real thing end to end: a real `enroll()` + real
+    `renew()` against the mini-CA fake HTTP servers from test_identity.py
+    (so the old files are genuinely unlinked from disk, not just
+    hand-waved), a real `MqttPublisher` (paho faked out, per
+    test_mqtt_publisher.py's convention), and `FleetService._renewal_check`
+    -- the actual seam that must call `MqttPublisher.set_tls` before a
+    caller can safely force a reconnect.
+    """
+
+    def test_renewal_check_updates_the_live_publisher_before_next_reconnect(
+        self,
+        fake_server: str,
+        fake_renew_server: str,
+        tmp_path: pathlib.Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        directory = tmp_path / "identity"
+        enrolled = identity_mod.enroll(VALID_TOKEN, fake_server, directory)
+        # _FakeRenewHandler (test_identity.py) reads the scenario back off
+        # the CSR's common name -- "renew-ok" is its happy-path scenario.
+        old_identity = dataclasses.replace(
+            enrolled, robot_id="renew-ok", enroll_url=fake_renew_server
+        )
+        old_key_path, old_cert_path, old_ca_path = (
+            old_identity.key_path,
+            old_identity.cert_path,
+            old_identity.ca_path,
+        )
+        assert old_key_path.exists()  # sanity: real files from a real enroll()
+
+        fake_paho_client = _install_fake_tls_capturing_paho(monkeypatch)
+
+        publisher = MqttPublisher(
+            broker_url=old_identity.broker_url,
+            tenant=old_identity.tenant,
+            robot=old_identity.robot_id,
+            tls_ca_certs=str(old_identity.ca_path),
+            tls_certfile=str(old_identity.cert_path),
+            tls_keyfile=str(old_identity.key_path),
+        )
+        publisher.connect()
+        assert fake_paho_client["client"].tls == {
+            "ca_certs": str(old_ca_path),
+            "certfile": str(old_cert_path),
+            "keyfile": str(old_key_path),
+        }
+
+        service = FleetService(
+            sink=FakeSink({}),
+            streams=_imu_streams(),
+            publisher=publisher,
+            spool=Spool(tmp_path / "spool"),
+            identity=old_identity,
+        )
+        monkeypatch.setattr(service_mod, "should_attempt_renewal", lambda *a, **kw: True)
+
+        service._renewal_check()  # runs the REAL renew() against fake_renew_server
+
+        new_identity = service._identity
+        assert new_identity is not old_identity
+        assert new_identity.key_path != old_key_path
+        # The pointer-swap's cleanup step really did unlink the old files.
+        assert not old_key_path.exists()
+        assert not old_cert_path.exists()
+
+        publisher.connect()  # forced reconnect, e.g. the router's backoff retry
+
+        assert fake_paho_client["client"].tls == {
+            "ca_certs": str(new_identity.ca_path),
+            "certfile": str(new_identity.cert_path),
+            "keyfile": str(new_identity.key_path),
+        }

--- a/test/sink/publish/test_service.py
+++ b/test/sink/publish/test_service.py
@@ -499,7 +499,21 @@ class TestIdentityWiring:
         # call this same closure through the real thread) immediately and
         # asynchronously, racing this test's own explicit call.
         old_identity = _fake_identity(tmp_path, expires_at="2026-09-05T00:00:00Z")  # soon
-        new_identity = dataclasses.replace(old_identity, expires_at="2027-09-05T00:00:00Z")
+        # The real identity.renew() returns a new Identity pointing at fresh,
+        # versioned file basenames (the pointer-commit scheme -- see
+        # identity.py's TestRenewPointerCommitCrashSemantics), not the same
+        # key_path/cert_path/ca_path as before. This fake mirrors that shape
+        # rather than only changing expires_at, so this test would catch a
+        # bug where the service's wiring somehow held onto stale paths
+        # instead of the whole new Identity renew() hands back.
+        directory = tmp_path / "identity"
+        new_identity = dataclasses.replace(
+            old_identity,
+            expires_at="2027-09-05T00:00:00Z",
+            key_path=directory / "robot-999.key",
+            cert_path=directory / "robot-999.crt",
+            ca_path=directory / "ca-999.crt",
+        )
         renew_calls: list[Identity] = []
 
         monkeypatch.setattr(service_mod, "should_attempt_renewal", lambda *a, **kw: True)
@@ -522,6 +536,8 @@ class TestIdentityWiring:
 
         assert renew_calls == [old_identity]
         assert service._identity is new_identity
+        assert service._identity.key_path == directory / "robot-999.key"
+        assert service._identity.key_path != old_identity.key_path
         assert service.status()["cert_expires_at"] == "2027-09-05T00:00:00Z"
         assert service._last_renewal_attempt_at is not None
 

--- a/test/sink/publish/test_spool.py
+++ b/test/sink/publish/test_spool.py
@@ -287,6 +287,39 @@ class TestOversizedRecord:
         assert s.stats()["heartbeat"].evicted == 0
 
 
+class TestPendingToleratesConcurrentEviction:
+    def test_segment_evicted_mid_iteration_is_skipped_not_raised(
+        self, root: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Codex review (3909414307): pending()'s segment list is a
+        # point-in-time snapshot; a concurrent _evict() unlinking one of the
+        # captured paths mid-iteration used to raise an uncaught
+        # FileNotFoundError, aborting replay entirely instead of tolerating
+        # the race (skip the evicted segment, keep going).
+        monkeypatch.setattr(spool_mod, "SEGMENT_MAX_BYTES", 40)
+        s = Spool(root)
+        for i in range(1, 4):
+            s.append("channels", i, {"n": i})
+        segments = sorted((root / "channels").glob("segment-*.jsonl"))
+        assert len(segments) == 3  # one record per (small-capped) segment
+
+        real_scan_segment = spool_mod._scan_segment
+        call_count = {"n": 0}
+
+        def scan_and_evict_first(segment: pathlib.Path, **kwargs: object) -> object:
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                segments[1].unlink()  # simulate a concurrent _evict() mid-iteration
+            return real_scan_segment(segment, **kwargs)
+
+        monkeypatch.setattr(spool_mod, "_scan_segment", scan_and_evict_first)
+
+        result = list(s.pending("channels"))  # must not raise
+
+        seqs = [seq for seq, _ in result]
+        assert seqs == [1, 3]  # the evicted segment's record (seq 2) is skipped
+
+
 class TestReadPathPurity:
     def test_pending_and_stats_do_not_create_dirs_for_unknown_lane(
         self, root: pathlib.Path

--- a/test/sink/publish/test_spool.py
+++ b/test/sink/publish/test_spool.py
@@ -391,6 +391,29 @@ class TestAckAndWatermark:
         assert len(remaining) < segments_before
         assert [seq for seq, _ in s.pending("channels")] == [9]
 
+    def test_outage_backlog_survives_early_ack_and_idempotent_reack(
+        self, root: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Chaos-e2e regression suspect, pinned as an invariant (2026-09-01
+        # CI failure "delivered [1, 38, 39]"): one batch acked pre-outage,
+        # then a backlog spooled while the broker is down. pending() must
+        # return the ENTIRE backlog in order, and an idempotent re-ack of
+        # the pre-outage seq (which now retries _prune) must never unlink a
+        # segment still holding unacked records. Multi-segment on purpose:
+        # _prune's only delete path is non-final segments, so the
+        # single-segment case can't even exercise the suspected bug.
+        monkeypatch.setattr(spool_mod, "SEGMENT_MAX_BYTES", 120)
+        s = Spool(root)
+        s.append("channels", 1, {"pad": "x" * 40, "n": 1})
+        s.ack("channels", 1)
+        for i in range(2, 40):
+            s.append("channels", i, {"pad": "x" * 40, "n": i})
+        assert len(list((root / "channels").glob("segment-*.jsonl"))) >= 3
+        backlog = list(range(2, 40))
+        assert [seq for seq, _ in s.pending("channels")] == backlog
+        s.ack("channels", 1)  # idempotent re-ack: prune retry must spare live segments
+        assert [seq for seq, _ in s.pending("channels")] == backlog
+
     def test_watermark_survives_restart_exactly(self, root: pathlib.Path) -> None:
         s = Spool(root)
         for i in range(1, 6):

--- a/test/sink/publish/test_spool.py
+++ b/test/sink/publish/test_spool.py
@@ -126,18 +126,23 @@ class TestCrashTolerance:
 class TestRollBoundaryCrashRecovery:
     """Final-review Critical 1: a crash exactly at a segment roll must not reset seq.
 
-    With SEGMENT_MAX_BYTES forced to 1, every append rolls into its own segment, so
-    each segment holds exactly one record and its name's first_seq equals that
-    record's seq. This makes "the last segment lost its only record" deterministic
-    to set up: whatever is left in segments[:-1] proves seqs up to
-    first_seq_of(segments[-1]) - 1 were durably written, even though the last
-    segment itself now looks empty (or wholly torn).
+    With SEGMENT_MAX_BYTES forced to 32 -- the exact byte length of one of
+    this test's `{"seq": i, "payload": {"n": i}}` JSONL lines, chosen so a
+    single record is never itself "oversized" (Codex review: append() now
+    drops a record whose own size alone exceeds SEGMENT_MAX_BYTES, which a
+    cap of 1 would trip on every record here) -- every append still rolls
+    into its own segment (one record's size plus the next exceeds the cap),
+    so each segment holds exactly one record and its name's first_seq equals
+    that record's seq. This makes "the last segment lost its only record"
+    deterministic to set up: whatever is left in segments[:-1] proves seqs up
+    to first_seq_of(segments[-1]) - 1 were durably written, even though the
+    last segment itself now looks empty (or wholly torn).
     """
 
     def test_empty_last_segment_floors_seq_at_segment_name_not_watermark(
         self, root: pathlib.Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setattr(spool_mod, "SEGMENT_MAX_BYTES", 1)
+        monkeypatch.setattr(spool_mod, "SEGMENT_MAX_BYTES", 32)
         s = Spool(root)
         for i in range(1, 4):
             s.append("channels", i, {"n": i})
@@ -157,7 +162,7 @@ class TestRollBoundaryCrashRecovery:
     def test_torn_only_line_of_last_segment_floors_seq_at_segment_name_not_watermark(
         self, root: pathlib.Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setattr(spool_mod, "SEGMENT_MAX_BYTES", 1)
+        monkeypatch.setattr(spool_mod, "SEGMENT_MAX_BYTES", 32)
         s = Spool(root)
         for i in range(1, 4):
             s.append("channels", i, {"n": i})
@@ -230,6 +235,58 @@ class TestTornTailSealedOnRestart:
             json.loads(line)
 
 
+class TestOversizedRecord:
+    def test_oversized_record_is_dropped_not_written(
+        self, root: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Codex review (3905367602): _evict() only unlinks while
+        # len(segments) > 1, so a single record whose own serialized size
+        # exceeds SEGMENT_MAX_BYTES becomes its own sole/newest segment and
+        # can never be evicted -- unboundedly blowing past a capped lane's
+        # byte cap. Ruling: drop-oldest semantics extend to drop-oversized --
+        # append() must refuse to write a record that alone exceeds the cap.
+        monkeypatch.setattr(spool_mod, "SEGMENT_MAX_BYTES", 200)
+        s = Spool(root)
+        s.append("channels", 1, {"n": 1})  # a normal record first
+
+        giant = {"pad": "x" * 1000}
+        s.append("channels", 2, giant)  # oversized: must be dropped, not written
+
+        assert [seq for seq, _ in s.pending("channels")] == [1]  # seq 2 never landed
+        assert s.stats()["channels"].evicted == 1
+
+        # The seq is still consumed (not reissued) and normal appends continue.
+        assert s.next_seq("channels") == 3
+        s.append("channels", 3, {"n": 3})
+        assert [seq for seq, _ in s.pending("channels")] == [1, 3]
+
+    def test_oversized_record_logs_one_warning(
+        self, root: pathlib.Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        import logging
+
+        monkeypatch.setattr(spool_mod, "SEGMENT_MAX_BYTES", 200)
+        s = Spool(root)
+        giant = {"pad": "x" * 1000}
+        with caplog.at_level(logging.WARNING):
+            s.append("channels", 1, giant)
+        warnings_ = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings_) == 1
+
+    def test_oversized_record_on_heartbeat_lane_is_still_written(
+        self, root: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Ruling exception: heartbeat is the never-drop lane -- even an
+        # (in-practice-unreachable) oversized heartbeat payload must still
+        # be written, not dropped.
+        monkeypatch.setattr(spool_mod, "SEGMENT_MAX_BYTES", 200)
+        s = Spool(root)
+        giant = {"pad": "x" * 1000}
+        s.append("heartbeat", 1, giant)
+        assert [seq for seq, _ in s.pending("heartbeat")] == [1]
+        assert s.stats()["heartbeat"].evicted == 0
+
+
 class TestReadPathPurity:
     def test_pending_and_stats_do_not_create_dirs_for_unknown_lane(
         self, root: pathlib.Path
@@ -269,6 +326,37 @@ class TestAckAndWatermark:
         s.ack("channels", 2)
         s.ack("channels", 1)  # stale: no-op
         assert [seq for seq, _ in s.pending("channels")] == [3]
+
+    def test_idempotent_reack_still_prunes_after_crash_between_watermark_and_prune(
+        self, root: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Codex review (3905367589): ack()'s idempotent early-return
+        # (seq <= watermark) used to skip retrying _prune() entirely. If the
+        # process died after _write_watermarks() committed but before
+        # _prune() ran, the fully-acked segments were left un-pruned
+        # forever -- a repeated (idempotent) ack for the same seq never
+        # cleaned them up. Simulate that crash directly: write the
+        # watermark, but never call _prune, then re-ack the same seq.
+        monkeypatch.setattr(spool_mod, "SEGMENT_MAX_BYTES", 120)
+        s = Spool(root)
+        for i in range(1, 10):
+            s.append("channels", i, {"pad": "x" * 40, "n": i})
+        segments_before = len(list((root / "channels").glob("segment-*.jsonl")))
+        assert segments_before >= 3
+
+        # Simulate "crashed after watermark write, before prune": write the
+        # watermark directly, bypassing ack()'s own _prune call.
+        s._write_watermarks({"channels": 8})
+        assert len(list((root / "channels").glob("segment-*.jsonl"))) == segments_before
+
+        # A re-ack for the SAME (already-watermarked) seq is the idempotent
+        # early-return path -- it must still prune against the persisted
+        # watermark.
+        s.ack("channels", 8)
+
+        remaining = sorted((root / "channels").glob("segment-*.jsonl"))
+        assert len(remaining) < segments_before
+        assert [seq for seq, _ in s.pending("channels")] == [9]
 
     def test_watermark_survives_restart_exactly(self, root: pathlib.Path) -> None:
         s = Spool(root)

--- a/test/sink/publish/test_spool_properties.py
+++ b/test/sink/publish/test_spool_properties.py
@@ -54,13 +54,34 @@ def test_capped_lane_bounded_and_ordered(
     with pytest.MonkeyPatch.context() as mp:
         mp.setattr(spool_mod, "SEGMENT_MAX_BYTES", 128)
         s = Spool(root, capped_lanes={"channels": cap})
+
+        def line_len(i: int) -> int:
+            return (
+                len(
+                    json.dumps({"seq": i, "payload": {"pad": "x" * record_pad, "n": i}}).encode(
+                        "utf-8"
+                    )
+                )
+                + 1
+            )
+
+        # A record's own line length grows with its seq's digit count, so
+        # "oversized" (Codex review: append() now drops -- rather than
+        # writes -- a record whose own serialized size alone exceeds
+        # SEGMENT_MAX_BYTES) is computed per-seq, not once for the whole run.
+        non_oversized_seqs = [
+            i for i in range(1, n_records + 1) if line_len(i) <= spool_mod.SEGMENT_MAX_BYTES
+        ]
         for i in range(1, n_records + 1):
             s.append("channels", i, {"pad": "x" * record_pad, "n": i})
         lane_bytes = sum(p.stat().st_size for p in (root / "channels").glob("*.jsonl"))
         assert lane_bytes <= cap + spool_mod.SEGMENT_MAX_BYTES
         pending = [seq for seq, _ in s.pending("channels")]
         assert pending == sorted(pending)
-        assert pending[-1] == n_records  # newest always survives
+        if non_oversized_seqs:
+            assert pending[-1] == non_oversized_seqs[-1]  # newest survivor
+        else:
+            assert pending == []  # every record was dropped, not written
         # No parse damage anywhere.
         for seg in (root / "channels").glob("*.jsonl"):
             for line in seg.read_text().splitlines():

--- a/test/sink/publish/test_stream_e2e.py
+++ b/test/sink/publish/test_stream_e2e.py
@@ -174,6 +174,13 @@ class _Subscriber:
         self._client.on_message = lambda cl, ud, msg: self.inbox.put(
             (msg.topic, msg.payload, msg.retain)
         )
+        # paho's own auto-reconnect waits >= min_delay (default 1s, doubling)
+        # before retrying a dropped connection -- an eternity against
+        # StreamRouter's jittered post-restart reconnect (see
+        # `reconnect_now`'s docstring). Keep any paho-internal retry this
+        # client ever performs fast too (floats are fine at runtime; the
+        # int annotation is just paho's signature).
+        self._client.reconnect_delay_set(min_delay=0.1, max_delay=0.5)
 
     def _on_connect(
         self, client: object, userdata: object, flags: object, reason_code: object, *_a: object
@@ -204,7 +211,7 @@ class _Subscriber:
         self._subscribed.clear()
 
     def reconnect_now(self, timeout_s: float = 15.0) -> None:
-        """Hammer a raw reconnect the instant the broker is reachable again.
+        """Hammer a raw reconnect until this client is actually RESUBSCRIBED.
 
         Call `prepare_for_outage()` first (right after killing the broker).
         Polls tightly (10ms) rather than waiting on a separate "is the port
@@ -212,21 +219,38 @@ class _Subscriber:
         accepting connections and this client's own reconnect attempt only
         widens the race against StreamRouter's own reconnect (see class
         docstring).
+
+        Critically, a TCP-level `reconnect()` success is verified all the
+        way to SUBACK before it is trusted: a freshly-restarted container
+        can accept the TCP connection before mosquitto is actually serving
+        sessions, and a connection that dies between that accept and the
+        CONNACK/SUBACK would otherwise be retried only by paho's
+        auto-reconnect after its built-in delay. That delay is long enough
+        for StreamRouter's jittered reconnect to land and drain the entire
+        QoS-1 backlog while nobody is subscribed -- no persistent session
+        survives the container restart, so every batch published before
+        this client's SUBACK is gone for good (observed live as the chaos
+        test's "gap or missing seq: delivered [1, 38, 39]" CI failure: an
+        instrumented run showed the router reconnecting 0.95s after the
+        broker came back and finishing the whole drain before this
+        client's SUBACK at +1.85s). A session that hasn't reached SUBACK
+        within its attempt budget is torn down and re-attempted
+        immediately instead.
         """
         deadline = time.monotonic() + timeout_s
-        connected = False
         while time.monotonic() < deadline:
             try:
                 self._client.reconnect()
-                connected = True
-                break
             except OSError:
                 time.sleep(0.01)
-        assert connected, "subscriber could not reconnect to the restarted broker"
-        self._client.loop_start()
-        assert _wait_until(self._subscribed.is_set, timeout_s=timeout_s), (
-            "subscriber never resubscribed after the broker restart"
-        )
+                continue
+            self._client.loop_start()
+            if _wait_until(self._subscribed.is_set, timeout_s=2.0, interval_s=0.005):
+                return
+            # Stillborn session (TCP accepted, SUBACK never arrived): drop
+            # it and hammer again ourselves rather than waiting out paho.
+            self._client.loop_stop()
+        raise AssertionError("subscriber never resubscribed after the broker restart")
 
     def close(self) -> None:
         self._client.loop_stop()
@@ -322,6 +346,60 @@ def test_chaos_broker_start_cleans_up_on_unreachable_broker(
         )
     finally:
         broker.cleanup()  # belt-and-braces: start() should already have removed it
+
+
+class _StillbornThenLiveClient:
+    """Fake paho client: the first reconnect() is a TCP-level success whose
+    session dies before CONNACK/SUBACK ever arrives (a freshly-restarted
+    container accepting the connection before mosquitto actually serves it);
+    any later reconnect() lands on a live broker and the CONNACK ->
+    SUBSCRIBE -> SUBACK flow completes as soon as the loop runs.
+    """
+
+    def __init__(self, subscribed: threading.Event) -> None:
+        self._subscribed = subscribed
+        self.reconnect_calls = 0
+        self.loop_stops = 0
+
+    def reconnect(self) -> int:
+        self.reconnect_calls += 1
+        return 0
+
+    def loop_start(self) -> None:
+        if self.reconnect_calls >= 2:
+            self._subscribed.set()
+
+    def loop_stop(self) -> None:
+        self.loop_stops += 1
+
+
+def test_reconnect_now_retries_a_stillborn_tcp_connection() -> None:
+    """A TCP-level reconnect() success is not a recovered subscriber.
+
+    Pins the chaos test's own recovery helper against the failure mode
+    observed live (instrumented run: sub SUBACK 1.85s after the broker came
+    back, router reconnect + full backlog drain at +0.95s, delivered seqs
+    [1] / CI's [1, 38, 39]): when `reconnect_now`'s first successful
+    `reconnect()` latches a connection that dies before SUBACK, it must tear
+    that session down and hammer again itself -- never sit out paho's >=1s
+    auto-reconnect delay, which is long enough for StreamRouter's jittered
+    reconnect to drain the whole QoS-1 backlog with nobody subscribed. No
+    broker involved: a fake client simulates the stillborn-then-live broker.
+    """
+    sub = _Subscriber.__new__(_Subscriber)  # no real paho client, no broker
+    sub._subscribed = threading.Event()
+    client = _StillbornThenLiveClient(sub._subscribed)
+    sub._client = client
+    started = time.monotonic()
+    sub.reconnect_now(timeout_s=8.0)
+    elapsed = time.monotonic() - started
+    assert sub._subscribed.is_set()
+    assert client.reconnect_calls >= 2, (
+        "reconnect_now trusted a single TCP-level reconnect() that never "
+        "reached SUBACK instead of retrying it"
+    )
+    assert client.loop_stops >= 1, "the stillborn session was never torn down"
+    assert elapsed < 6.0, "recovery took long enough for the router to drain the backlog"
 
 
 def _build_service(  # noqa: PLR0913 -- test helper collecting one scenario's full config

--- a/test/sink/test_startup_streams.py
+++ b/test/sink/test_startup_streams.py
@@ -24,6 +24,7 @@ from src.sink import mqtt as sink_mqtt
 from src.sink import startup
 from src.sink.publish import EnrollmentError
 from src.sink.publish import identity as identity_mod
+from src.sink.publish.service import FleetService
 
 _PORT_COUNTER = itertools.count(31000)
 
@@ -235,6 +236,65 @@ class TestFleetServiceReplacement:
 
         # The second service is the one actually live.
         assert service_2._started is True
+
+
+class TestFleetServiceReplacementFailure:
+    """MINOR fix: a failed second start must not leave `_FLEET_SERVICE`
+    pointing at the FIRST service's now-stopped instance -- a caller reading
+    the holder (step 7's status/control tools) would see a dead service as
+    if it were live.
+    """
+
+    def test_new_start_failure_after_stopping_old_leaves_fleet_service_none(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _write_identity(pathlib.Path(settings.FLEET_IDENTITY_DIRECTORY))
+        monkeypatch.setattr(startup.MqttPublisher, "connect", lambda self: None)
+
+        fake = FakePahoClient()
+        fake.retained = {
+            "robot/telemetry_1": [b'{"speed": 1.5, "t": 100.0}'],
+            "robot/telemetry_2": [b'{"speed": 2.5, "t": 100.0}'],
+        }
+        monkeypatch.setattr(sink_mqtt.paho, "Client", lambda **_: fake)
+
+        entry_1 = _subscription_entry("manifest.test", "robot/telemetry_1")
+        manifest_1 = {
+            "subscriptions": [entry_1],
+            "streams": {
+                "channels": [{"topic": "robot/telemetry_1", "fields": ["speed"], "rate_hz": 1}]
+            },
+        }
+        manifest_file_1 = _write_manifest(tmp_path, manifest_1, name="startup1.yaml")
+
+        reports_1 = startup.start(manifest_file_1)
+        assert reports_1[-1] == {"fleet": "started"}
+        service_1 = startup._FLEET_SERVICE
+        assert service_1 is not None
+
+        # The second start's FleetService.start() fails AFTER the first
+        # service has already been stopped and replaced.
+        def failing_start(self: FleetService) -> None:
+            raise RuntimeError("simulated start failure")
+
+        monkeypatch.setattr(FleetService, "start", failing_start)
+
+        entry_2 = _subscription_entry("manifest.test", "robot/telemetry_2")
+        manifest_2 = {
+            "subscriptions": [entry_2],
+            "streams": {
+                "channels": [{"topic": "robot/telemetry_2", "fields": ["speed"], "rate_hz": 1}]
+            },
+        }
+        manifest_file_2 = _write_manifest(tmp_path, manifest_2, name="startup2.yaml")
+
+        reports_2 = startup.start(manifest_file_2)  # must not raise
+
+        assert reports_2[-1]["fleet"] == "failed"
+        # BUG (pre-fix): _FLEET_SERVICE still pointed at the stopped, dead
+        # service_1 -- a caller reading the holder would see a dead service
+        # as if it were the live one.
+        assert startup._FLEET_SERVICE is None
 
 
 class TestFleetDisabled:

--- a/test/sink/test_startup_streams.py
+++ b/test/sink/test_startup_streams.py
@@ -86,8 +86,10 @@ def _subscription_entry(host: str, topic: str) -> dict:
     }
 
 
-def _write_manifest(tmp_path: pathlib.Path, manifest: dict) -> pathlib.Path:
-    manifest_file = tmp_path / "startup.yaml"
+def _write_manifest(
+    tmp_path: pathlib.Path, manifest: dict, name: str = "startup.yaml"
+) -> pathlib.Path:
+    manifest_file = tmp_path / name
     manifest_file.write_text(yaml.safe_dump(manifest))
     return manifest_file
 
@@ -156,6 +158,83 @@ class TestFleetStartedReport:
         assert reports[-1] == {"fleet": "started"}
         assert startup._FLEET_SERVICE is not None
         assert startup._FLEET_SERVICE._identity is None
+
+
+class TestFleetServiceReplacement:
+    def test_second_start_stops_the_previous_fleet_service(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Reproduces a second `startup.start()` in the same process (e.g. a
+        # re-applied manifest): the previous FleetService must be stopped --
+        # not merely dropped -- before the holder is replaced.
+        _write_identity(pathlib.Path(settings.FLEET_IDENTITY_DIRECTORY))
+        monkeypatch.setattr(startup.MqttPublisher, "connect", lambda self: None)
+
+        # Spy on close() (rather than trusting `.connected`, which is
+        # already False for a publisher whose connect() was no-op'd) to
+        # prove the orphaned service's publisher was actually torn down.
+        closed_publishers: list[object] = []
+        real_close = startup.MqttPublisher.close
+
+        def spy_close(self: object) -> None:
+            closed_publishers.append(self)
+            real_close(self)
+
+        monkeypatch.setattr(startup.MqttPublisher, "close", spy_close)
+
+        fake = FakePahoClient()
+        fake.retained = {
+            "robot/telemetry_1": [b'{"speed": 1.5, "t": 100.0}'],
+            "robot/telemetry_2": [b'{"speed": 2.5, "t": 100.0}'],
+        }
+        monkeypatch.setattr(sink_mqtt.paho, "Client", lambda **_: fake)
+
+        entry_1 = _subscription_entry("manifest.test", "robot/telemetry_1")
+        manifest_1 = {
+            "subscriptions": [entry_1],
+            "streams": {
+                "channels": [{"topic": "robot/telemetry_1", "fields": ["speed"], "rate_hz": 1}]
+            },
+        }
+        manifest_file_1 = _write_manifest(tmp_path, manifest_1, name="startup1.yaml")
+
+        reports_1 = startup.start(manifest_file_1)
+        assert reports_1[-1] == {"fleet": "started"}
+        service_1 = startup._FLEET_SERVICE
+        assert service_1 is not None
+        assert service_1._started is True
+        assert service_1._router is not None
+        assert service_1._router.alive is True
+        assert service_1._heartbeat is not None
+        assert service_1._heartbeat.alive is True
+
+        entry_2 = _subscription_entry("manifest.test", "robot/telemetry_2")
+        manifest_2 = {
+            "subscriptions": [entry_2],
+            "streams": {
+                "channels": [{"topic": "robot/telemetry_2", "fields": ["speed"], "rate_hz": 1}]
+            },
+        }
+        manifest_file_2 = _write_manifest(tmp_path, manifest_2, name="startup2.yaml")
+
+        reports_2 = startup.start(manifest_file_2)  # must not raise
+
+        assert reports_2[-1] == {"fleet": "started"}
+        service_2 = startup._FLEET_SERVICE
+        assert service_2 is not None
+        assert service_2 is not service_1
+
+        # The orphaned first service was actually stopped: not started,
+        # its threads dead, its publisher closed -- not just replaced in
+        # the holder and abandoned still running.
+        assert service_1._started is False
+        assert service_1._router.alive is False
+        assert service_1._heartbeat.alive is False
+        assert service_1._publisher.connected is False
+        assert service_1._publisher in closed_publishers
+
+        # The second service is the one actually live.
+        assert service_2._started is True
 
 
 class TestFleetDisabled:

--- a/test/sink/test_startup_streams.py
+++ b/test/sink/test_startup_streams.py
@@ -1,0 +1,358 @@
+"""Tests for Task 4: first-boot enrollment hook + startup `streams:` wiring.
+
+Reuses test_startup.py's FakePahoClient/monkeypatch conventions for the
+subscribing sink side, and writes fleet identities directly to disk in
+Task 1's on-disk layout (key/cert/ca + identity.yaml) rather than standing
+up the fake enroll HTTP server -- these tests only need `is_enrolled()` /
+`load_identity()` to see a complete identity, not a real enrollment round
+trip (that's covered by test/sink/publish/test_identity.py).
+"""
+
+import itertools
+import pathlib
+
+import pytest
+
+pytest.importorskip("paho")
+
+import yaml
+from conftest import FakePahoClient
+
+from settings import settings
+from src.sink import base as sink_base
+from src.sink import mqtt as sink_mqtt
+from src.sink import startup
+from src.sink.publish import EnrollmentError
+from src.sink.publish import identity as identity_mod
+
+_PORT_COUNTER = itertools.count(31000)
+
+
+def _write_identity(  # noqa: PLR0913 -- one field per identity.yaml key, matching enroll()'s own shape
+    directory: pathlib.Path,
+    *,
+    tenant: str = "acme",
+    robot_id: str = "robot-1",
+    broker_url: str = "mqtts://fleet.example.com:8883",
+    enroll_url: str = "https://enroll.example.com",
+    expires_at: str = "2030-01-01T00:00:00Z",
+) -> None:
+    """Write a complete, `is_enrolled()`-satisfying identity (Task 1's fixed-name layout)."""
+    directory.mkdir(parents=True, exist_ok=True)
+    key_path = directory / "robot.key"
+    key_path.write_bytes(b"fake-key-material")
+    key_path.chmod(0o600)
+    (directory / "robot.crt").write_bytes(b"fake-cert-material")
+    (directory / "ca.crt").write_bytes(b"fake-ca-material")
+    (directory / "identity.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "tenant": tenant,
+                "robot_id": robot_id,
+                "broker_url": broker_url,
+                "enroll_url": enroll_url,
+                "expires_at": expires_at,
+            }
+        )
+    )
+
+
+@pytest.fixture(autouse=True)
+def _isolated_settings(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "CACHE_DIRECTORY", str(tmp_path / "cache"))
+    monkeypatch.setattr(settings, "ARTIFACT_DIRECTORY", str(tmp_path / "artifacts"))
+    monkeypatch.setattr(settings, "FLEET_IDENTITY_DIRECTORY", str(tmp_path / "identity"))
+    monkeypatch.setattr(settings, "FLEET_ENABLED", True)
+    monkeypatch.setattr(settings, "FLEET_DEV_INSECURE", False)
+    monkeypatch.setattr(settings, "FLEET_ENROLL_TOKEN", None)
+    monkeypatch.setattr(settings, "FLEET_ENROLL_URL", None)
+    sink_base._global_sink_singletons.clear()
+    startup._FLEET_SERVICE = None
+    yield
+    if startup._FLEET_SERVICE is not None:
+        startup._FLEET_SERVICE.stop()
+        startup._FLEET_SERVICE = None
+    sink_base._global_sink_singletons.clear()
+
+
+def _subscription_entry(host: str, topic: str) -> dict:
+    """One `subscriptions:` manifest entry subscribing to a single topic."""
+    return {
+        "sink": "mqtt",
+        "host": host,
+        "port": next(_PORT_COUNTER),
+        "args": {"discovery_seconds": 0.0, "timestamp_field": "t"},
+        "topics": [topic],
+    }
+
+
+def _write_manifest(tmp_path: pathlib.Path, manifest: dict) -> pathlib.Path:
+    manifest_file = tmp_path / "startup.yaml"
+    manifest_file.write_text(yaml.safe_dump(manifest))
+    return manifest_file
+
+
+class TestFleetStartedReport:
+    def test_started_when_identity_enrolled_and_topics_covered_by_one_entry(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _write_identity(pathlib.Path(settings.FLEET_IDENTITY_DIRECTORY))
+        # The router's background thread will try a real connect() in a daemon
+        # thread once FleetService.start() launches it; no-op it so tests never
+        # touch the network (host `fleet.example.com` is a placeholder, not a
+        # real broker).
+        monkeypatch.setattr(startup.MqttPublisher, "connect", lambda self: None)
+
+        fake = FakePahoClient()
+        fake.retained = {"robot/telemetry": [b'{"speed": 1.5, "t": 100.0}']}
+        monkeypatch.setattr(sink_mqtt.paho, "Client", lambda **_: fake)
+
+        entry = _subscription_entry("manifest.test", "robot/telemetry")
+        manifest = {
+            "subscriptions": [entry],
+            "streams": {
+                "channels": [{"topic": "robot/telemetry", "fields": ["speed"], "rate_hz": 1}]
+            },
+        }
+        manifest_file = _write_manifest(tmp_path, manifest)
+
+        reports = startup.start(manifest_file)
+
+        assert reports[0] == {
+            "sink": "mqtt",
+            "status": "subscribed",
+            "topics": ["robot/telemetry"],
+        }
+        assert reports[1] == {"fleet": "started"}
+        assert startup._FLEET_SERVICE is not None
+
+        # Taps wired: the fleet service must have attached its queue tap to
+        # the subscribed topic's buffer.
+        buffer = startup._FLEET_SERVICE._sink._buffers["robot/telemetry"]
+        assert buffer._tap is not None
+
+    def test_dev_insecure_mqtt_broker_starts_without_identity(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(settings, "FLEET_DEV_INSECURE", True)
+        monkeypatch.setattr(startup.MqttPublisher, "connect", lambda self: None)
+
+        fake = FakePahoClient()
+        fake.retained = {"robot/telemetry": [b'{"speed": 1.5, "t": 100.0}']}
+        monkeypatch.setattr(sink_mqtt.paho, "Client", lambda **_: fake)
+
+        entry = _subscription_entry("manifest.test", "robot/telemetry")
+        manifest = {
+            "subscriptions": [entry],
+            "streams": {
+                "broker": "mqtt://127.0.0.1:1883",
+                "channels": [{"topic": "robot/telemetry", "fields": ["speed"], "rate_hz": 1}],
+            },
+        }
+        manifest_file = _write_manifest(tmp_path, manifest)
+
+        reports = startup.start(manifest_file)
+
+        assert reports[-1] == {"fleet": "started"}
+        assert startup._FLEET_SERVICE is not None
+        assert startup._FLEET_SERVICE._identity is None
+
+
+class TestFleetDisabled:
+    def test_fleet_enabled_false_reports_disabled(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(settings, "FLEET_ENABLED", False)
+        _write_identity(pathlib.Path(settings.FLEET_IDENTITY_DIRECTORY))
+
+        fake = FakePahoClient()
+        fake.retained = {"robot/telemetry": [b'{"speed": 1.5, "t": 100.0}']}
+        monkeypatch.setattr(sink_mqtt.paho, "Client", lambda **_: fake)
+
+        entry = _subscription_entry("manifest.test", "robot/telemetry")
+        manifest = {
+            "subscriptions": [entry],
+            "streams": {
+                "channels": [{"topic": "robot/telemetry", "fields": ["speed"], "rate_hz": 1}]
+            },
+        }
+        manifest_file = _write_manifest(tmp_path, manifest)
+
+        reports = startup.start(manifest_file)
+
+        assert reports[-1] == {"fleet": "disabled"}
+        assert startup._FLEET_SERVICE is None
+
+
+class TestFleetFailures:
+    def test_mqtts_broker_with_no_identity_fails_with_not_enrolled_error(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # FLEET_IDENTITY_DIRECTORY is isolated to an empty tmp dir by the
+        # autouse fixture -- nothing has enrolled here.
+        fake = FakePahoClient()
+        fake.retained = {"robot/telemetry": [b'{"speed": 1.5, "t": 100.0}']}
+        monkeypatch.setattr(sink_mqtt.paho, "Client", lambda **_: fake)
+
+        entry = _subscription_entry("manifest.test", "robot/telemetry")
+        manifest = {
+            "subscriptions": [entry],
+            "streams": {
+                "broker": "mqtts://fleet.example.com:8883",
+                "channels": [{"topic": "robot/telemetry", "fields": ["speed"], "rate_hz": 1}],
+            },
+        }
+        manifest_file = _write_manifest(tmp_path, manifest)
+
+        reports = startup.start(manifest_file)
+
+        assert reports[-1]["fleet"] == "failed"
+        assert "enrolled fleet identity" in reports[-1]["error"]
+        assert startup._FLEET_SERVICE is None
+
+    def test_topics_spanning_two_subscription_entries_fails_with_v1_limitation(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _write_identity(pathlib.Path(settings.FLEET_IDENTITY_DIRECTORY))
+
+        fake = FakePahoClient()
+        fake.retained = {
+            "robot/telemetry_a": [b'{"speed": 1.5, "t": 100.0}'],
+            "robot/telemetry_b": [b'{"battery": 90.0, "t": 100.0}'],
+        }
+        monkeypatch.setattr(sink_mqtt.paho, "Client", lambda **_: fake)
+
+        entry_a = _subscription_entry("manifest.test", "robot/telemetry_a")
+        entry_b = _subscription_entry("manifest.test", "robot/telemetry_b")
+        manifest = {
+            "subscriptions": [entry_a, entry_b],
+            "streams": {
+                "channels": [
+                    {"topic": "robot/telemetry_a", "fields": ["speed"], "rate_hz": 1},
+                    {"topic": "robot/telemetry_b", "fields": ["battery"], "rate_hz": 1},
+                ]
+            },
+        }
+        manifest_file = _write_manifest(tmp_path, manifest)
+
+        reports = startup.start(manifest_file)
+
+        assert reports[-1]["fleet"] == "failed"
+        error = reports[-1]["error"]
+        assert "single" in error.lower()
+        assert "robot/telemetry_a" in error
+        assert "robot/telemetry_b" in error
+        assert startup._FLEET_SERVICE is None
+
+    def test_no_subscription_covers_streams_topics_fails(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _write_identity(pathlib.Path(settings.FLEET_IDENTITY_DIRECTORY))
+
+        manifest = {
+            "streams": {
+                "channels": [{"topic": "robot/telemetry", "fields": ["speed"], "rate_hz": 1}]
+            },
+        }
+        manifest_file = _write_manifest(tmp_path, manifest)
+
+        reports = startup.start(manifest_file)
+
+        assert reports == [{"fleet": "failed", "error": reports[0]["error"]}]
+        assert "robot/telemetry" in reports[0]["error"]
+        assert startup._FLEET_SERVICE is None
+
+
+class TestNoStreamsKey:
+    def test_manifest_without_streams_key_produces_no_fleet_report_entry(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake = FakePahoClient()
+        fake.retained = {"robot/telemetry": [b'{"speed": 1.5, "t": 100.0}']}
+        monkeypatch.setattr(sink_mqtt.paho, "Client", lambda **_: fake)
+
+        entry = _subscription_entry("manifest.test", "robot/telemetry")
+        manifest = {"subscriptions": [entry]}
+        manifest_file = _write_manifest(tmp_path, manifest)
+
+        reports = startup.start(manifest_file)
+
+        assert reports == [{"sink": "mqtt", "status": "subscribed", "topics": ["robot/telemetry"]}]
+        assert all("fleet" not in report for report in reports)
+        assert startup._FLEET_SERVICE is None
+
+
+class TestFirstBootEnrollHook:
+    TOKEN = "first-boot-secret-token"  # noqa: S105 -- test fixture token, not a real secret
+
+    def test_enrolls_when_token_and_url_set_and_not_enrolled(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        directory = pathlib.Path(settings.FLEET_IDENTITY_DIRECTORY)
+        monkeypatch.setattr(settings, "FLEET_ENROLL_TOKEN", self.TOKEN)
+        monkeypatch.setattr(settings, "FLEET_ENROLL_URL", "https://enroll.example.com")
+
+        calls = []
+
+        def fake_enroll(token: str, url: str, dir_: pathlib.Path) -> identity_mod.Identity:
+            calls.append((token, url, dir_))
+            _write_identity(pathlib.Path(dir_))
+            return identity_mod.load_identity(dir_)
+
+        monkeypatch.setattr(identity_mod, "enroll", fake_enroll)
+
+        identity_mod.maybe_enroll_on_first_boot()
+
+        assert calls == [(self.TOKEN, "https://enroll.example.com", directory)]
+        # Startup's fleet wiring must find the fresh identity right after.
+        assert identity_mod.is_enrolled(directory) is True
+
+    def test_skips_when_already_enrolled(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        directory = pathlib.Path(settings.FLEET_IDENTITY_DIRECTORY)
+        _write_identity(directory)
+        monkeypatch.setattr(settings, "FLEET_ENROLL_TOKEN", self.TOKEN)
+        monkeypatch.setattr(settings, "FLEET_ENROLL_URL", "https://enroll.example.com")
+
+        def fail_enroll(*_a: object, **_kw: object) -> None:
+            raise AssertionError("enroll() must not be called when already enrolled")
+
+        monkeypatch.setattr(identity_mod, "enroll", fail_enroll)
+
+        identity_mod.maybe_enroll_on_first_boot()  # must not raise
+
+    def test_skips_when_token_or_url_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def fail_enroll(*_a: object, **_kw: object) -> None:
+            raise AssertionError("enroll() must not be called with no token/url configured")
+
+        monkeypatch.setattr(identity_mod, "enroll", fail_enroll)
+
+        identity_mod.maybe_enroll_on_first_boot()  # FLEET_ENROLL_TOKEN/_URL are None -- no-op
+
+    def test_enrollment_failure_logs_error_and_server_continues(
+        self,
+        tmp_path: pathlib.Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        directory = pathlib.Path(settings.FLEET_IDENTITY_DIRECTORY)
+        monkeypatch.setattr(settings, "FLEET_ENROLL_TOKEN", self.TOKEN)
+        monkeypatch.setattr(settings, "FLEET_ENROLL_URL", "https://enroll.example.com")
+
+        def failing_enroll(*_a: object, **_kw: object) -> identity_mod.Identity:
+            raise EnrollmentError(401, "unknown token")
+
+        monkeypatch.setattr(identity_mod, "enroll", failing_enroll)
+
+        import logging
+
+        with caplog.at_level(logging.DEBUG):
+            identity_mod.maybe_enroll_on_first_boot()  # must not raise
+
+        assert identity_mod.is_enrolled(directory) is False
+        assert any(
+            "First-boot fleet enrollment failed" in record.getMessage() for record in caplog.records
+        )
+        for record in caplog.records:
+            assert self.TOKEN not in record.getMessage()

--- a/test/sink/test_startup_streams.py
+++ b/test/sink/test_startup_streams.py
@@ -383,6 +383,62 @@ class TestFleetFailures:
         assert "robot/telemetry_b" in error
         assert startup._FLEET_SERVICE is None
 
+    def test_topics_split_across_two_same_sink_entries_coverage_passes(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Codex review (3909413506): TopicSink.__new__ is a (host, port)
+        # singleton -- two `subscriptions:` entries pointed at the SAME
+        # host/port get the SAME sink object, with each entry's topics list
+        # only naming what THAT entry subscribed. _find_covering_sink used
+        # to test each (sink, topics) tuple independently, so a manifest
+        # whose needed topics were split across two same-sink entries was
+        # wrongly rejected even though the singleton sink is actually
+        # subscribed to their union. RULING A's own docstring assumes this
+        # would work ("each entry's sink is a fresh instance"), which the
+        # singleton falsifies -- this is the real gap the ruling didn't
+        # intend, not the genuine two-different-sinks v1 limitation covered
+        # by test_topics_spanning_two_subscription_entries_fails_with_v1_limitation.
+        _write_identity(pathlib.Path(settings.FLEET_IDENTITY_DIRECTORY))
+        monkeypatch.setattr(startup.MqttPublisher, "connect", lambda self: None)
+
+        fake = FakePahoClient()
+        fake.retained = {
+            "robot/telemetry_a": [b'{"speed": 1.5, "t": 100.0}'],
+            "robot/telemetry_b": [b'{"battery": 90.0, "t": 100.0}'],
+        }
+        monkeypatch.setattr(sink_mqtt.paho, "Client", lambda **_: fake)
+
+        same_port = next(_PORT_COUNTER)
+        entry_a = {
+            "sink": "mqtt",
+            "host": "manifest.test",
+            "port": same_port,
+            "args": {"discovery_seconds": 0.0, "timestamp_field": "t"},
+            "topics": ["robot/telemetry_a"],
+        }
+        entry_b = {
+            "sink": "mqtt",
+            "host": "manifest.test",
+            "port": same_port,
+            "args": {"discovery_seconds": 0.0, "timestamp_field": "t"},
+            "topics": ["robot/telemetry_b"],
+        }
+        manifest = {
+            "subscriptions": [entry_a, entry_b],
+            "streams": {
+                "channels": [
+                    {"topic": "robot/telemetry_a", "fields": ["speed"], "rate_hz": 1},
+                    {"topic": "robot/telemetry_b", "fields": ["battery"], "rate_hz": 1},
+                ]
+            },
+        }
+        manifest_file = _write_manifest(tmp_path, manifest)
+
+        reports = startup.start(manifest_file)
+
+        assert reports[-1] == {"fleet": "started"}
+        assert startup._FLEET_SERVICE is not None
+
     def test_no_subscription_covers_streams_topics_fails(
         self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/test/test_packaging.py
+++ b/test/test_packaging.py
@@ -11,10 +11,11 @@ def _groups() -> dict[str, list[str]]:
     return tomllib.loads((ROOT / "pyproject.toml").read_text())["dependency-groups"]
 
 
-def test_fleet_group_exists_with_only_the_mqtt_client() -> None:
+def test_fleet_group_exists_with_only_the_mqtt_client_and_cryptography() -> None:
     fleet = _groups()["fleet"]
-    assert len(fleet) == 1
+    assert len(fleet) == 2
     assert fleet[0].startswith("paho-mqtt")
+    assert fleet[1].startswith("cryptography")
 
 
 def test_fleet_group_is_opt_in_per_image() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -280,6 +280,7 @@ dev = [
     { name = "ruff" },
 ]
 fleet = [
+    { name = "cryptography" },
     { name = "paho-mqtt" },
 ]
 iot = [
@@ -360,7 +361,10 @@ dev = [
     { name = "pytest-cov", specifier = ">=5.0.0,<7.0.0" },
     { name = "ruff", specifier = "==0.12.4" },
 ]
-fleet = [{ name = "paho-mqtt", specifier = ">=2.1.0,<3.0.0" }]
+fleet = [
+    { name = "cryptography", specifier = ">=43.0.0,<47.0.0" },
+    { name = "paho-mqtt", specifier = ">=2.1.0,<3.0.0" },
+]
 iot = [
     { name = "influxdb3-python", specifier = ">=0.10.0" },
     { name = "paho-mqtt", specifier = ">=2.1.0,<3.0.0" },


### PR DESCRIPTION
## Summary

Stacked on `feat/fleet-step5` (#209, open). Delivers spec §6 (enrollment,
identity, dev mode, renewal) and wires it into the manifest-driven `startup:`
flow, then proves the whole first-boot loop end-to-end.

- **Protocol client (§6)**: `POST {enroll_url}/v1/enroll`, JSON
  `{"token": ..., "csr_pem": ...}` -> 200
  `{cert_pem, ca_pem, broker_url, tenant, robot_id, expires_at}`; 401 ->
  "unknown token"; 410 -> "used/expired"; other non-200 -> status-carrying
  `EnrollmentError`. `enroll_url` and the OPTIONAL `renew_url` are both
  **base** URLs (no trailing path) — the client appends `/v1/enroll` /
  `/v1/renew` itself. `renew_url` exists because enroll and renew commonly
  live on different hosts in production (enroll: a path-routed HTTPS ALB;
  renew: an mTLS listener on the broker itself) — agreed cross-repo with the
  cloud side. When the enroll response carries one, `renew()` targets it
  instead of falling back to `enroll_url`; the new e2e (below) asserts the
  response's `renew_url` field actually lands in `identity.yaml`.

- **Storage**: `FLEET_IDENTITY_DIRECTORY` (default `~/.bagel/identity`):
  `robot.key` (0600, `os.fchmod` on the temp fd before it's ever visible at
  its final path), `robot.crt`, `ca.crt`, `identity.yaml`. All writes are
  atomic (sibling tempfile + `os.replace`). Renewal uses a **pointer-commit**
  scheme rather than overwriting the current key/cert/ca in place: the new
  files land under fresh, never-before-used basenames first, and ONE atomic
  `identity.yaml` write repoints `key_file`/`cert_file`/`ca_file` at them —
  the single moment a renewal takes effect. This closes a Critical found in
  review: an in-place overwrite left a crash window between the key and cert
  writes where `identity.yaml`'s fixed pointer could resolve to a
  **mismatched new-key/old-cert pair forever** (`is_enrolled()` still blessed
  it, and every subsequent renewal's mTLS context kept failing against the
  same broken pair). With the pointer scheme there is no reachable state
  where the pointer names a mismatched pair — see `identity.py`'s
  `_commit_renewed_files`/`renew()` docstrings for the full crash-safety
  argument, and `TestRenewPointerCommitCrashSemantics` for the regression
  tests (crash-before-swap / crash-after-swap / unlink-failure-during-cleanup).
  The enrollment token is consumed in the POST body only — never logged,
  never stored, and redacted from an echoing/reflecting server's error body
  before it's ever truncated into an exception message (defends against a
  debug-mode server or a malicious endpoint handing it straight back).

- **Dev-insecure policy**: `FLEET_DEV_INSECURE: bool = False`. When true,
  `mqtt://` brokers are allowed ONLY for hostnames resolving to loopback or
  RFC1918/RFC4193 private addresses — `"localhost"` is accepted by name;
  a literal IP is checked directly via `ipaddress`; any other hostname is
  resolved via `socket.getaddrinfo` and **every** returned address (IPv4
  and IPv6 both covered) must be private/loopback, so a DNS answer mixing a
  private and a public address is rejected rather than trusted on its best
  entry. When false, `mqtt://` is refused with a typed error naming the
  setting. `mqtts://` always requires an enrolled identity — no anonymous
  TLS.

- **Renewal, with 501-grace**: `should_attempt_renewal(now, expires_at,
  last_attempt_at)` — within 30 days of expiry AND >=1 day since the last
  attempt. Each renewal POSTs a fresh CSR backed by a **new** key (not a
  reuse of the current one — the safer read of "with a new CSR"), over mTLS
  authenticated with the current cert/key pair. 501/404 responses ("this
  deployment doesn't offer renewal yet") log at INFO, record the attempt,
  and return `None` — never raise. This is deliberate: **the cloud ships
  renewal disabled behind a flag** by default (per the peer team), so the
  501-grace path is the expected day-one behavior, not an edge case. The
  live publisher connection keeps authenticating with the OLD cert until its
  own next reconnect — renewal never forces one; documented on `renew()`.

- **Startup wiring**, two pre-execution rulings (both binding, both
  documented in `startup.py`'s module docstring):
  - **Ruling A** (v1 limitation): every topic `streams.channels`/
    `streams.events` reference must be covered by a SINGLE
    `subscriptions:` entry's sink — `FleetService` taps one sink's topic
    buffers, and each entry gets a fresh sink instance, so a `streams:`
    block spanning two entries can't be served. It produces a failed fleet
    report entry naming the limitation instead of silently dropping half
    the topics.
  - **Ruling B** (deferred to step 7): there is no `TopicSink.close()` ->
    `FleetService.stop()` coupling yet — the fleet service, once started,
    runs for the process's lifetime (daemon threads + publisher LWT +
    finalizer cover process exit). Deliberate, narrow deviation from §2's
    "TopicSink.close() stops it": cost is a closed sink's taps going quiet
    (buffers gone) while the fleet service's threads idle until process
    exit — no data corruption path, just idle threads.

  `startup.start()` returns one additional report entry,
  `{"fleet": "started" | "disabled" | "failed", ...}`, alongside the
  per-subscription ones.

- **First-boot enroll** (`server.py`): before the `STARTUP_PIPELINES_FILE`
  gate — if `FLEET_ENROLL_TOKEN` and `FLEET_ENROLL_URL` are set and the
  robot isn't already enrolled, `maybe_enroll_on_first_boot()` calls
  `identity.enroll()`. Failure logs an error (never the token) and the
  server continues booting unenrolled — enrollment failing must never brick
  the container. Runs BEFORE `startup.start()` so the manifest's `streams:`
  wiring finds the fresh identity. `FLEET_ENROLL_TOKEN` is consumed at
  first boot only, never persisted to disk.

- **cert_expires_at is now live in heartbeats**: `FleetService`, when
  constructed with an identity, carries `cert_expires_at` in both
  `status()` and the heartbeat payload. Every prior e2e in this repo ran
  without an identity, so this field was always `None` there.

## This PR (task 5): end-to-end proof

New `test/sink/publish/test_enroll_e2e.py`, env-gated on `MQTT_TEST_BROKER`
like the step-3/5 e2e files:

- **Full first-boot loop, no real cloud**: an in-thread fake enrollment
  server (`http.server`) backed by a REAL throwaway CA (`cryptography`)
  signs the robot's actual posted CSR. Its response's `broker_url` is the
  dev-insecure path (`mqtt://<host>:<port>` of the very MQTT_TEST_BROKER
  this suite already spins up), so the real mosquitto broker needs no TLS.
  `maybe_enroll_on_first_boot()` (settings monkeypatched:
  `FLEET_ENROLL_TOKEN`/`_URL`, `FLEET_IDENTITY_DIRECTORY=tmp`,
  `FLEET_DEV_INSECURE=1`) writes the identity to disk with a 0600 key,
  exactly as `server.py`'s boot sequence would.

  Manifest-driven startup is then driven via `startup._start_fleet`
  **directly**, with a manually built `subscribed` list, rather than
  `startup.start()`'s full `subscriptions:` loop — documented in-test:
  none of this repo's host-runnable `TopicSink` types (`ros1.bridge`,
  `ros2.bridge`, `mqtt`) can be stood up here without extra infrastructure
  this suite doesn't have (a real ROS bridge process, or the `mqtt` sink's
  own time-boxed `#`-discovery racing the deterministic sample-append
  assertions). Step 5's own e2e (`test_stream_e2e.py`) already established
  a real-`TopicBufferWriter`-backed `FakeSink` double as the standard way
  to drive the tap -> RouterCore -> StreamRouter -> Spool -> MqttPublisher
  pipeline for real without a real upstream sink; `_start_fleet` only ever
  touches `sink.subscribed_topics`/`sink._buffers`, which this double
  provides identically to a real `TopicSink`. This is the plan's
  explicitly authorized fallback — the identity, its on-disk files, and the
  broker/wire traffic are all real; only "who feeds the buffer" is a
  double.

  Appending samples to that writer and reading them back off the same real
  broker's `bagel/v1/<tenant>/<robot>/channels` topic proves the fresh
  identity's broker_url/tenant/robot_id actually drive a live
  MqttPublisher. The retained heartbeat carries the enrolled cert's real,
  non-null `cert_expires_at` — the first e2e in this repo where that's not
  `None`.

- **Renewal-501-grace**: a second test points the enrolled identity's own
  `renew_url` (a different host than its enroll server, mirroring
  production's split topology) at a fake server that always answers 501.
  `renew()` returns `None`, records the attempt, and never raises.

Also extends `test_gate.py`'s existing publish-package eager-import guard
to cover `cryptography` alongside `paho` (the Global Constraint that
`cryptography` stays lazy outside `identity.py`).

## Test plan

- [x] `uv run pytest -q test/sink test/test_packaging.py -p no:cacheprovider`
      — 385 passed, 2 skipped (the two `MQTT_TEST_BROKER_MANAGED=1`-gated
      chaos tests; the new e2e file itself skips cleanly with no broker set
      and passes with one).
- [x] `MQTT_TEST_BROKER=mqtt://localhost:<port> uv run pytest -q test/sink/publish/test_enroll_e2e.py`
      run 6x consecutively — stable every time.
- [x] Lazy-import sweep: `paho` and `cryptography` both absent from
      `sys.modules` after `import src.sink.publish` (manual check + the new
      automated `test_gate.py` regression test).
- [x] `uv run ruff check .` / `uv run ruff format --check .` / `scripts/check_boundary.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
