### PR TITLE
fix(fleet): compose enrollment wiring and renewal cert validation (Codex round 2)

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -16,6 +16,16 @@ services:
       CONTAINER_MODE: true
       # Runtime kill switch for fleet streaming (beta); build-time opt-out is BAGEL_FLEET.
       FLEET_ENABLED: ${FLEET_ENABLED:-1}
+      # Fleet enrollment/identity settings (settings.py); forwarded
+      # unconditionally like FLEET_ENABLED itself so flipping FLEET_ENABLED
+      # at runtime never also requires editing this file. Unset host vars
+      # resolve to Settings' own defaults inside the container (empty
+      # string is falsy for the two optional str fields; the identity
+      # directory default below matches the volume mount below).
+      FLEET_ENROLL_TOKEN: ${FLEET_ENROLL_TOKEN:-}
+      FLEET_ENROLL_URL: ${FLEET_ENROLL_URL:-}
+      FLEET_IDENTITY_DIRECTORY: ${FLEET_IDENTITY_DIRECTORY:-/home/ubuntu/.bagel/identity}
+      FLEET_DEV_INSECURE: ${FLEET_DEV_INSECURE:-false}
       MCP_SERVER_PORT: ${MCP_SERVER_PORT}
       # Containers must listen on all container interfaces for Docker port
       # publishing; host-side exposure stays behind the 127.0.0.1 mapping.
@@ -38,6 +48,16 @@ services:
       # list_agent_capabilities and written by save_agent_capability. On Linux,
       # run `mkdir -p ~/.bagel/capabilities` once so the directory is owned by you.
       - ${HOME}/.bagel/capabilities:/home/ubuntu/.bagel/capabilities
+      # Fleet enrollment identity (robot.key, robot.crt, ca.crt,
+      # identity.yaml) -- persisted on the host so it survives container
+      # recreation. Without this mount, the identity written by
+      # `docker compose run` lives only in that one-off container's
+      # writable layer: it is lost the moment the container exits, and
+      # because FLEET_ENROLL_TOKEN is single-use, a later run cannot
+      # re-enroll to replace it (Codex review). Must match
+      # FLEET_IDENTITY_DIRECTORY above. On Linux, run
+      # `mkdir -p ~/.bagel/identity` once so the directory is owned by you.
+      - ${HOME}/.bagel/identity:/home/ubuntu/.bagel/identity
       # - <path-to-local-data>:/home/ubuntu/data
 
   ros2-jazzy:
@@ -57,6 +77,16 @@ services:
       CONTAINER_MODE: true
       # Runtime kill switch for fleet streaming (beta); build-time opt-out is BAGEL_FLEET.
       FLEET_ENABLED: ${FLEET_ENABLED:-1}
+      # Fleet enrollment/identity settings (settings.py); forwarded
+      # unconditionally like FLEET_ENABLED itself so flipping FLEET_ENABLED
+      # at runtime never also requires editing this file. Unset host vars
+      # resolve to Settings' own defaults inside the container (empty
+      # string is falsy for the two optional str fields; the identity
+      # directory default below matches the volume mount below).
+      FLEET_ENROLL_TOKEN: ${FLEET_ENROLL_TOKEN:-}
+      FLEET_ENROLL_URL: ${FLEET_ENROLL_URL:-}
+      FLEET_IDENTITY_DIRECTORY: ${FLEET_IDENTITY_DIRECTORY:-/home/ubuntu/.bagel/identity}
+      FLEET_DEV_INSECURE: ${FLEET_DEV_INSECURE:-false}
       MCP_SERVER_PORT: ${MCP_SERVER_PORT}
       # Containers must listen on all container interfaces for Docker port
       # publishing; host-side exposure stays behind the 127.0.0.1 mapping.
@@ -79,6 +109,16 @@ services:
       # list_agent_capabilities and written by save_agent_capability. On Linux,
       # run `mkdir -p ~/.bagel/capabilities` once so the directory is owned by you.
       - ${HOME}/.bagel/capabilities:/home/ubuntu/.bagel/capabilities
+      # Fleet enrollment identity (robot.key, robot.crt, ca.crt,
+      # identity.yaml) -- persisted on the host so it survives container
+      # recreation. Without this mount, the identity written by
+      # `docker compose run` lives only in that one-off container's
+      # writable layer: it is lost the moment the container exits, and
+      # because FLEET_ENROLL_TOKEN is single-use, a later run cannot
+      # re-enroll to replace it (Codex review). Must match
+      # FLEET_IDENTITY_DIRECTORY above. On Linux, run
+      # `mkdir -p ~/.bagel/identity` once so the directory is owned by you.
+      - ${HOME}/.bagel/identity:/home/ubuntu/.bagel/identity
       # - <path-to-local-data>:/home/ubuntu/data
 
   ros2-iron:
@@ -98,6 +138,16 @@ services:
       CONTAINER_MODE: true
       # Runtime kill switch for fleet streaming (beta); build-time opt-out is BAGEL_FLEET.
       FLEET_ENABLED: ${FLEET_ENABLED:-1}
+      # Fleet enrollment/identity settings (settings.py); forwarded
+      # unconditionally like FLEET_ENABLED itself so flipping FLEET_ENABLED
+      # at runtime never also requires editing this file. Unset host vars
+      # resolve to Settings' own defaults inside the container (empty
+      # string is falsy for the two optional str fields; the identity
+      # directory default below matches the volume mount below).
+      FLEET_ENROLL_TOKEN: ${FLEET_ENROLL_TOKEN:-}
+      FLEET_ENROLL_URL: ${FLEET_ENROLL_URL:-}
+      FLEET_IDENTITY_DIRECTORY: ${FLEET_IDENTITY_DIRECTORY:-/home/ubuntu/.bagel/identity}
+      FLEET_DEV_INSECURE: ${FLEET_DEV_INSECURE:-false}
       MCP_SERVER_PORT: ${MCP_SERVER_PORT}
       # Containers must listen on all container interfaces for Docker port
       # publishing; host-side exposure stays behind the 127.0.0.1 mapping.
@@ -120,6 +170,16 @@ services:
       # list_agent_capabilities and written by save_agent_capability. On Linux,
       # run `mkdir -p ~/.bagel/capabilities` once so the directory is owned by you.
       - ${HOME}/.bagel/capabilities:/home/ubuntu/.bagel/capabilities
+      # Fleet enrollment identity (robot.key, robot.crt, ca.crt,
+      # identity.yaml) -- persisted on the host so it survives container
+      # recreation. Without this mount, the identity written by
+      # `docker compose run` lives only in that one-off container's
+      # writable layer: it is lost the moment the container exits, and
+      # because FLEET_ENROLL_TOKEN is single-use, a later run cannot
+      # re-enroll to replace it (Codex review). Must match
+      # FLEET_IDENTITY_DIRECTORY above. On Linux, run
+      # `mkdir -p ~/.bagel/identity` once so the directory is owned by you.
+      - ${HOME}/.bagel/identity:/home/ubuntu/.bagel/identity
       # - <path-to-local-data>:/home/ubuntu/data
 
   ros2-humble:
@@ -139,6 +199,16 @@ services:
       CONTAINER_MODE: true
       # Runtime kill switch for fleet streaming (beta); build-time opt-out is BAGEL_FLEET.
       FLEET_ENABLED: ${FLEET_ENABLED:-1}
+      # Fleet enrollment/identity settings (settings.py); forwarded
+      # unconditionally like FLEET_ENABLED itself so flipping FLEET_ENABLED
+      # at runtime never also requires editing this file. Unset host vars
+      # resolve to Settings' own defaults inside the container (empty
+      # string is falsy for the two optional str fields; the identity
+      # directory default below matches the volume mount below).
+      FLEET_ENROLL_TOKEN: ${FLEET_ENROLL_TOKEN:-}
+      FLEET_ENROLL_URL: ${FLEET_ENROLL_URL:-}
+      FLEET_IDENTITY_DIRECTORY: ${FLEET_IDENTITY_DIRECTORY:-/home/ubuntu/.bagel/identity}
+      FLEET_DEV_INSECURE: ${FLEET_DEV_INSECURE:-false}
       MCP_SERVER_PORT: ${MCP_SERVER_PORT}
       # Containers must listen on all container interfaces for Docker port
       # publishing; host-side exposure stays behind the 127.0.0.1 mapping.
@@ -161,6 +231,16 @@ services:
       # list_agent_capabilities and written by save_agent_capability. On Linux,
       # run `mkdir -p ~/.bagel/capabilities` once so the directory is owned by you.
       - ${HOME}/.bagel/capabilities:/home/ubuntu/.bagel/capabilities
+      # Fleet enrollment identity (robot.key, robot.crt, ca.crt,
+      # identity.yaml) -- persisted on the host so it survives container
+      # recreation. Without this mount, the identity written by
+      # `docker compose run` lives only in that one-off container's
+      # writable layer: it is lost the moment the container exits, and
+      # because FLEET_ENROLL_TOKEN is single-use, a later run cannot
+      # re-enroll to replace it (Codex review). Must match
+      # FLEET_IDENTITY_DIRECTORY above. On Linux, run
+      # `mkdir -p ~/.bagel/identity` once so the directory is owned by you.
+      - ${HOME}/.bagel/identity:/home/ubuntu/.bagel/identity
       # - <path-to-local-data>:/home/ubuntu/data
 
   ros1-noetic:
@@ -179,6 +259,16 @@ services:
       CONTAINER_MODE: true
       # Runtime kill switch for fleet streaming (beta); build-time opt-out is BAGEL_FLEET.
       FLEET_ENABLED: ${FLEET_ENABLED:-1}
+      # Fleet enrollment/identity settings (settings.py); forwarded
+      # unconditionally like FLEET_ENABLED itself so flipping FLEET_ENABLED
+      # at runtime never also requires editing this file. Unset host vars
+      # resolve to Settings' own defaults inside the container (empty
+      # string is falsy for the two optional str fields; the identity
+      # directory default below matches the volume mount below).
+      FLEET_ENROLL_TOKEN: ${FLEET_ENROLL_TOKEN:-}
+      FLEET_ENROLL_URL: ${FLEET_ENROLL_URL:-}
+      FLEET_IDENTITY_DIRECTORY: ${FLEET_IDENTITY_DIRECTORY:-/home/ubuntu/.bagel/identity}
+      FLEET_DEV_INSECURE: ${FLEET_DEV_INSECURE:-false}
       MCP_SERVER_PORT: ${MCP_SERVER_PORT}
       # Containers must listen on all container interfaces for Docker port
       # publishing; host-side exposure stays behind the 127.0.0.1 mapping.
@@ -199,6 +289,16 @@ services:
       # list_agent_capabilities and written by save_agent_capability. On Linux,
       # run `mkdir -p ~/.bagel/capabilities` once so the directory is owned by you.
       - ${HOME}/.bagel/capabilities:/home/ubuntu/.bagel/capabilities
+      # Fleet enrollment identity (robot.key, robot.crt, ca.crt,
+      # identity.yaml) -- persisted on the host so it survives container
+      # recreation. Without this mount, the identity written by
+      # `docker compose run` lives only in that one-off container's
+      # writable layer: it is lost the moment the container exits, and
+      # because FLEET_ENROLL_TOKEN is single-use, a later run cannot
+      # re-enroll to replace it (Codex review). Must match
+      # FLEET_IDENTITY_DIRECTORY above. On Linux, run
+      # `mkdir -p ~/.bagel/identity` once so the directory is owned by you.
+      - ${HOME}/.bagel/identity:/home/ubuntu/.bagel/identity
       # - <path-to-local-data>:/home/ubuntu/data
 
   ros1-noetic-cv:
@@ -217,6 +317,16 @@ services:
       CONTAINER_MODE: true
       # Runtime kill switch for fleet streaming (beta); build-time opt-out is BAGEL_FLEET.
       FLEET_ENABLED: ${FLEET_ENABLED:-1}
+      # Fleet enrollment/identity settings (settings.py); forwarded
+      # unconditionally like FLEET_ENABLED itself so flipping FLEET_ENABLED
+      # at runtime never also requires editing this file. Unset host vars
+      # resolve to Settings' own defaults inside the container (empty
+      # string is falsy for the two optional str fields; the identity
+      # directory default below matches the volume mount below).
+      FLEET_ENROLL_TOKEN: ${FLEET_ENROLL_TOKEN:-}
+      FLEET_ENROLL_URL: ${FLEET_ENROLL_URL:-}
+      FLEET_IDENTITY_DIRECTORY: ${FLEET_IDENTITY_DIRECTORY:-/home/ubuntu/.bagel/identity}
+      FLEET_DEV_INSECURE: ${FLEET_DEV_INSECURE:-false}
       MCP_SERVER_PORT: ${MCP_SERVER_PORT}
       # Containers must listen on all container interfaces for Docker port
       # publishing; host-side exposure stays behind the 127.0.0.1 mapping.
@@ -237,6 +347,16 @@ services:
       # list_agent_capabilities and written by save_agent_capability. On Linux,
       # run `mkdir -p ~/.bagel/capabilities` once so the directory is owned by you.
       - ${HOME}/.bagel/capabilities:/home/ubuntu/.bagel/capabilities
+      # Fleet enrollment identity (robot.key, robot.crt, ca.crt,
+      # identity.yaml) -- persisted on the host so it survives container
+      # recreation. Without this mount, the identity written by
+      # `docker compose run` lives only in that one-off container's
+      # writable layer: it is lost the moment the container exits, and
+      # because FLEET_ENROLL_TOKEN is single-use, a later run cannot
+      # re-enroll to replace it (Codex review). Must match
+      # FLEET_IDENTITY_DIRECTORY above. On Linux, run
+      # `mkdir -p ~/.bagel/identity` once so the directory is owned by you.
+      - ${HOME}/.bagel/identity:/home/ubuntu/.bagel/identity
       # - <path-to-local-data>:/home/ubuntu/data
 
   px4:
@@ -254,6 +374,16 @@ services:
       CONTAINER_MODE: true
       # Runtime kill switch for fleet streaming (beta); build-time opt-out is BAGEL_FLEET.
       FLEET_ENABLED: ${FLEET_ENABLED:-1}
+      # Fleet enrollment/identity settings (settings.py); forwarded
+      # unconditionally like FLEET_ENABLED itself so flipping FLEET_ENABLED
+      # at runtime never also requires editing this file. Unset host vars
+      # resolve to Settings' own defaults inside the container (empty
+      # string is falsy for the two optional str fields; the identity
+      # directory default below matches the volume mount below).
+      FLEET_ENROLL_TOKEN: ${FLEET_ENROLL_TOKEN:-}
+      FLEET_ENROLL_URL: ${FLEET_ENROLL_URL:-}
+      FLEET_IDENTITY_DIRECTORY: ${FLEET_IDENTITY_DIRECTORY:-/home/ubuntu/.bagel/identity}
+      FLEET_DEV_INSECURE: ${FLEET_DEV_INSECURE:-false}
       MCP_SERVER_PORT: ${MCP_SERVER_PORT}
       # Containers must listen on all container interfaces for Docker port
       # publishing; host-side exposure stays behind the 127.0.0.1 mapping.
@@ -274,6 +404,16 @@ services:
       # list_agent_capabilities and written by save_agent_capability. On Linux,
       # run `mkdir -p ~/.bagel/capabilities` once so the directory is owned by you.
       - ${HOME}/.bagel/capabilities:/home/ubuntu/.bagel/capabilities
+      # Fleet enrollment identity (robot.key, robot.crt, ca.crt,
+      # identity.yaml) -- persisted on the host so it survives container
+      # recreation. Without this mount, the identity written by
+      # `docker compose run` lives only in that one-off container's
+      # writable layer: it is lost the moment the container exits, and
+      # because FLEET_ENROLL_TOKEN is single-use, a later run cannot
+      # re-enroll to replace it (Codex review). Must match
+      # FLEET_IDENTITY_DIRECTORY above. On Linux, run
+      # `mkdir -p ~/.bagel/identity` once so the directory is owned by you.
+      - ${HOME}/.bagel/identity:/home/ubuntu/.bagel/identity
       # - <path-to-local-data>:/home/ubuntu/data
 
   ardupilot:
@@ -291,6 +431,16 @@ services:
       CONTAINER_MODE: true
       # Runtime kill switch for fleet streaming (beta); build-time opt-out is BAGEL_FLEET.
       FLEET_ENABLED: ${FLEET_ENABLED:-1}
+      # Fleet enrollment/identity settings (settings.py); forwarded
+      # unconditionally like FLEET_ENABLED itself so flipping FLEET_ENABLED
+      # at runtime never also requires editing this file. Unset host vars
+      # resolve to Settings' own defaults inside the container (empty
+      # string is falsy for the two optional str fields; the identity
+      # directory default below matches the volume mount below).
+      FLEET_ENROLL_TOKEN: ${FLEET_ENROLL_TOKEN:-}
+      FLEET_ENROLL_URL: ${FLEET_ENROLL_URL:-}
+      FLEET_IDENTITY_DIRECTORY: ${FLEET_IDENTITY_DIRECTORY:-/home/ubuntu/.bagel/identity}
+      FLEET_DEV_INSECURE: ${FLEET_DEV_INSECURE:-false}
       MCP_SERVER_PORT: ${MCP_SERVER_PORT}
       # Containers must listen on all container interfaces for Docker port
       # publishing; host-side exposure stays behind the 127.0.0.1 mapping.
@@ -311,6 +461,16 @@ services:
       # list_agent_capabilities and written by save_agent_capability. On Linux,
       # run `mkdir -p ~/.bagel/capabilities` once so the directory is owned by you.
       - ${HOME}/.bagel/capabilities:/home/ubuntu/.bagel/capabilities
+      # Fleet enrollment identity (robot.key, robot.crt, ca.crt,
+      # identity.yaml) -- persisted on the host so it survives container
+      # recreation. Without this mount, the identity written by
+      # `docker compose run` lives only in that one-off container's
+      # writable layer: it is lost the moment the container exits, and
+      # because FLEET_ENROLL_TOKEN is single-use, a later run cannot
+      # re-enroll to replace it (Codex review). Must match
+      # FLEET_IDENTITY_DIRECTORY above. On Linux, run
+      # `mkdir -p ~/.bagel/identity` once so the directory is owned by you.
+      - ${HOME}/.bagel/identity:/home/ubuntu/.bagel/identity
       # - <path-to-local-data>:/home/ubuntu/data
 
   betaflight:
@@ -328,6 +488,16 @@ services:
       CONTAINER_MODE: true
       # Runtime kill switch for fleet streaming (beta); build-time opt-out is BAGEL_FLEET.
       FLEET_ENABLED: ${FLEET_ENABLED:-1}
+      # Fleet enrollment/identity settings (settings.py); forwarded
+      # unconditionally like FLEET_ENABLED itself so flipping FLEET_ENABLED
+      # at runtime never also requires editing this file. Unset host vars
+      # resolve to Settings' own defaults inside the container (empty
+      # string is falsy for the two optional str fields; the identity
+      # directory default below matches the volume mount below).
+      FLEET_ENROLL_TOKEN: ${FLEET_ENROLL_TOKEN:-}
+      FLEET_ENROLL_URL: ${FLEET_ENROLL_URL:-}
+      FLEET_IDENTITY_DIRECTORY: ${FLEET_IDENTITY_DIRECTORY:-/home/ubuntu/.bagel/identity}
+      FLEET_DEV_INSECURE: ${FLEET_DEV_INSECURE:-false}
       MCP_SERVER_PORT: ${MCP_SERVER_PORT}
       # Containers must listen on all container interfaces for Docker port
       # publishing; host-side exposure stays behind the 127.0.0.1 mapping.
@@ -348,6 +518,16 @@ services:
       # list_agent_capabilities and written by save_agent_capability. On Linux,
       # run `mkdir -p ~/.bagel/capabilities` once so the directory is owned by you.
       - ${HOME}/.bagel/capabilities:/home/ubuntu/.bagel/capabilities
+      # Fleet enrollment identity (robot.key, robot.crt, ca.crt,
+      # identity.yaml) -- persisted on the host so it survives container
+      # recreation. Without this mount, the identity written by
+      # `docker compose run` lives only in that one-off container's
+      # writable layer: it is lost the moment the container exits, and
+      # because FLEET_ENROLL_TOKEN is single-use, a later run cannot
+      # re-enroll to replace it (Codex review). Must match
+      # FLEET_IDENTITY_DIRECTORY above. On Linux, run
+      # `mkdir -p ~/.bagel/identity` once so the directory is owned by you.
+      - ${HOME}/.bagel/identity:/home/ubuntu/.bagel/identity
       # - <path-to-local-data>:/home/ubuntu/data
 
   apache-arrow:
@@ -365,6 +545,16 @@ services:
       CONTAINER_MODE: true
       # Runtime kill switch for fleet streaming (beta); build-time opt-out is BAGEL_FLEET.
       FLEET_ENABLED: ${FLEET_ENABLED:-1}
+      # Fleet enrollment/identity settings (settings.py); forwarded
+      # unconditionally like FLEET_ENABLED itself so flipping FLEET_ENABLED
+      # at runtime never also requires editing this file. Unset host vars
+      # resolve to Settings' own defaults inside the container (empty
+      # string is falsy for the two optional str fields; the identity
+      # directory default below matches the volume mount below).
+      FLEET_ENROLL_TOKEN: ${FLEET_ENROLL_TOKEN:-}
+      FLEET_ENROLL_URL: ${FLEET_ENROLL_URL:-}
+      FLEET_IDENTITY_DIRECTORY: ${FLEET_IDENTITY_DIRECTORY:-/home/ubuntu/.bagel/identity}
+      FLEET_DEV_INSECURE: ${FLEET_DEV_INSECURE:-false}
       MCP_SERVER_PORT: ${MCP_SERVER_PORT}
       # Containers must listen on all container interfaces for Docker port
       # publishing; host-side exposure stays behind the 127.0.0.1 mapping.
@@ -385,6 +575,16 @@ services:
       # list_agent_capabilities and written by save_agent_capability. On Linux,
       # run `mkdir -p ~/.bagel/capabilities` once so the directory is owned by you.
       - ${HOME}/.bagel/capabilities:/home/ubuntu/.bagel/capabilities
+      # Fleet enrollment identity (robot.key, robot.crt, ca.crt,
+      # identity.yaml) -- persisted on the host so it survives container
+      # recreation. Without this mount, the identity written by
+      # `docker compose run` lives only in that one-off container's
+      # writable layer: it is lost the moment the container exits, and
+      # because FLEET_ENROLL_TOKEN is single-use, a later run cannot
+      # re-enroll to replace it (Codex review). Must match
+      # FLEET_IDENTITY_DIRECTORY above. On Linux, run
+      # `mkdir -p ~/.bagel/identity` once so the directory is owned by you.
+      - ${HOME}/.bagel/identity:/home/ubuntu/.bagel/identity
       # - <path-to-local-data>:/home/ubuntu/data
 
   iot:
@@ -403,6 +603,16 @@ services:
       CONTAINER_MODE: true
       # Runtime kill switch for fleet streaming (beta); build-time opt-out is BAGEL_FLEET.
       FLEET_ENABLED: ${FLEET_ENABLED:-1}
+      # Fleet enrollment/identity settings (settings.py); forwarded
+      # unconditionally like FLEET_ENABLED itself so flipping FLEET_ENABLED
+      # at runtime never also requires editing this file. Unset host vars
+      # resolve to Settings' own defaults inside the container (empty
+      # string is falsy for the two optional str fields; the identity
+      # directory default below matches the volume mount below).
+      FLEET_ENROLL_TOKEN: ${FLEET_ENROLL_TOKEN:-}
+      FLEET_ENROLL_URL: ${FLEET_ENROLL_URL:-}
+      FLEET_IDENTITY_DIRECTORY: ${FLEET_IDENTITY_DIRECTORY:-/home/ubuntu/.bagel/identity}
+      FLEET_DEV_INSECURE: ${FLEET_DEV_INSECURE:-false}
       MCP_SERVER_PORT: ${MCP_SERVER_PORT}
       # Containers must listen on all container interfaces for Docker port
       # publishing; host-side exposure stays behind the 127.0.0.1 mapping.
@@ -425,6 +635,16 @@ services:
       # list_agent_capabilities and written by save_agent_capability. On Linux,
       # run `mkdir -p ~/.bagel/capabilities` once so the directory is owned by you.
       - ${HOME}/.bagel/capabilities:/home/ubuntu/.bagel/capabilities
+      # Fleet enrollment identity (robot.key, robot.crt, ca.crt,
+      # identity.yaml) -- persisted on the host so it survives container
+      # recreation. Without this mount, the identity written by
+      # `docker compose run` lives only in that one-off container's
+      # writable layer: it is lost the moment the container exits, and
+      # because FLEET_ENROLL_TOKEN is single-use, a later run cannot
+      # re-enroll to replace it (Codex review). Must match
+      # FLEET_IDENTITY_DIRECTORY above. On Linux, run
+      # `mkdir -p ~/.bagel/identity` once so the directory is owned by you.
+      - ${HOME}/.bagel/identity:/home/ubuntu/.bagel/identity
       # - <path-to-local-data>:/home/ubuntu/data
 
   # Local LLM for a fully offline stack: your data AND your model never leave

--- a/src/sink/publish/identity.py
+++ b/src/sink/publish/identity.py
@@ -675,6 +675,30 @@ def _commit_renewed_files(
     )
 
 
+def _cert_matches_key(cert_pem: str, key_pem: bytes) -> bool:
+    """Report whether ``cert_pem``'s public key matches the private key in ``key_pem``.
+
+    Guards a renewal commit against a response whose ``cert_pem`` was issued
+    for a different CSR (server bug, stale/replayed response, or a
+    mismatched-CSR mixup) -- committing such a pair would repoint
+    identity.yaml at a cert nothing on disk holds the matching private key
+    for. Malformed PEM on either side is treated as a mismatch (returns
+    False) rather than raising, so callers get one uniform reject path.
+    """
+    from cryptography import x509
+    from cryptography.exceptions import UnsupportedAlgorithm
+    from cryptography.hazmat.primitives.serialization import load_pem_private_key
+
+    try:
+        cert = x509.load_pem_x509_certificate(cert_pem.encode())
+        private_key = load_pem_private_key(key_pem, password=None)
+        cert_public_numbers = cert.public_key().public_numbers()
+        key_public_numbers = private_key.public_key().public_numbers()
+    except (ValueError, TypeError, UnsupportedAlgorithm):
+        return False
+    return cert_public_numbers == key_public_numbers
+
+
 def _renew_inner(  # noqa: PLR0911 -- one early return per distinct failure branch, each logged/recorded differently
     identity: Identity, now: float, logger: logging.Logger
 ) -> Identity | None:
@@ -746,6 +770,19 @@ def _renew_inner(  # noqa: PLR0911 -- one early return per distinct failure bran
     missing = [field for field in ("cert_pem", "expires_at") if field not in payload]
     if missing:
         logger.warning("renewal response missing fields: %s", missing)
+        _record_renewal_attempt(identity, now)
+        return None
+
+    # The server is trusted to sign whatever CSR it was handed, but never
+    # trusted to hand back a cert for a DIFFERENT key -- a server bug, a
+    # stale/replayed response, or a mismatched-CSR mixup would otherwise get
+    # committed as-is: identity.yaml would repoint at a cert nothing on disk
+    # holds the matching private key for, breaking the next mTLS handshake
+    # with no automatic recovery (Codex review). Reject before committing --
+    # same typed-error path as the other malformed-response branches above:
+    # no commit, old identity untouched, next daily attempt retries.
+    if not _cert_matches_key(payload["cert_pem"], new_key_pem):
+        logger.warning("renewal response cert_pem does not match this renewal's private key")
         _record_renewal_attempt(identity, now)
         return None
 

--- a/test/sink/publish/test_identity.py
+++ b/test/sink/publish/test_identity.py
@@ -200,6 +200,26 @@ class _FakeRenewHandler(http.server.BaseHTTPRequestHandler):
         if scenario == "renew-not-json":
             self._respond(200, b"not json at all")
             return
+        if scenario == "renew-key-mismatch":
+            # Cert issued for a DIFFERENT, freshly-generated key -- not the
+            # CSR's public key -- simulating a server bug (or a response for
+            # a stale/replayed CSR) that hands back a cert/key pair that
+            # doesn't match. renew() must reject this before committing.
+            from cryptography.hazmat.primitives.asymmetric import ec
+
+            other_key = ec.generate_private_key(ec.SECP256R1())
+            robot_cert_pem, ca_cert_pem = _build_ca_and_robot_cert(
+                "renewed-cn", other_key.public_key()
+            )
+            body = json.dumps(
+                {
+                    "cert_pem": robot_cert_pem.decode(),
+                    "ca_pem": ca_cert_pem.decode(),
+                    "expires_at": "2028-01-01T00:00:00Z",
+                }
+            ).encode()
+            self._respond(200, body)
+            return
 
         robot_cert_pem, ca_cert_pem = _build_ca_and_robot_cert("renewed-cn", csr.public_key())
         body = json.dumps(
@@ -1480,6 +1500,61 @@ class TestRenewOtherFailures:
         assert "last_renewal_attempt_at" in doc
 
 
+class TestRenewCertKeyMismatch:
+    """Codex review: a renewal response's cert_pem must match the key generated
+
+    for THIS renewal before it is committed -- otherwise identity.yaml would
+    repoint at a cert nothing on disk holds the matching private key for,
+    breaking the next mTLS handshake with no automatic recovery.
+    """
+
+    def test_mismatched_cert_returns_none_no_commit_and_records_attempt(
+        self,
+        fake_server: str,
+        fake_renew_server: str,
+        tmp_path: object,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        identity = _identity_for_renew(
+            fake_server, fake_renew_server, tmp_path, "renew-key-mismatch"
+        )
+        old_key_bytes = identity.key_path.read_bytes()
+        old_cert_bytes = identity.cert_path.read_bytes()
+        old_key_path, old_cert_path = identity.key_path, identity.cert_path
+
+        with caplog.at_level(logging.WARNING):
+            result = identity_mod.renew(identity)
+
+        assert result is None
+        # Old identity is completely untouched -- no pointer swap, nothing
+        # unlinked, nothing extra written under the directory.
+        assert old_key_path.exists()
+        assert old_cert_path.exists()
+        assert old_key_path.read_bytes() == old_key_bytes
+        assert old_cert_path.read_bytes() == old_cert_bytes
+
+        doc = yaml.safe_load((old_key_path.parent / "identity.yaml").read_text())
+        assert doc["key_file"] == old_key_path.name
+        assert doc["cert_file"] == old_cert_path.name
+        assert "last_renewal_attempt_at" in doc  # the attempt is still recorded
+
+        warnings_ = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert warnings_
+
+    def test_matching_cert_still_commits(
+        self, fake_server: str, fake_renew_server: str, tmp_path: object
+    ) -> None:
+        """Regression guard: the new validation must not reject a legitimate renewal."""
+        identity = _identity_for_renew(fake_server, fake_renew_server, tmp_path, "renew-ok")
+        old_key_path = identity.key_path
+
+        result = identity_mod.renew(identity)
+
+        assert result is not None
+        assert result.key_path != old_key_path
+        assert not old_key_path.exists()  # old pointer's file cleaned up -- the commit happened
+
+
 class TestRenewNeverRaises:
     def test_unexpected_exception_is_caught_logged_and_returns_none(
         self,
@@ -1510,7 +1585,15 @@ class TestFailedRenewalLeavesIdentityIntact:
     """Self-review requirement: a failed renewal deletes nothing and changes no old bytes."""
 
     @pytest.mark.parametrize(
-        "scenario", ["renew-501", "renew-404", "renew-500", "renew-malformed", "renew-not-json"]
+        "scenario",
+        [
+            "renew-501",
+            "renew-404",
+            "renew-500",
+            "renew-malformed",
+            "renew-not-json",
+            "renew-key-mismatch",
+        ],
     )
     def test_all_files_present_and_byte_identical_except_the_attempt_timestamp(
         self, fake_server: str, fake_renew_server: str, tmp_path: object, scenario: str

--- a/test/test_compose_bindings.py
+++ b/test/test_compose_bindings.py
@@ -78,6 +78,55 @@ def test_every_mcp_publishing_service_passes_mcp_server_port_env() -> None:
     )
 
 
+def test_every_fleet_enabled_service_forwards_enrollment_settings() -> None:
+    """Every service that gets FLEET_ENABLED must also get the enrollment settings.
+
+    Codex review (round 2): compose.yaml forwarded FLEET_ENABLED but not
+    FLEET_ENROLL_TOKEN/FLEET_ENROLL_URL, so `maybe_enroll_on_first_boot()`
+    silently no-ops even when an operator exports both on the host --
+    production mqtts:// startup fails with no obvious cause. Also requires
+    FLEET_IDENTITY_DIRECTORY and FLEET_DEV_INSECURE passthrough, matching
+    FLEET_ENABLED's own ``${VAR:-default}`` style.
+    """
+    required = {
+        "FLEET_ENROLL_TOKEN": "${FLEET_ENROLL_TOKEN:-}",
+        "FLEET_ENROLL_URL": "${FLEET_ENROLL_URL:-}",
+        "FLEET_IDENTITY_DIRECTORY": "${FLEET_IDENTITY_DIRECTORY:-/home/ubuntu/.bagel/identity}",
+        "FLEET_DEV_INSECURE": "${FLEET_DEV_INSECURE:-false}",
+    }
+    offenders = []
+    for name, service in _services().items():
+        env = service.get("environment", {}) or {}
+        if "FLEET_ENABLED" not in env:
+            continue
+        for key, expected in required.items():
+            if str(env.get(key, "")) != expected:
+                offenders.append(f"{name}: {key}")
+    assert not offenders, f"FLEET_ENABLED services missing enrollment passthrough: {offenders}"
+
+
+def test_every_fleet_enabled_service_persists_identity_directory() -> None:
+    """The identity directory must be mounted from the host, not left in the container layer.
+
+    Codex review (round 2): with the documented `docker compose run`
+    workflow, an unmounted identity directory lives only in the one-off
+    container's writable layer and is lost on exit; because
+    FLEET_ENROLL_TOKEN is single-use, a later run can't re-enroll to replace
+    it. The host-side mount must match FLEET_IDENTITY_DIRECTORY's
+    container-side default (/home/ubuntu/.bagel/identity) set above.
+    """
+    expected = "${HOME}/.bagel/identity:/home/ubuntu/.bagel/identity"
+    offenders = []
+    for name, service in _services().items():
+        env = service.get("environment", {}) or {}
+        if "FLEET_ENABLED" not in env:
+            continue
+        volumes = [str(v) for v in service.get("volumes", [])]
+        if expected not in volumes:
+            offenders.append(name)
+    assert not offenders, f"FLEET_ENABLED services missing a persistent identity mount: {offenders}"
+
+
 def test_no_dockerfile_copies_env_file() -> None:
     """Published images must never bake in the local .env (see SECURITY.md).
 


### PR DESCRIPTION
## Summary

Follow-up to #210 carrying the two fixes from Codex's final review round (held off #210 so the green merge state wasn't lost to another review cycle):

- **Compose enrollment wiring**: forward `FLEET_ENROLL_TOKEN`, `FLEET_ENROLL_URL`, `FLEET_IDENTITY_DIRECTORY`, `FLEET_DEV_INSECURE` to every service that already gets `FLEET_ENABLED`, and point the default identity directory at the established data mount so an enrolled identity survives container restarts (a lost identity burns a single-use enrollment token).
- **Renewal cert validation**: before pointer-committing renewed credentials, verify the returned certificate's public key matches the private key generated for this renewal. A mismatched cert (cloud-side bug) now fails the attempt cleanly — no commit, old identity untouched, next daily attempt retries.

The fourth round-2 finding (live client keeping old TLS material) was verified **by-design**: the managed reconnect path always rebuilds the client from current paths, and paho's internal auto-reconnect reuses its in-memory SSL context, which stays valid until cert expiry.

## Testing

- `uv run pytest test/sink/ -q` — 435 passed, 11 skipped (on this branch, post-cherry-pick)
- `uv run pytest test/test_compose_bindings.py -q` — 7 passed (2 new)
- `docker compose config` verified for default and override identity-directory cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)
