### PR TITLE
feat(fleet): step 7 — MCP tools, selftest, protocol doc and runbook

### DIFF
--- a/doc/fleet_protocol_v1.md
+++ b/doc/fleet_protocol_v1.md
@@ -302,7 +302,11 @@ uv run python -m src.sink.publish.selftest [--broker mqtt(s)://...] \
 It publishes, in order, using the enrolled identity (or `--broker` on a dev
 rig): one retained schema, N channel batches (default 10, default 0.5 s
 apart), one heartbeat, one event -- then prints a one-line JSON summary and
-exits 0 (any expected failure prints to stderr and exits 1).
+exits 0 (any expected failure prints to stderr and exits 1). It requires both
+spool lanes (`channels`, `events`) to be fully drained (no pending unacked
+entries) before it will start -- it allocates and acks real seqs on those
+lanes, so pending backlog would otherwise be silently advanced past; run it
+with fleet streaming paused or stopped.
 
 The fixture is fixed and deterministic. The schema is exactly these four
 channels:
@@ -324,6 +328,8 @@ fixed). For batch index `i` (0-based) at publish time `t`:
 
 The heartbeat reports `subscriptions: ["selftest"]` and `channels_active: 4`.
 The event has `name: "selftest"`, an `event_id` of the form
-`selftest-<uuid4>`, `summary: {"kind": "selftest", "batches": N}`, and no
-`artifact`. Seqs come from the robot's real lanes, so they continue from
-whatever the robot last used rather than starting at 1.
+`selftest-<uuid4>`, a `summary` that contains at least
+`{"kind": "selftest", "batches": N}` (future fields may be added; existing
+readers must not require an exact match), and no `artifact`. Seqs come from
+the robot's real lanes, so they continue from whatever the robot last used
+rather than starting at 1.

--- a/doc/fleet_protocol_v1.md
+++ b/doc/fleet_protocol_v1.md
@@ -1,0 +1,329 @@
+# Bagel fleet wire protocol v1
+
+This document is the binding v1 contract between a Bagel robot and a fleet service.
+Everything below is stated as built: a fleet service can pin automated conformance
+probes to this page. Additive change (a new OPTIONAL field, a new topic kind) does not
+bump the version; any breaking change ships as `bagel/v2/...` alongside v1.
+
+Consumers MUST ignore unknown fields in every payload.
+
+## 1. Versioning and namespace
+
+All traffic for one robot lives under one topic subtree:
+
+```
+bagel/v1/{tenant}/{robot}/{kind}
+```
+
+where `{kind}` is one of `schema`, `channels`, `events`, `heartbeat`, `cmd`.
+`cmd` is reserved for a future release and is not published or subscribed in v1.
+
+- Transport is MQTT v5. Payloads are JSON, UTF-8. The robot emits compact JSON
+  (no insignificant whitespace), but that is an emission detail, not a parsing
+  contract.
+- Every publish is QoS 1 (see §3). The robot never publishes at QoS 0 or 2.
+
+## 2. Identity and authorization
+
+- The robot authenticates with mTLS. Its client certificate's CN is
+  `{tenant}/{robot}`, assigned and signed by the fleet service at enrollment
+  (the CSR's own CN is advisory only and is ignored).
+- Broker ACLs restrict each certificate to its own
+  `bagel/v1/{tenant}/{robot}/#` subtree. Because identity is carried entirely
+  by the certificate and the topic, **payloads contain no tenant or robot
+  fields**.
+- The MQTT client id is `bagel/{tenant}/{robot}`. Neither id ever contains `/`
+  (robot ids match `^[a-z0-9][a-z0-9_-]{0,62}$`), so the delimiter is
+  unambiguous. The client id is deterministic per robot: a reconnecting robot
+  displaces its own stale session rather than leaking a second one.
+- MQTT keepalive is 30 s.
+
+## 3. QoS and retain
+
+| kind        | QoS | retained |
+|-------------|-----|----------|
+| `schema`    | 1   | yes      |
+| `channels`  | 1   | no       |
+| `events`    | 1   | no       |
+| `heartbeat` | 1   | yes      |
+| LWT (on `heartbeat`) | 1 | yes |
+
+A late subscriber therefore always sees the current schema and the robot's
+last-known liveness state immediately; channel batches and events are only
+seen live (plus at-least-once replay, §6).
+
+## 4. Last will and offline reasons
+
+At connect time the robot arms a retained last-will on its `heartbeat` topic:
+
+```json
+{"v": 1, "online": false, "reason": "lwt"}
+```
+
+An ungraceful drop (crash, power loss, network partition) makes the broker
+publish it after the keepalive lapses. The LWT payload carries no `t` field.
+
+A graceful disconnect publishes a retained clean-stop heartbeat before closing:
+
+```json
+{"v": 1, "t": <epoch seconds>, "online": false, "reason": "stopped"}
+```
+
+`reason` is `"stopped"` for a stop or shutdown and `"paused"` for a deliberate
+pause -- a paused robot is distinguishable from a stopped one by the retained
+payload alone. Consumers MUST treat any `online: false` heartbeat as
+offline regardless of `reason`, and MUST tolerate new `reason` values.
+
+## 5. `schema` payload
+
+```json
+{
+  "v": 1,
+  "channels": [
+    {
+      "c": "telemetry.battery.percent",
+      "type": "number",
+      "unit": "%",
+      "source_topic": "robot/telemetry",
+      "source_field": "battery.percent"
+    }
+  ]
+}
+```
+
+- `c`: the channel name every `channels` sample refers to (unique per robot).
+- `type`: one of `number`, `string`, `bool`, `geo`.
+- `unit`: a unit string or `null` (source metadata is often absent).
+- `source_topic` / `source_field`: provenance on the robot. For a `geo`
+  channel, `source_field` is the comma-joined component map (e.g.
+  `"lat=lat,lon=lon"`).
+
+The schema is republished (retained) on **every** (re)connect, and a rule
+change on the robot restarts its streaming session -- reconnect, then a fresh
+schema -- so the retained schema always describes the samples that follow it.
+Consumers must tolerate re-receiving an identical schema.
+
+## 6. `channels` payload and seq semantics
+
+```json
+{
+  "v": 1,
+  "seq": 42,
+  "t_batch": 1767312000.5,
+  "samples": [
+    {"c": "telemetry.battery.percent", "t": 1767312000.1, "v": 87.5},
+    {"c": "telemetry.gps.geo", "t": 1767312000.2,
+     "v": {"lat": 52.5, "lon": 13.4, "alt": 34.2}}
+  ]
+}
+```
+
+- `t_batch`: epoch seconds when the batch was flushed. `t`: the sample's
+  source timestamp, epoch seconds. Both are floats.
+- `v` is typed per the schema: JSON number for `number`, string for `string`,
+  boolean for `bool`, and for `geo` an object `{"lat": <num>, "lon": <num>}`
+  with an OPTIONAL `"alt"` key (present only when the robot's rule mapped an
+  altitude field).
+- Sample density: each channel is rate-capped on the robot at its configured
+  `rate_hz` (at most one sample per `1/rate_hz` interval, capped at 50 Hz).
+
+**Batching.** The robot flushes a batch every `flush_interval_s` (default
+1 s) or as soon as 500 samples are pending, whichever comes first. A batch
+carries at most 500 samples; a wider backlog is split into consecutive
+batches in the same flush pass, each with its own `seq`.
+
+**seq.** Monotonic per lane (`channels` and `events` are separate seq
+spaces), per robot, starting at 1, persisted on the robot's disk spool across
+restarts -- a rebooted robot continues its seq, it never restarts from 1.
+
+**Delivery.** At-least-once: QoS 1 plus spool replay after reconnect means a
+consumer can see a batch twice. The dedupe key is
+`(tenant, robot, kind, seq)` -- tenant and robot from the topic, `kind` the
+topic's last segment. Replay is strictly seq-ordered: batches never arrive
+out of order within a lane. A **gap** in the `channels` seq therefore means
+exactly one thing: the robot's capped spool evicted oldest batches during a
+sustained disconnect (reported in the heartbeat's `spool.evicted`, §8) --
+never reordering.
+
+## 7. `events` payload
+
+```json
+{
+  "v": 1,
+  "seq": 7,
+  "event_id": "e0a1...",
+  "name": "low_battery",
+  "t_start": 1767312000.0,
+  "t_end": 1767312030.0,
+  "source_topic": "robot/telemetry",
+  "summary": {},
+  "artifact": {"kind": "mcap", "uri": "..."}
+}
+```
+
+- Events have their **own lane and seq space**, independent of `channels`,
+  with the same at-least-once + seq-ordered semantics and the same dedupe key.
+  The events lane is never evicted: an event, once recorded, is delivered.
+- `event_id` is a globally unique id; `name` is the robot-side rule name;
+  `summary` is a free-form JSON object.
+- `artifact` is OPTIONAL. When present, `kind` is `"mcap"` (the only v1 kind)
+  and `uri` points at the captured artifact.
+
+The on-robot event *emitter* ships in a future release; this shape is
+contractual now, and the conformance selftest (§10) already publishes one
+event (without `artifact`).
+
+## 8. `heartbeat` payload
+
+Published retained every **30 s** (first beat immediately at session start):
+
+```json
+{
+  "v": 1,
+  "t": 1767312000.0,
+  "online": true,
+  "bagel_version": "2.2.3",
+  "uptime_s": 3600.5,
+  "subscriptions": ["robot/telemetry"],
+  "channels_active": 3,
+  "queue": {"depth": 0, "dropped": 0},
+  "spool": {"bytes": 12288, "pending": 0, "evicted": 0},
+  "disk_free_bytes": 52000000000,
+  "cert_expires_at": "2026-12-01T00:00:00Z",
+  "reconnects": 2
+}
+```
+
+- `bagel_version`: version string, or `"unknown"` when the robot cannot
+  determine its own version.
+- `uptime_s`: seconds since the streaming session started.
+- `subscriptions`: the source topics currently tapped; `channels_active`: the
+  number of resolved channels in the current schema.
+- `queue`: the robot's in-memory sample queue -- `depth` now, `dropped`
+  cumulative (oldest-dropped on overflow).
+- `spool`: on-disk store-and-forward totals summed across lanes -- `bytes` on
+  disk, `pending` records not yet acknowledged by the broker, and
+  **`evicted`: the eviction indicator.** A nonzero (or growing) `evicted`
+  count is how data loss is reported: it counts batches discarded from the
+  capped `channels` lane under sustained disconnect, and it is exactly what a
+  consumer's observed gaps in the `channels` seq (§6) correspond to.
+- `disk_free_bytes`: free space on the robot's cache filesystem.
+- `cert_expires_at`: ISO-8601 expiry of the robot's client certificate, or
+  `null` until the robot is enrolled. Consumers MUST tolerate `null`.
+- `reconnects`: cumulative unexpected disconnects this session.
+
+**OPTIONAL, reserved:** a `build` block --
+`"build": {"build_id": "...", "vcs_ref": "..."}` -- is reserved for a future
+release. Consumers MUST tolerate both its absence and its arrival.
+
+Heartbeats are point-in-time liveness: a beat that cannot be published while
+offline is recorded to the robot's spool for diagnostics but is not replayed
+to the broker -- the retained heartbeat/LWT is the liveness source of truth.
+
+## 9. Enrollment and renewal protocol
+
+Both endpoints take JSON bodies and return JSON. `enroll_url` and `renew_url`
+are **BASE** URLs: the client appends the `/v1/...` path itself (a trailing
+slash on the base is tolerated). They may point at entirely different hosts.
+
+### Enroll
+
+```
+POST {enroll_url}/v1/enroll
+{"token": "<one-time token>", "csr_pem": "<PEM CSR>"}
+```
+
+- The private key is generated on the robot and never leaves it; only the CSR
+  crosses the network. The token appears in the request body only -- the
+  client never logs or stores it.
+- `200` response:
+
+```json
+{
+  "cert_pem": "...", "ca_pem": "...", "broker_url": "mqtts://...",
+  "tenant": "...", "robot_id": "...", "expires_at": "2026-12-01T00:00:00Z",
+  "renew_url": "https://..."
+}
+```
+
+  The first six fields are required. `renew_url` is **OPTIONAL**: when
+  present it is the BASE the client's future renewals target; when absent the
+  client renews against `enroll_url`.
+- Error statuses: `401` = unknown token; `410` = token already used or
+  expired. Tokens are single-use.
+- `expires_at` (here and in renew) is ISO-8601 with an explicit timezone
+  (`Z` accepted).
+
+### Renew
+
+```
+POST {renew_url or enroll_url}/v1/renew        (over mTLS)
+{"csr_pem": "<PEM CSR>"}
+```
+
+- Authenticated by the robot's CURRENT client certificate over mTLS; no token.
+  The CSR is backed by a brand-new private key every time.
+- `200` response:
+
+```json
+{"cert_pem": "...", "expires_at": "...", "ca_pem": "...", "renew_url": "..."}
+```
+
+  `cert_pem` and `expires_at` are required. `ca_pem` is OPTIONAL (present
+  only when the CA is being rotated). `renew_url` is **OPTIONAL here too**,
+  with the same BASE semantics: present means the fleet service is rotating
+  the base future renewals target (without re-enrollment); **absent means no
+  change** to whatever base the client already uses.
+- `404` or `501` = renewal not offered on this deployment; the client treats
+  this as expected (quiet), keeps its current certificate, and retries later.
+
+**Client timing** (what a fleet service can rely on): renewal attempts begin
+30 days before `expires_at`, are rate-limited to at most one attempt per day
+(persisted across robot restarts), and use a 30 s HTTP timeout. A failed
+renewal never damages the stored identity. The live MQTT session keeps its
+old certificate until its next reconnect.
+
+## 10. Conformance
+
+What a fleet service MUST accept: everything in §§1-8, including duplicate
+batches (dedupe on seq), seq gaps on `channels` (evictions), re-published
+identical schemas, `null` units and `null` `cert_expires_at`, unknown fields,
+and all three offline `reason` values.
+
+To validate an ingestion pipeline without a robot, run the selftest against
+the target broker from any Bagel checkout or image with the fleet group
+installed:
+
+```bash
+uv run python -m src.sink.publish.selftest [--broker mqtt(s)://...] \
+    [--batches N] [--interval-s S]
+```
+
+It publishes, in order, using the enrolled identity (or `--broker` on a dev
+rig): one retained schema, N channel batches (default 10, default 0.5 s
+apart), one heartbeat, one event -- then prints a one-line JSON summary and
+exits 0 (any expected failure prints to stderr and exits 1).
+
+The fixture is fixed and deterministic. The schema is exactly these four
+channels:
+
+| c | type | unit | source_topic | source_field |
+|---|------|------|--------------|--------------|
+| `selftest.number` | `number` | `"1"` | `selftest` | `number` |
+| `selftest.bool`   | `bool`   | `null` | `selftest` | `bool` |
+| `selftest.string` | `string` | `null` | `selftest` | `string` |
+| `selftest.geo`    | `geo`    | `null` | `selftest` | `lat=lat,lon=lon` |
+
+Every batch carries exactly 4 samples (one per channel; the batch size is
+fixed). For batch index `i` (0-based) at publish time `t`:
+
+- `selftest.number`: `v = float(i)`
+- `selftest.bool`: `v = (i % 2 == 0)`
+- `selftest.string`: `v = "selftest-{i}"`
+- `selftest.geo`: `v = {"lat": 52.0 + i*0.001, "lon": 13.0 + i*0.001}`
+
+The heartbeat reports `subscriptions: ["selftest"]` and `channels_active: 4`.
+The event has `name: "selftest"`, an `event_id` of the form
+`selftest-<uuid4>`, `summary: {"kind": "selftest", "batches": N}`, and no
+`artifact`. Seqs come from the robot's real lanes, so they continue from
+whatever the robot last used rather than starting at 1.

--- a/doc/runbooks/fleet_streaming.md
+++ b/doc/runbooks/fleet_streaming.md
@@ -114,6 +114,12 @@ spool lanes, and a concurrently running streaming service makes one side fail
 a sequence check. That failure is clean and harmless -- a typed error, exit
 code 1, nothing corrupted -- but the run doesn't count; pause and rerun.
 
+The selftest also refuses outright if either spool lane already has pending
+unacked backlog (e.g. a paused service's queued-but-unsent data) -- exit 1,
+nothing touched -- since it would otherwise ack its way past that backlog and
+silently drop it; let the service drain the backlog, or discard it first via
+`pause_fleet_streaming(discard=True)`.
+
 ## Dev rigs
 
 `FLEET_DEV_INSECURE=1` permits a plaintext `mqtt://` broker **only** when its

--- a/doc/runbooks/fleet_streaming.md
+++ b/doc/runbooks/fleet_streaming.md
@@ -28,7 +28,9 @@ Once `identity.yaml` exists, both variables are ignored and can be removed.
 > Enroll this robot with the fleet broker at `https://fleet.example.com` using token `<token>`.
 
 (`enroll_fleet_identity`). An already-enrolled robot refuses rather than
-overwriting -- unenroll first.
+overwriting -- unenroll first. Enrolling while a dev-placeholder streaming
+service is already running leaves that service unchanged; the new identity
+only takes effect on the next `stream_live_topics`/`stop_live_streams` restart.
 
 ### Token pitfalls
 
@@ -76,8 +78,10 @@ Add or replace streaming rules with `stream_live_topics`, remove them with
 
 Rule changes restart the streaming service: expect a brief reconnect blip
 (the retained schema is republished, and the disk spool preserves anything
-queued across the gap). Rules applied this way are persisted to the startup
-manifest's `streams:` section, so they survive container restarts.
+queued across the gap). Rule changes preserve paused state; the service
+reconnects briefly to republish the schema, then re-pauses -- it never
+silently comes back online. Rules applied this way are persisted to the
+startup manifest's `streams:` section, so they survive container restarts.
 
 `pause_fleet_streaming` / `resume_fleet_streaming` take the connection
 offline and back without touching identity or rules -- a paused robot leaves

--- a/doc/runbooks/fleet_streaming.md
+++ b/doc/runbooks/fleet_streaming.md
@@ -1,0 +1,123 @@
+# Stream live telemetry to a fleet service
+
+Bagel can stream selected channels, events and heartbeats from a robot to a fleet
+broker over MQTT/mTLS, with store-and-forward on disk so an unreliable link never
+loses data. The wire contract is pinned in [`doc/fleet_protocol_v1.md`](../fleet_protocol_v1.md);
+this runbook is the operator's side: enroll, stream, pause, verify, unenroll.
+
+## Enroll a robot
+
+Two paths, same result -- an identity lands in `FLEET_IDENTITY_DIRECTORY`
+(default `~/.bagel/identity`): `robot.key` (0600, generated on the robot and
+never transmitted), `robot.crt`, `ca.crt`, and `identity.yaml` (tenant, robot
+id, broker URL, expiry). Renewals later add versioned file names; `identity.yaml`
+always points at the current set.
+
+**First boot, hands-off:** set both env vars before starting the container --
+
+```bash
+FLEET_ENROLL_TOKEN=<one-time token>
+FLEET_ENROLL_URL=https://fleet.example.com
+```
+
+The server enrolls itself at boot if (and only if) it isn't already enrolled.
+Once `identity.yaml` exists, both variables are ignored and can be removed.
+
+**Interactively:** from your MCP client,
+
+> Enroll this robot with the fleet broker at `https://fleet.example.com` using token `<token>`.
+
+(`enroll_fleet_identity`). An already-enrolled robot refuses rather than
+overwriting -- unenroll first.
+
+### Token pitfalls
+
+Enrollment tokens are single-use. If the robot crashes between the server's
+HTTP 200 and storing the identity locally, the token is consumed but the robot
+has nothing to show for it -- a retry gets `410`. Re-issue a fresh token and
+retry; there is nothing to clean up on the robot. The token is never logged
+and never stored, so there is no copy to recover (or leak) after the attempt.
+
+## Kill switch
+
+`FLEET_ENABLED=0` makes the fleet subsystem fully inert: nothing connects,
+nothing leaves the box, the streaming tools refuse, and **first-boot
+enrollment is skipped too** -- an env-configured token is left unconsumed for
+when you re-enable. Two tools still work regardless: `describe_stream_status`
+(so you can see *that* it's disabled) and `unenroll_fleet_identity` (which
+only makes things more inert).
+
+## Certificate renewal
+
+Renewal is automatic: from 30 days before the certificate expires, the robot
+attempts a renewal once per day (rate limit persists across restarts) and
+carries on with its current certificate on any failure. While a fleet service
+ships renewal disabled, the robot's daily attempt gets `404`/`501` and treats
+it as expected -- no operator action, nothing in the logs above INFO.
+
+The renew endpoint can differ from the enroll endpoint: the enroll response's
+optional `renew_url` tells the robot where to renew, and each renew response
+may rotate it again. The client honors both as of this release -- but until
+the fleet service starts sending `renew_url` in renew responses, rotating the
+renewal endpoint of an already-enrolled robot requires unenroll + re-enroll.
+
+## Operate
+
+`describe_stream_status` is the local source of truth -- it answers sanely in
+every state (not installed, disabled, unenrolled, stopped, paused, running)
+and never depends on the broker being reachable:
+
+> Is this robot streaming to the fleet broker right now?
+
+Add or replace streaming rules with `stream_live_topics`, remove them with
+`stop_live_streams`:
+
+> Stream battery percent from `robot/telemetry` at 1 Hz to the fleet broker.
+
+Rule changes restart the streaming service: expect a brief reconnect blip
+(the retained schema is republished, and the disk spool preserves anything
+queued across the gap). Rules applied this way are persisted to the startup
+manifest's `streams:` section, so they survive container restarts.
+
+`pause_fleet_streaming` / `resume_fleet_streaming` take the connection
+offline and back without touching identity or rules -- a paused robot leaves
+a retained `reason: "paused"` heartbeat on the broker, so fleet-side
+dashboards can tell it from a crash. `pause_fleet_streaming(discard=True)`
+also drops the unsent channels backlog.
+
+Disk budget: the spool's channels lane is capped by `FLEET_SPOOL_MAX_BYTES`
+(default 256 MB) -- oldest batches are evicted first under a sustained
+disconnect, and the heartbeat's `spool.evicted` counter reports it. Events
+and heartbeats are never dropped.
+
+`unenroll_fleet_identity` stops any live streaming, deletes exactly the
+identity file set (key, cert, CA cert, `identity.yaml`, plus any versioned
+renewal leftovers) and removes the manifest's `streams:` section -- nothing
+else in the manifest is touched. Re-enrolling needs a fresh token.
+
+## Selftest
+
+To prove a broker + ingestion pipeline end to end with no robot data in the
+loop -- after enrolling, or against a dev broker:
+
+```bash
+uv run python -m src.sink.publish.selftest            # enrolled robot
+uv run python -m src.sink.publish.selftest --broker mqtt://localhost:1883  # dev rig
+```
+
+It publishes a fixed four-channel schema, ten deterministic batches, a
+heartbeat and an event (exact expected values are in the contract doc's
+Conformance section), prints a one-line JSON summary, and exits 0.
+
+Run it with fleet streaming **paused or stopped**: it shares the robot's real
+spool lanes, and a concurrently running streaming service makes one side fail
+a sequence check. That failure is clean and harmless -- a typed error, exit
+code 1, nothing corrupted -- but the run doesn't count; pause and rerun.
+
+## Dev rigs
+
+`FLEET_DEV_INSECURE=1` permits a plaintext `mqtt://` broker **only** when its
+host resolves to loopback or a private (RFC1918) address -- a production
+robot can never silently fall back to an unencrypted public broker. An
+unenrolled dev robot streams as the placeholder identity `dev/robot`.
+Production is always `mqtts://` with an enrolled identity.

--- a/plugin/skills/operating-fleet-streams/SKILL.md
+++ b/plugin/skills/operating-fleet-streams/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: operating-fleet-streams
+description: Use when enrolling a robot with a fleet service, streaming live channels/events/heartbeats to a fleet broker, pausing or stopping fleet streaming, or diagnosing spool/queue/certificate questions.
+---
+
+# Operating fleet streams
+
+A robot enrolls once with a fleet service (mTLS identity on disk), then
+streams selected channels, events and heartbeats to a fleet broker with
+store-and-forward spooling -- an unreliable link delays data, never loses it.
+
+- Start every diagnosis with `describe_stream_status`: it is the local source
+  of truth and answers sanely in every state (not installed, disabled,
+  unenrolled, stopped, paused, running) without needing the broker reachable.
+- Workflow: `describe_stream_status` -> `enroll_fleet_identity` (one-time
+  token + enroll URL) -> `stream_live_topics` to add/replace channel and
+  event rules -> `pause_fleet_streaming`/`resume_fleet_streaming` for
+  temporary offline -> `stop_live_streams` to remove rules ->
+  `unenroll_fleet_identity` to leave the fleet entirely (deletes the identity
+  file set and the manifest's `streams:` section; re-enrolling needs a fresh
+  token).
+- Rules applied via `stream_live_topics` persist to the startup manifest's
+  `streams:` section and survive restarts:
+
+  ```yaml
+  streams:
+    broker: mqtts://fleet.example.com:8883   # optional; defaults to the
+                                             # enrolled identity's broker_url
+    flush_interval_s: 1.0                    # optional; default 1.0
+    channels:
+      - topic: "robot/telemetry"
+        fields: ["speed", "battery.percent"]
+        rate_hz: 5
+    events:
+      - name: low_battery
+        topic: "robot/telemetry"
+        predicate: "\"robot/telemetry\"['battery']['percent'] < 10"
+  ```
+
+  A rule change restarts the streaming service (brief reconnect; the spool
+  preserves data across it).
+- Kill switch: `FLEET_ENABLED=0` makes the subsystem fully inert -- no
+  connections, no first-boot enrollment, tools refuse. Only
+  `describe_stream_status` and `unenroll_fleet_identity` still work.
+- Spool/queue questions: the channels lane is capped by
+  `FLEET_SPOOL_MAX_BYTES` (evict-oldest; the heartbeat's `spool.evicted`
+  counts losses); events and heartbeats are never dropped. Certificate
+  renewal is automatic from 30 days before expiry (`cert_expires_at` in
+  status). See references/settings-knobs.md for every `FLEET_*` knob.
+- Deeper dives: `doc/runbooks/fleet_streaming.md` (operator runbook) and
+  `doc/fleet_protocol_v1.md` (the v1 wire contract a fleet service consumes).

--- a/server.py
+++ b/server.py
@@ -1151,7 +1151,10 @@ def enroll_fleet_identity(token: str, enroll_url: str) -> dict[str, Any]:
     Generates a keypair locally (the private key never leaves this robot),
     submits a CSR to `enroll_url` alongside the one-time `token`, and stores
     the returned identity on disk. Already enrolled -> raises; run
-    `unenroll_fleet_identity` first.
+    `unenroll_fleet_identity` first. If a streaming service is already
+    running on the dev-placeholder identity, enrolling leaves it unchanged;
+    the new identity takes effect on the next `stream_live_topics`/
+    `stop_live_streams` restart.
 
     Args:
         token (str): One-time enrollment token issued out of band. Sent once
@@ -1167,6 +1170,8 @@ def enroll_fleet_identity(token: str, enroll_url: str) -> dict[str, Any]:
     Raises:
         EnrollmentError: Already enrolled, a rejected/expired token, a
             malformed response, or a transport failure.
+        FleetDisabledError: Fleet streaming is disabled (`FLEET_ENABLED=0`).
+        FleetNotInstalledError: The `fleet` dependency group isn't installed.
 
     Examples:
         As an LLM prompt:
@@ -1204,7 +1209,9 @@ def stream_live_topics(
     leaves a previously-running service completely untouched. Valid rules
     are merged onto the currently running (or persisted) rule set and become
     the new live streaming service; the merged set is also persisted back to
-    the manifest, if one is configured.
+    the manifest, if one is configured. Rule changes preserve paused state:
+    if the service was paused, it reconnects briefly to republish the
+    schema, then re-pauses -- it does not come back online.
 
     Args:
         channels (list[dict[str, Any]] | None, optional): Channel rules, in
@@ -1221,15 +1228,18 @@ def stream_live_topics(
             `artifact`. Defaults to None (no event changes).
 
     Returns:
-        dict[str, Any]: ``service`` ("running"), the resolved ``channels``,
-            the ``events`` names, and whether the change was ``persisted``
-            to the manifest.
+        dict[str, Any]: ``service`` ("running" or "paused" -- "paused" when
+            the service this replaced was paused), the resolved
+            ``channels``, the ``events`` names, and whether the change was
+            ``persisted`` to the manifest.
 
     Raises:
         StreamConfigError: An invalid rule, or no viable broker/covering
             sink for the merged topics.
         FleetNotEnrolledError: No broker configured and this robot isn't
             enrolled.
+        FleetDisabledError: Fleet streaming is disabled (`FLEET_ENABLED=0`).
+        FleetNotInstalledError: The `fleet` dependency group isn't installed.
 
     Examples:
         As an LLM prompt:
@@ -1260,6 +1270,10 @@ def stop_live_streams(
 ) -> dict[str, Any]:
     """Remove channel/event rules by name, restart, persist.
 
+    A restart (when something changed and a service was running) preserves
+    paused state: if the service was paused, it reconnects briefly to
+    republish the schema, then re-pauses -- it does not come back online.
+
     Args:
         channels (list[str] | None, optional): Channel names to remove, as
             reported by `describe_stream_status` (the resolved/renamed
@@ -1269,15 +1283,19 @@ def stop_live_streams(
             Unknown names are no-ops. Defaults to None.
 
     Returns:
-        dict[str, Any]: ``service`` ("running" or "stopped"), the remaining
-            ``channels``, the remaining ``events`` names, whether anything
-            ``changed``, and whether that change was ``persisted``.
+        dict[str, Any]: ``service`` ("running", "paused", or "stopped" --
+            "paused" when a restart happened and the service it replaced was
+            paused), the remaining ``channels``, the remaining ``events``
+            names, whether anything ``changed``, and whether that change was
+            ``persisted``.
 
     Raises:
         FleetNotEnrolledError | StreamConfigError: Only reachable when
             something changed and a service is running -- and, per the
             failure-outcome contract, such a failure leaves the previously
             running service running, untouched.
+        FleetDisabledError: Fleet streaming is disabled (`FLEET_ENABLED=0`).
+        FleetNotInstalledError: The `fleet` dependency group isn't installed.
 
     Examples:
         As an LLM prompt:
@@ -1319,6 +1337,10 @@ def pause_fleet_streaming(discard: bool = False) -> dict[str, Any]:
             running service (calling this again on an already-paused service
             reports ``changed: False``).
 
+    Raises:
+        FleetDisabledError: Fleet streaming is disabled (`FLEET_ENABLED=0`).
+        FleetNotInstalledError: The `fleet` dependency group isn't installed.
+
     Examples:
         As an LLM prompt:
             Pause fleet streaming, and drop any backlog we haven't sent yet.
@@ -1349,6 +1371,10 @@ def resume_fleet_streaming() -> dict[str, Any]:
             "running", "changed": bool}``, where ``changed`` is True only
             when this call actually resumed a paused service (calling this
             again on an already-running service reports ``changed: False``).
+
+    Raises:
+        FleetDisabledError: Fleet streaming is disabled (`FLEET_ENABLED=0`).
+        FleetNotInstalledError: The `fleet` dependency group isn't installed.
 
     Examples:
         As an LLM prompt:

--- a/server.py
+++ b/server.py
@@ -28,6 +28,7 @@ from src.pipeline import (
 )
 from src.pipeline.tasks.waffle import snap as waffle_snap
 from src.sink import startup
+from src.sink.publish import control as fleet_control
 from src.sink.publish import identity as fleet_identity
 
 server = mcp_compat.create_server(
@@ -1127,6 +1128,318 @@ def snap_hardware(directory: str = ".") -> dict[str, Any]:
         f"{BaseModule.SOURCE_FACTORY.value}.{ds_type.value}", {"path": str(form)}
     )
     return {"form": str(form), **factory.metadata}
+
+
+@server.tool(
+    title="Enroll this robot with a fleet broker",
+    description=(
+        "Use this tool to enroll this robot with a fleet broker using a one-time "
+        "enrollment token issued out of band. The token is single-use and is "
+        "never stored on disk or logged: it is sent once, in the enrollment "
+        "request body, and forgotten. If the server responds 200 but this "
+        "process crashes before finishing, the token has already been consumed "
+        "server-side -- the operator must re-issue a fresh token and retry "
+        "(mirrors the enrollment runbook)."
+    ),
+    annotations=mcp_compat.tool_annotations(
+        read_only=False, idempotent=False, destructive=False, open_world=True
+    ),
+)
+def enroll_fleet_identity(token: str, enroll_url: str) -> dict[str, Any]:
+    """Enroll this robot with a fleet broker: keygen, CSR, store identity.
+
+    Generates a keypair locally (the private key never leaves this robot),
+    submits a CSR to `enroll_url` alongside the one-time `token`, and stores
+    the returned identity on disk. Already enrolled -> raises; run
+    `unenroll_fleet_identity` first.
+
+    Args:
+        token (str): One-time enrollment token issued out of band. Sent once
+            in the request body; never stored or logged.
+        enroll_url (str): Base URL of the fleet broker's enrollment endpoint
+            (e.g. ``https://fleet.example.com``); ``/v1/enroll`` is appended.
+
+    Returns:
+        dict[str, Any]: ``tenant``, ``robot_id``, ``broker_url``, and
+            ``expires_at`` for the new identity. Never the token, never key
+            material or paths.
+
+    Raises:
+        EnrollmentError: Already enrolled, a rejected/expired token, a
+            malformed response, or a transport failure.
+
+    Examples:
+        As an LLM prompt:
+            Enroll this robot with the fleet broker using the token the
+            operator gave me.
+
+        As a Python call:
+            >>> enroll_fleet_identity("abc123", "https://fleet.example.com")
+
+    """
+    return fleet_control.enroll_identity(token, enroll_url)
+
+
+@server.tool(
+    title="Start or update live streaming rules",
+    description=(
+        "Use this tool to add or replace channel and event rules that stream "
+        "data to a fleet broker in real time, then (re)start streaming with "
+        "the merged rule set. A channel rule projects fields (or a `lat`/`lon` "
+        "geo pair) off a topic at a capped rate; an event rule fires a named "
+        "predicate with optional pre/post capture windows. A matching "
+        "`topic`/`name` REPLACES the existing rule; anything new is appended."
+    ),
+    annotations=mcp_compat.tool_annotations(
+        read_only=False, idempotent=False, destructive=False, open_world=True
+    ),
+)
+def stream_live_topics(
+    channels: list[dict[str, Any]] | None = None,
+    events: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Add/replace channel and event streaming rules, restart, persist.
+
+    Every rule is validated before any state changes: an invalid entry
+    leaves a previously-running service completely untouched. Valid rules
+    are merged onto the currently running (or persisted) rule set and become
+    the new live streaming service; the merged set is also persisted back to
+    the manifest, if one is configured.
+
+    Args:
+        channels (list[dict[str, Any]] | None, optional): Channel rules, in
+            the manifest `streams: channels:` shape. Each entry needs
+            `topic`, `rate_hz`, and exactly one of `fields` or `geo`, plus an
+            optional `as` rename map. For example, a fields rule:
+            ``{"topic": "/imu", "fields": ["orientation.w"], "rate_hz": 10}``;
+            a geo rule: ``{"topic": "/gps", "geo": {"lat": "latitude", "lon":
+            "longitude"}, "rate_hz": 1}``. Defaults to None (no channel
+            changes).
+        events (list[dict[str, Any]] | None, optional): Event rules, in the
+            manifest `streams: events:` shape: `name`, `topic`, `predicate`,
+            and optional `pre_seconds`/`post_seconds`/`debounce_seconds`/
+            `artifact`. Defaults to None (no event changes).
+
+    Returns:
+        dict[str, Any]: ``service`` ("running"), the resolved ``channels``,
+            the ``events`` names, and whether the change was ``persisted``
+            to the manifest.
+
+    Raises:
+        StreamConfigError: An invalid rule, or no viable broker/covering
+            sink for the merged topics.
+        FleetNotEnrolledError: No broker configured and this robot isn't
+            enrolled.
+
+    Examples:
+        As an LLM prompt:
+            Start streaming IMU orientation at 10 Hz and GPS position at 1 Hz.
+
+        As a Python call:
+            >>> stream_live_topics(channels=[{"topic": "/imu",
+            ...     "fields": ["orientation.w"], "rate_hz": 10}])
+
+    """
+    return fleet_control.stream_topics(channels, events)
+
+
+@server.tool(
+    title="Stop live streaming rules",
+    description=(
+        "Use this tool to remove channel and event rules by name from the "
+        "live streaming service, then restart with what remains (or leave a "
+        "running service alone when nothing matched)."
+    ),
+    annotations=mcp_compat.tool_annotations(
+        read_only=False, idempotent=True, destructive=False, open_world=True
+    ),
+)
+def stop_live_streams(
+    channels: list[str] | None = None,
+    events: list[str] | None = None,
+) -> dict[str, Any]:
+    """Remove channel/event rules by name, restart, persist.
+
+    Args:
+        channels (list[str] | None, optional): Channel names to remove, as
+            reported by `describe_stream_status` (the resolved/renamed
+            channel name, not the topic). Unknown names are no-ops. Defaults
+            to None.
+        events (list[str] | None, optional): Event rule names to remove.
+            Unknown names are no-ops. Defaults to None.
+
+    Returns:
+        dict[str, Any]: ``service`` ("running" or "stopped"), the remaining
+            ``channels``, the remaining ``events`` names, whether anything
+            ``changed``, and whether that change was ``persisted``.
+
+    Raises:
+        FleetNotEnrolledError | StreamConfigError: Only reachable when
+            something changed and a service is running -- and, per the
+            failure-outcome contract, such a failure leaves the previously
+            running service running, untouched.
+
+    Examples:
+        As an LLM prompt:
+            Stop streaming the IMU channel but leave GPS running.
+
+        As a Python call:
+            >>> stop_live_streams(channels=["imu.orientation.w"])
+
+    """
+    return fleet_control.stop_streams(channels, events)
+
+
+@server.tool(
+    title="Pause fleet streaming",
+    description=(
+        "Use this tool to take the live streaming connection to a fleet "
+        "broker offline while keeping this robot's identity and streaming "
+        "rules intact, so `resume_fleet_streaming` can bring it back exactly "
+        "as it was."
+    ),
+    annotations=mcp_compat.tool_annotations(
+        read_only=False, idempotent=True, destructive=False, open_world=True
+    ),
+)
+def pause_fleet_streaming(discard: bool = False) -> dict[str, Any]:
+    """Pause the live streaming service, if any: go offline, keep identity + rules.
+
+    Args:
+        discard (bool, optional): When True, additionally empties the
+            channel lane's still-unacked spool backlog. The events and
+            heartbeat lanes are never-drop and are left untouched regardless.
+            Defaults to False.
+
+    Returns:
+        dict[str, Any]: ``{"service": "stopped", "changed": False}`` when no
+            service is running (an idempotent no-op). Otherwise ``{"service":
+            "paused", "changed": bool, "discarded": discard}``, where
+            ``changed`` is True only when this call actually paused a
+            running service (calling this again on an already-paused service
+            reports ``changed: False``).
+
+    Examples:
+        As an LLM prompt:
+            Pause fleet streaming, and drop any backlog we haven't sent yet.
+
+        As a Python call:
+            >>> pause_fleet_streaming(discard=True)
+
+    """
+    return fleet_control.pause_streaming(discard=discard)
+
+
+@server.tool(
+    title="Resume fleet streaming",
+    description=(
+        "Use this tool to bring a paused streaming connection to a fleet "
+        "broker back online, mirroring `pause_fleet_streaming`."
+    ),
+    annotations=mcp_compat.tool_annotations(
+        read_only=False, idempotent=True, destructive=False, open_world=True
+    ),
+)
+def resume_fleet_streaming() -> dict[str, Any]:
+    """Resume the live streaming service, if any: mirror image of `pause_fleet_streaming`.
+
+    Returns:
+        dict[str, Any]: ``{"service": "stopped", "changed": False}`` when no
+            service is running (an idempotent no-op). Otherwise ``{"service":
+            "running", "changed": bool}``, where ``changed`` is True only
+            when this call actually resumed a paused service (calling this
+            again on an already-running service reports ``changed: False``).
+
+    Examples:
+        As an LLM prompt:
+            Resume fleet streaming now that the connection issue is fixed.
+
+        As a Python call:
+            >>> resume_fleet_streaming()
+
+    """
+    return fleet_control.resume_streaming()
+
+
+@server.tool(
+    title="Describe fleet streaming status",
+    description=(
+        "Use this tool to check this robot's fleet-streaming state: whether "
+        "the fleet dependencies are installed, enabled, whether this robot is "
+        "enrolled, and what the live streaming service is currently doing. "
+        "This is the local source of truth -- it works and answers sanely in "
+        "every state, including when a fleet broker itself is unreachable."
+    ),
+    annotations=mcp_compat.tool_annotations(
+        read_only=True, idempotent=True, destructive=False, open_world=False
+    ),
+)
+def describe_stream_status() -> dict[str, Any]:
+    """Report this robot's fleet-streaming state.
+
+    Never raises: answers sanely whether the fleet dependency group is
+    installed, whether fleet streaming is enabled, whether this robot is
+    enrolled, or whether a streaming service is currently running -- useful
+    for diagnosing exactly one of those states without depending on a fleet
+    broker being reachable.
+
+    Returns:
+        dict[str, Any]: ``enabled``, ``installed``, ``enrolled`` (bools);
+            ``identity`` (tenant/robot_id/broker_url/cert_expires_at/
+            renew_url, or None -- never key material or paths); ``service``
+            ("running"/"paused"/"stopped"); ``channels`` (resolved channel
+            descriptors, `[]` if no service); ``status`` (the running
+            service's counters block, or None).
+
+    Examples:
+        As an LLM prompt:
+            Is this robot streaming to the fleet broker right now?
+
+        As a Python call:
+            >>> describe_stream_status()
+
+    """
+    return fleet_control.fleet_status()
+
+
+@server.tool(
+    title="Unenroll this robot from its fleet broker",
+    description=(
+        "Use this tool to permanently remove this robot's fleet identity and "
+        "streaming rules, stopping any live streaming service first. The "
+        "robot returns to local-only operation; re-enrolling later requires a "
+        "fresh enrollment token."
+    ),
+    annotations=mcp_compat.tool_annotations(
+        read_only=False, idempotent=True, destructive=True, open_world=False
+    ),
+)
+def unenroll_fleet_identity() -> dict[str, Any]:
+    """Unenroll this robot: stop any live service, delete identity, clear manifest streams.
+
+    Best-effort stops the live streaming service, if any. Deletes exactly
+    the identity file set (key, cert, CA cert, `identity.yaml`) and, if a
+    manifest is configured, removes its `streams:` section -- nothing else
+    in the manifest (e.g. `subscriptions:`) is touched. Idempotent: calling
+    this again when nothing is enrolled returns `deleted: []` without error.
+
+    Returns:
+        dict[str, Any]: ``deleted`` (the identity file basenames removed, `[]`
+            if none were present), ``streams_removed`` (whether the manifest
+            was rewritten to drop its `streams:` section -- True whenever a
+            manifest is configured, regardless of whether it previously had a
+            `streams:` section to remove; always False when
+            `STARTUP_PIPELINES_FILE` is unset), and ``service`` ("stopped").
+
+    Examples:
+        As an LLM prompt:
+            Unenroll this robot from the fleet broker entirely.
+
+        As a Python call:
+            >>> unenroll_fleet_identity()
+
+    """
+    return fleet_control.unenroll_identity()
 
 
 if __name__ == "__main__":

--- a/src/sink/base.py
+++ b/src/sink/base.py
@@ -21,6 +21,35 @@ from src.sink.buffer import TopicBufferWriter
 _global_sink_singletons: dict[tuple[str, int], "TopicSink"] = {}  # (host, port) -> instance
 _global_sink_singletons_lock = threading.Lock()
 
+# Callbacks run as the FIRST act of every `TopicSink.close()`, before any
+# teardown -- the supported seam for something else to react to a sink
+# closing (e.g. a fleet service tapping its buffers; see startup.py).
+_close_hooks: list[Callable[["TopicSink"], None]] = []
+
+
+def register_close_hook(hook: Callable[["TopicSink"], None]) -> Callable[[], None]:
+    """Register a callback to run at the start of every `TopicSink.close()`.
+
+    Returns an unregister closure; calling it (even more than once, or after
+    the hook was never registered) is always a safe no-op.
+    """
+    _close_hooks.append(hook)
+
+    def _unregister() -> None:
+        if hook in _close_hooks:
+            _close_hooks.remove(hook)
+
+    return _unregister
+
+
+def live_sinks() -> list["TopicSink"]:
+    """Snapshot of all currently live TopicSink singletons.
+
+    Needed by callers (e.g. `control.stream_topics`) that must find an
+    already-connected sink without a fleet service running yet.
+    """
+    return list(_global_sink_singletons.values())
+
 
 class TopicNotFoundError(Exception):
     """Raised when topic is not found."""
@@ -181,6 +210,21 @@ class TopicSink(abc.ABC):
         """Topics currently subscribed on this sink, in insertion order."""
         return list(self._buffers)
 
+    def buffer_writer(self, topic: str) -> TopicBufferWriter:
+        """Return the live `TopicBufferWriter` for a subscribed topic.
+
+        The supported seam for fleet taps (spec §2): callers that need to
+        attach a tap to a topic's live buffer (e.g. `FleetService.start()`)
+        use this rather than reaching into the private `_buffers` mapping.
+
+        Raises:
+            TopicNotFoundError: If `topic` is not currently subscribed.
+
+        """
+        if topic not in self._buffers:
+            raise TopicNotFoundError([topic])
+        return self._buffers[topic]
+
     def ensure_capacity(
         self,
         topics: list[str],
@@ -336,6 +380,13 @@ class TopicSink(abc.ABC):
                 logging.debug("Best-effort disconnect of a partially constructed sink failed")
             return
         try:
+            for hook in list(_close_hooks):
+                try:
+                    hook(self)
+                except Exception:
+                    logging.warning(
+                        "Close hook %r raised while closing sink %r", hook, self, exc_info=True
+                    )
             self.pause()
             self._disconnect()
         finally:

--- a/src/sink/publish/config.py
+++ b/src/sink/publish/config.py
@@ -104,6 +104,22 @@ class ChannelRule(BaseModel):
     rate_hz: float
     renames: dict[str, str] = {}
 
+    def to_manifest(self) -> dict:
+        """Serialize back to the exact dict shape `ChannelRule.build` accepts.
+
+        Emits `"fields"` or `"geo"` (whichever this rule carries -- exactly
+        one, per `build`'s own invariant), and `"as"` only when `renames` is
+        non-empty (an unrenamed rule round-trips without the key at all).
+        """
+        doc: dict = {"topic": self.topic, "rate_hz": self.rate_hz}
+        if self.fields is not None:
+            doc["fields"] = list(self.fields)
+        else:
+            doc["geo"] = dict(self.geo)  # type: ignore[arg-type]  -- fields is None => geo is set
+        if self.renames:
+            doc["as"] = dict(self.renames)
+        return doc
+
     @staticmethod
     def build(config: dict, label: str = "channels[]") -> "ChannelRule":
         """Build and validate a channel rule from config dict."""
@@ -167,6 +183,22 @@ class EventRule(BaseModel):
     post_seconds: float = 0.0
     debounce_seconds: float = 0.0
     artifact: str | None = None
+
+    def to_manifest(self) -> dict:
+        """Serialize back to the exact dict shape `EventRule.build` accepts.
+
+        The required trio always appears; each window key appears only when
+        non-zero, and `"artifact"` only when set -- an unwindowed,
+        artifact-less event round-trips as just the three required keys.
+        """
+        doc: dict = {"name": self.name, "topic": self.topic, "predicate": self.predicate}
+        for key in ("pre_seconds", "post_seconds", "debounce_seconds"):
+            value = getattr(self, key)
+            if value != 0.0:
+                doc[key] = value
+        if self.artifact is not None:
+            doc["artifact"] = self.artifact
+        return doc
 
     @staticmethod
     def build(config: dict, label: str = "events[]") -> "EventRule":
@@ -237,6 +269,18 @@ def _stem(topic: str) -> str:
     return topic.rsplit("/", 1)[-1]
 
 
+def channel_name(rule: ChannelRule, field: str) -> str:
+    """Return the resolved (or renamed) channel name for one field of a channel rule.
+
+    `field` is a dotted field path (for a `fields:` rule) or the literal
+    `"geo"` (for a `geo:` rule) -- the same key space `rule.renames` uses.
+    This is the ONE formula both `_resolve_channel_rule` (below) and
+    `control.stop_streams` (which identifies channels to drop by this same
+    derived name) use -- extracted so the two never drift apart.
+    """
+    return rule.renames.get(field, f"{_stem(rule.topic)}.{field}")
+
+
 def _check_renames(renames: dict[str, str], allowed: set[str], label: str) -> None:
     """Reject a rename key that matches none of the rule's field paths."""
     for key in renames:
@@ -256,7 +300,7 @@ def _resolve_channel_rule(
                 type_name = classify(ap.pa_type)
             except ValueError as exc:
                 raise StreamConfigError(f"{label}.fields", str(exc)) from exc
-            name = rule.renames.get(field_path, f"{_stem(rule.topic)}.{field_path}")
+            name = channel_name(rule, field_path)
             resolved.append(
                 ResolvedChannel(
                     name=name,
@@ -279,7 +323,7 @@ def _resolve_channel_rule(
             except ValueError as exc:
                 raise StreamConfigError(f"{label}.geo.{key}", str(exc)) from exc
             paths[key] = ap
-        name = rule.renames.get("geo", f"{_stem(rule.topic)}.geo")
+        name = channel_name(rule, "geo")
         resolved.append(
             ResolvedChannel(
                 name=name,
@@ -364,6 +408,25 @@ class StreamsConfig(BaseModel):
             channels=channels,
             events=events,
         )
+
+    def to_manifest(self) -> dict:
+        """Serialize back to the exact dict shape `StreamsConfig.build` accepts.
+
+        `"broker"`/`"flush_interval_s"` appear only when non-default (a
+        fresh `StreamsConfig()` round-trips without either); `"channels"`/
+        `"events"` always appear, even as an empty list -- `build` accepts
+        an explicit `[]` for either, and control.py's stop_streams relies on
+        this to persist an emptied config as `{"channels": [], "events":
+        []}` rather than omitting the section's shape entirely.
+        """
+        doc: dict = {}
+        if self.broker is not None:
+            doc["broker"] = self.broker
+        if self.flush_interval_s != 1.0:
+            doc["flush_interval_s"] = self.flush_interval_s
+        doc["channels"] = [rule.to_manifest() for rule in self.channels]
+        doc["events"] = [rule.to_manifest() for rule in self.events]
+        return doc
 
     def resolve(self, structs: dict[str, pa.StructType]) -> list[ResolvedChannel]:
         """Resolve channel rules against topic schemas."""

--- a/src/sink/publish/control.py
+++ b/src/sink/publish/control.py
@@ -23,6 +23,13 @@ paho/cryptography eagerly either (see each module's own docstring), so
 doing so does not trip the package's no-eager-import invariant; a lazy
 regression test for THIS module lives in `test_control.py` alongside the
 existing gate/service ones.
+
+`_control_lock` (I2 ruling) serializes every mutating operation here --
+`stream_topics`, `stop_streams`, `unenroll_identity`, `pause_streaming`,
+`resume_streaming`, `enroll_identity` -- since an MCP client may invoke
+tools concurrently and stop-old/start-new is not itself atomic across two
+interleaved callers. `fleet_status()` intentionally never acquires it: it
+is read-only and must never block on a slow mutating call.
 """
 
 import importlib.util
@@ -31,6 +38,7 @@ import os
 import pathlib
 import stat
 import tempfile
+import threading
 from collections.abc import Callable
 
 import yaml
@@ -49,6 +57,13 @@ from src.sink.publish.connect import resolve_publisher_kwargs
 from src.sink.publish.mqtt import MqttPublisher
 from src.sink.publish.service import FleetService
 from src.sink.publish.spool import Spool
+
+# Serializes tool-driven lifecycle transitions (I2 ruling): MCP workers may
+# run tools concurrently, and stop-old/start-new (`_restart_service`) is not
+# itself atomic across two interleaved callers. `fleet_status()` is
+# intentionally left unlocked -- it is read-only and must never block on a
+# slow mutating call.
+_control_lock = threading.Lock()
 
 
 def fleet_status() -> dict:
@@ -136,12 +151,13 @@ def pause_streaming(discard: bool = False) -> dict:
 
     """
     require_fleet()
-    service = startup.fleet_service()
-    if service is None:
-        return {"service": "stopped", "changed": False}
-    changed = not service.paused
-    service.pause(discard=discard)
-    return {"service": "paused", "changed": changed, "discarded": discard}
+    with _control_lock:
+        service = startup.fleet_service()
+        if service is None:
+            return {"service": "stopped", "changed": False}
+        changed = not service.paused
+        service.pause(discard=discard)
+        return {"service": "paused", "changed": changed, "discarded": discard}
 
 
 def resume_streaming() -> dict:
@@ -162,12 +178,13 @@ def resume_streaming() -> dict:
 
     """
     require_fleet()
-    service = startup.fleet_service()
-    if service is None:
-        return {"service": "stopped", "changed": False}
-    changed = service.paused
-    service.resume()
-    return {"service": "running", "changed": changed}
+    with _control_lock:
+        service = startup.fleet_service()
+        if service is None:
+            return {"service": "stopped", "changed": False}
+        changed = service.paused
+        service.resume()
+        return {"service": "running", "changed": changed}
 
 
 def enroll_identity(token: str, enroll_url: str) -> dict:
@@ -189,16 +206,17 @@ def enroll_identity(token: str, enroll_url: str) -> dict:
 
     """
     require_fleet()
-    directory = pathlib.Path(settings.FLEET_IDENTITY_DIRECTORY)
-    if identity.is_enrolled(directory):
-        raise EnrollmentError(0, "already enrolled; run unenroll_fleet_identity first")
-    enrolled = identity.enroll(token, enroll_url, directory)
-    return {
-        "tenant": enrolled.tenant,
-        "robot_id": enrolled.robot_id,
-        "broker_url": enrolled.broker_url,
-        "expires_at": enrolled.expires_at,
-    }
+    with _control_lock:
+        directory = pathlib.Path(settings.FLEET_IDENTITY_DIRECTORY)
+        if identity.is_enrolled(directory):
+            raise EnrollmentError(0, "already enrolled; run unenroll_fleet_identity first")
+        enrolled = identity.enroll(token, enroll_url, directory)
+        return {
+            "tenant": enrolled.tenant,
+            "robot_id": enrolled.robot_id,
+            "broker_url": enrolled.broker_url,
+            "expires_at": enrolled.expires_at,
+        }
 
 
 def unenroll_identity() -> dict:
@@ -220,17 +238,18 @@ def unenroll_identity() -> dict:
         `{"deleted": list[str], "streams_removed": bool, "service": "stopped"}`.
 
     """
-    service = startup.fleet_service()
-    if service is not None:
-        try:
-            service.stop()
-        except Exception:
-            logging.warning("Best-effort stop of the live FleetService during unenroll failed")
-        finally:
-            startup.set_fleet_service(None)
-    deleted = identity.delete_identity(pathlib.Path(settings.FLEET_IDENTITY_DIRECTORY))
-    streams_removed = _persist_streams(None)
-    return {"deleted": deleted, "streams_removed": streams_removed, "service": "stopped"}
+    with _control_lock:
+        service = startup.fleet_service()
+        if service is not None:
+            try:
+                service.stop()
+            except Exception:
+                logging.warning("Best-effort stop of the live FleetService during unenroll failed")
+            finally:
+                startup.set_fleet_service(None)
+        deleted = identity.delete_identity(pathlib.Path(settings.FLEET_IDENTITY_DIRECTORY))
+        streams_removed = _persist_streams(None)
+        return {"deleted": deleted, "streams_removed": streams_removed, "service": "stopped"}
 
 
 def stream_topics(channels: list[dict] | None, events: list[dict] | None) -> dict:
@@ -247,8 +266,11 @@ def stream_topics(channels: list[dict] | None, events: list[dict] | None) -> dic
     configured.
 
     Returns:
-        `{"service": "running", "channels": list[dict], "events":
-        list[str], "persisted": bool}`.
+        `{"service": "running" | "paused", "channels": list[dict], "events":
+        list[str], "persisted": bool}`. `"paused"` when the service this
+        replaced was paused: `_restart_service` preserves paused-ness across
+        the rule-change restart (I1 ruling) -- a brief reconnect blip to
+        republish the schema, then straight back to paused.
 
     Raises:
         FleetDisabledError | FleetNotInstalledError: via `require_fleet()`.
@@ -268,31 +290,33 @@ def stream_topics(channels: list[dict] | None, events: list[dict] | None) -> dic
 
     """
     require_fleet()
-    new_channels = [
-        config.ChannelRule.build(entry, label=f"channels[{i}]")
-        for i, entry in enumerate(channels or [])
-    ]
-    new_events = [
-        config.EventRule.build(entry, label=f"events[{i}]") for i, entry in enumerate(events or [])
-    ]
+    with _control_lock:
+        new_channels = [
+            config.ChannelRule.build(entry, label=f"channels[{i}]")
+            for i, entry in enumerate(channels or [])
+        ]
+        new_events = [
+            config.EventRule.build(entry, label=f"events[{i}]")
+            for i, entry in enumerate(events or [])
+        ]
 
-    current = _current_streams()
-    merged = config.StreamsConfig(
-        broker=current.broker,
-        flush_interval_s=current.flush_interval_s,
-        channels=_merge_by_key(current.channels, new_channels, key=lambda rule: rule.topic),
-        events=_merge_by_key(current.events, new_events, key=lambda rule: rule.name),
-    )
+        current = _current_streams()
+        merged = config.StreamsConfig(
+            broker=current.broker,
+            flush_interval_s=current.flush_interval_s,
+            channels=_merge_by_key(current.channels, new_channels, key=lambda rule: rule.topic),
+            events=_merge_by_key(current.events, new_events, key=lambda rule: rule.name),
+        )
 
-    _restart_service(merged)
-    persisted = _persist_streams(merged.to_manifest())
-    service = startup.fleet_service()
-    return {
-        "service": "running",
-        "channels": service.channels,
-        "events": [rule.name for rule in merged.events],
-        "persisted": persisted,
-    }
+        _restart_service(merged)
+        persisted = _persist_streams(merged.to_manifest())
+        service = startup.fleet_service()
+        return {
+            "service": "paused" if service.paused else "running",
+            "channels": service.channels,
+            "events": [rule.name for rule in merged.events],
+            "persisted": persisted,
+        }
 
 
 def stop_streams(channels: list[str] | None, events: list[str] | None) -> dict:
@@ -318,8 +342,12 @@ def stop_streams(channels: list[str] | None, events: list[str] | None) -> dict:
     `persisted` reports `False`.
 
     Returns:
-        `{"service": "running" | "stopped", "channels": list[dict],
-        "events": list[str], "changed": bool, "persisted": bool}`.
+        `{"service": "running" | "paused" | "stopped", "channels":
+        list[dict], "events": list[str], "changed": bool, "persisted":
+        bool}`. `"paused"` when a restart happened and the service it
+        replaced was paused: `_restart_service` preserves paused-ness across
+        the restart (I1 ruling) -- a brief reconnect blip to republish the
+        schema, then straight back to paused.
 
     Raises:
         FleetDisabledError | FleetNotInstalledError: via `require_fleet()`.
@@ -331,38 +359,45 @@ def stop_streams(channels: list[str] | None, events: list[str] | None) -> dict:
 
     """
     require_fleet()
-    channel_names = set(channels or [])
-    event_names = set(events or [])
-    current = _current_streams()
+    with _control_lock:
+        channel_names = set(channels or [])
+        event_names = set(events or [])
+        current = _current_streams()
 
-    remaining_channels, channels_changed = _drop_channel_names(current.channels, channel_names)
-    remaining_events = [rule for rule in current.events if rule.name not in event_names]
-    events_changed = len(remaining_events) != len(current.events)
-    changed = channels_changed or events_changed
+        remaining_channels, channels_changed = _drop_channel_names(current.channels, channel_names)
+        remaining_events = [rule for rule in current.events if rule.name not in event_names]
+        events_changed = len(remaining_events) != len(current.events)
+        changed = channels_changed or events_changed
 
-    remaining = config.StreamsConfig(
-        broker=current.broker,
-        flush_interval_s=current.flush_interval_s,
-        channels=remaining_channels,
-        events=remaining_events,
-    )
+        remaining = config.StreamsConfig(
+            broker=current.broker,
+            flush_interval_s=current.flush_interval_s,
+            channels=remaining_channels,
+            events=remaining_events,
+        )
 
-    service = startup.fleet_service()
-    if changed and service is not None:
-        _restart_service(remaining)
         service = startup.fleet_service()
+        if changed and service is not None:
+            _restart_service(remaining)
+            service = startup.fleet_service()
 
-    # A pure no-op must not touch the manifest at all (not even a rewrite
-    # with identical content) -- a manifest with no `streams:` section stays
-    # byte-identical, and `persisted` truthfully reports `False`.
-    persisted = _persist_streams(remaining.to_manifest()) if changed else False
-    return {
-        "service": "running" if service is not None else "stopped",
-        "channels": service.channels if service is not None else [],
-        "events": [rule.name for rule in remaining.events],
-        "changed": changed,
-        "persisted": persisted,
-    }
+        # A pure no-op must not touch the manifest at all (not even a rewrite
+        # with identical content) -- a manifest with no `streams:` section
+        # stays byte-identical, and `persisted` truthfully reports `False`.
+        persisted = _persist_streams(remaining.to_manifest()) if changed else False
+        if service is None:
+            service_state = "stopped"
+        elif service.paused:
+            service_state = "paused"
+        else:
+            service_state = "running"
+        return {
+            "service": service_state,
+            "channels": service.channels if service is not None else [],
+            "events": [rule.name for rule in remaining.events],
+            "changed": changed,
+            "persisted": persisted,
+        }
 
 
 def _merge_by_key(current: list, new: list, *, key: Callable[[object], object]) -> list:
@@ -495,8 +530,16 @@ def _restart_service(streams: config.StreamsConfig) -> None:
     Any failure here propagates typed -- unlike `startup._start_fleet`
     (a boot-time path that swallows everything into a report), these are
     interactive tools: a caller needs to see exactly why a restart failed.
+
+    Paused-ness is preserved across the restart (I1 ruling): `old.paused` is
+    captured BEFORE `old` is touched at all, and if it was paused, the new
+    service is paused again immediately after `service.start()`. A rule
+    change on a paused service must not silently bring it back online --
+    the brief reconnect (to republish the retained schema) is an accepted,
+    documented blip, not a resume.
     """
     old = startup.fleet_service()
+    was_paused = old.paused if old is not None else False
     sink = _resolve_sink(streams, old)
 
     identity_obj = _load_identity_or_none()
@@ -516,6 +559,8 @@ def _restart_service(streams: config.StreamsConfig) -> None:
             startup.set_fleet_service(None)
 
     service.start()
+    if was_paused:
+        service.pause()
     startup.set_fleet_service(service)
 
 

--- a/src/sink/publish/control.py
+++ b/src/sink/publish/control.py
@@ -29,6 +29,7 @@ import importlib.util
 import logging
 import os
 import pathlib
+import stat
 import tempfile
 from collections.abc import Callable
 
@@ -252,7 +253,18 @@ def stream_topics(channels: list[dict] | None, events: list[dict] | None) -> dic
     Raises:
         FleetDisabledError | FleetNotInstalledError: via `require_fleet()`.
         StreamConfigError: an invalid rule dict, or `_restart_service`'s own
-            failure modes (no covering sink, no viable broker, etc).
+            failure modes (no covering sink for the merged topics, no
+            viable broker, etc).
+        FleetNotEnrolledError: `_restart_service`'s `resolve_publisher_kwargs`
+            call -- no broker configured and this robot isn't enrolled.
+
+        Failure-outcome contract (see `_restart_service`'s docstring): every
+        one of the above is checked BEFORE the old service (if any) is
+        touched, so a raise here always leaves a previously-running service
+        running, completely untouched. The only way this call can leave the
+        holder `None` on a raise is a failure INSIDE the new
+        `FleetService.start()` itself, which necessarily runs after the old
+        service has already been stopped.
 
     """
     require_fleet()
@@ -300,14 +312,22 @@ def stop_streams(channels: list[str] | None, events: list[str] | None) -> dict:
     starts one (that is `stream_topics`'s job) -- it only updates the
     persisted manifest.
 
+    A no-op (nothing matched) never touches the manifest either -- not just
+    "no restart": `_persist_streams` is skipped entirely, so a manifest that
+    had no `streams:` section stays exactly as it was (byte-identical), and
+    `persisted` reports `False`.
+
     Returns:
         `{"service": "running" | "stopped", "channels": list[dict],
         "events": list[str], "changed": bool, "persisted": bool}`.
 
     Raises:
         FleetDisabledError | FleetNotInstalledError: via `require_fleet()`.
-        StreamConfigError: via `_restart_service` (no covering sink, etc) --
-            only reachable when something changed and a service is running.
+        FleetNotEnrolledError | StreamConfigError: via `_restart_service`
+            (no covering sink, no viable broker, etc) -- only reachable when
+            something changed and a service is running; per its failure-
+            outcome contract, such a failure leaves the OLD service running
+            untouched (see `_restart_service`'s docstring).
 
     """
     require_fleet()
@@ -332,7 +352,10 @@ def stop_streams(channels: list[str] | None, events: list[str] | None) -> dict:
         _restart_service(remaining)
         service = startup.fleet_service()
 
-    persisted = _persist_streams(remaining.to_manifest())
+    # A pure no-op must not touch the manifest at all (not even a rewrite
+    # with identical content) -- a manifest with no `streams:` section stays
+    # byte-identical, and `persisted` truthfully reports `False`.
+    persisted = _persist_streams(remaining.to_manifest()) if changed else False
     return {
         "service": "running" if service is not None else "stopped",
         "channels": service.channels if service is not None else [],
@@ -401,40 +424,88 @@ def _current_streams() -> config.StreamsConfig:
     return loaded if loaded is not None else config.StreamsConfig()
 
 
+def _no_covering_sink_error(source_topics: set[str]) -> StreamConfigError:
+    return StreamConfigError(
+        "streams",
+        "all streams: source topics "
+        f"{sorted(source_topics)} must be subscribed within a SINGLE "
+        "startup manifest 'subscriptions:' entry -- fleet streaming "
+        "(v1) cannot span multiple subscription entries' sinks; list "
+        "every one of these topics under one entry's 'topics:'",
+    )
+
+
+def _resolve_sink(streams: config.StreamsConfig, old: FleetService | None) -> object:
+    """Pick the sink `_restart_service` will (re)build against -- raises before anything else.
+
+    When a service is already running, its sink is reused ONLY if it still
+    covers every one of `streams`'s source topics -- checked HERE, not left
+    to `FleetService.start()`'s own `StreamsConfig.resolve()`, precisely so
+    an uncovered/typo'd topic raises before `old` is ever touched (Codex
+    review: the previous version deferred this check until after `old` had
+    already been stopped and the holder cleared, so a bad rule call
+    destroyed a working service instead of being rejected cleanly). With no
+    service running, the first of `base.live_sinks()` whose
+    `subscribed_topics` cover every source topic is used instead (reusing
+    `startup._fleet_source_topics`/`_find_covering_sink`).
+    """
+    source_topics = startup._fleet_source_topics(streams)
+    if old is not None:
+        if not source_topics <= set(old.sink.subscribed_topics):
+            raise _no_covering_sink_error(source_topics)
+        return old.sink
+    candidates = [(s, s.subscribed_topics) for s in base.live_sinks()]
+    sink = startup._find_covering_sink(source_topics, candidates)
+    if sink is None:
+        raise _no_covering_sink_error(source_topics)
+    return sink
+
+
+def _load_identity_or_none() -> identity.Identity | None:
+    """Single-load `identity.load_identity`, `None` on `FleetNotEnrolledError`.
+
+    NOT `is_enrolled()` followed by a separate `load_identity()` call --
+    that two-call shape has the same TOCTOU `fleet_status()` was fixed for
+    (Task 4's carried finding): a corrupt/deleted identity between the two
+    calls would raise here instead of degrading to "unenrolled".
+    """
+    try:
+        return identity.load_identity(settings.FLEET_IDENTITY_DIRECTORY)
+    except FleetNotEnrolledError:
+        return None
+
+
 def _restart_service(streams: config.StreamsConfig) -> None:
     """Rebuild path for `stream_topics`/`stop_streams` (mirrors `startup._start_fleet`).
 
-    1. Pick the sink: the CURRENT service's, if one is running (its
-       `FleetService.start()`/`StreamsConfig.resolve()` will itself raise a
-       typed `StreamConfigError` if `streams` now references a topic that
-       sink never subscribed); otherwise the first of `base.live_sinks()`
-       whose `subscribed_topics` cover every source topic (reusing
-       `startup._fleet_source_topics`/`_find_covering_sink`) -- none found
-       raises `StreamConfigError` BEFORE anything else is touched.
-    2. Best-effort stop the old service (if any) and clear the holder.
-    3. Build a fresh publisher/spool/`FleetService` from `streams` and the
-       current enrollment state, start it, and install it as the holder.
+    Failure-outcome contract: every check that can be done WITHOUT touching
+    the old service -- sink coverage (`_resolve_sink`), identity resolution
+    (`_load_identity_or_none`), broker/auth resolution
+    (`resolve_publisher_kwargs`), and constructing the new publisher/spool/
+    `FleetService` -- runs first, while the old service (if any) is still
+    fully intact and untouched. Only once ALL of that has succeeded is the
+    old service stopped and the holder cleared. So: a validation failure
+    (bad topic, no viable broker, etc) always leaves the OLD service running
+    exactly as it was; the only way this call can leave the holder `None` is
+    a failure INSIDE the new `FleetService.start()` itself, which runs after
+    the old service has already been torn down (there is no way to
+    interleave "start the new one" before "stop the old one" -- they would
+    otherwise both be tapping the same sink's buffers at once).
 
     Any failure here propagates typed -- unlike `startup._start_fleet`
     (a boot-time path that swallows everything into a report), these are
     interactive tools: a caller needs to see exactly why a restart failed.
     """
     old = startup.fleet_service()
-    if old is not None:
-        sink = old.sink
-    else:
-        source_topics = startup._fleet_source_topics(streams)
-        candidates = [(s, s.subscribed_topics) for s in base.live_sinks()]
-        sink = startup._find_covering_sink(source_topics, candidates)
-        if sink is None:
-            raise StreamConfigError(
-                "streams",
-                "all streams: source topics "
-                f"{sorted(source_topics)} must be subscribed within a SINGLE "
-                "startup manifest 'subscriptions:' entry -- fleet streaming "
-                "(v1) cannot span multiple subscription entries' sinks; list "
-                "every one of these topics under one entry's 'topics:'",
-            )
+    sink = _resolve_sink(streams, old)
+
+    identity_obj = _load_identity_or_none()
+    publisher_kwargs = resolve_publisher_kwargs(streams, identity_obj)
+    publisher = MqttPublisher(**publisher_kwargs)
+    spool = Spool.for_robot(identity_obj.robot if identity_obj is not None else "dev/robot")
+    service = FleetService(
+        sink=sink, streams=streams, publisher=publisher, spool=spool, identity=identity_obj
+    )
 
     if old is not None:
         try:
@@ -444,14 +515,6 @@ def _restart_service(streams: config.StreamsConfig) -> None:
         finally:
             startup.set_fleet_service(None)
 
-    directory = settings.FLEET_IDENTITY_DIRECTORY
-    identity_obj = identity.load_identity(directory) if identity.is_enrolled(directory) else None
-    publisher_kwargs = resolve_publisher_kwargs(streams, identity_obj)
-    publisher = MqttPublisher(**publisher_kwargs)
-    spool = Spool.for_robot(identity_obj.robot if identity_obj is not None else "dev/robot")
-    service = FleetService(
-        sink=sink, streams=streams, publisher=publisher, spool=spool, identity=identity_obj
-    )
     service.start()
     startup.set_fleet_service(service)
 
@@ -494,11 +557,20 @@ def _persist_streams(streams_manifest: dict | None) -> bool:
     (`_read_manifest_doc` -- missing -> `{}`, unparsable -> raises rather
     than clobbering a human-maintained file), updates just the `"streams"`
     key, and writes the whole document back atomically (sibling tempfile +
-    `os.replace`) so a crash mid-write never corrupts it.
+    `os.replace`) so a crash mid-write never corrupts it. When the manifest
+    file already exists, its permission mode is copied onto the tempfile
+    before the replace -- `tempfile.mkstemp` creates at 0600 by default, so
+    without this a manifest a human left group/other-readable (or made
+    read-only) would silently end up 0600 after its first control-plane
+    write. A freshly-created manifest (no prior file) keeps that 0600
+    default -- there is no prior mode to preserve, and this file can carry
+    fleet broker configuration.
     """
     path = _manifest_path()
     if path is None:
         return False
+    preexisting = path.is_file()
+    mode = stat.S_IMODE(path.stat().st_mode) if preexisting else None
     doc = _read_manifest_doc()
     if streams_manifest is None:
         doc.pop("streams", None)
@@ -508,6 +580,8 @@ def _persist_streams(streams_manifest: dict | None) -> bool:
     fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
     tmp = pathlib.Path(tmp_name)
     try:
+        if mode is not None:
+            os.fchmod(fd, mode)
         with os.fdopen(fd, "w") as handle:
             yaml.safe_dump(doc, handle, sort_keys=False)
         os.replace(tmp, path)

--- a/src/sink/publish/control.py
+++ b/src/sink/publish/control.py
@@ -1,0 +1,142 @@
+"""Fleet control-plane operations: the tool-facing layer over `FleetService`.
+
+Step 7's MCP tools are thin passthroughs to this module (spec §7) -- this is
+where the four-state sanity ruling lives: every operation here behaves
+sanely whether the `fleet` dependency group is installed, whether
+`settings.FLEET_ENABLED` is on, whether this robot is enrolled, and whether a
+`FleetService` is currently running.
+
+`fleet_status()` is the one exception to `require_fleet()`: per the binding
+ruling, it calls NO gate at all, because it IS the tool that reports on
+those first two states rather than assuming them -- a caller diagnosing "why
+won't fleet streaming start" needs an answer even when it's not installed or
+disabled, not an exception. `pause_streaming`/`resume_streaming` call
+`require_fleet()` first, so `FLEET_ENABLED=0` raises `FleetDisabledError`
+before the live-service holder (`src.sink.startup.fleet_service()`) is ever
+touched -- there is no code path where a disabled fleet subsystem still
+reaches into the holder.
+
+Only `startup` (the live-service holder) and `identity` (enrollment status)
+are needed for the operations this module carries today (status/pause/
+resume); later tasks in this step add `enroll_identity`/`unenroll_identity`/
+`stream_topics`/`stop_streams`, which pull in `connect`, `config`, `spool`,
+and `mqtt` too -- all of those stay just as lazy about paho/cryptography as
+this module is (neither is imported here at module scope).
+"""
+
+import importlib.util
+
+from settings import settings
+from src.sink import startup
+from src.sink.publish import identity, require_fleet
+
+
+def fleet_status() -> dict:
+    """Report this robot's fleet-streaming state -- the local source of truth (spec §7).
+
+    Calls NO gate: this must answer sanely in every state (uninstalled,
+    disabled, unenrolled, no service running), not raise when one of those
+    is exactly what the caller is trying to diagnose.
+
+    Returns:
+        ```
+        {
+          "enabled": bool,        # settings.FLEET_ENABLED
+          "installed": bool,      # the `fleet` dependency group (paho-mqtt) is importable
+          "enrolled": bool,       # a complete identity is stored on disk
+          "identity": {"tenant", "robot_id", "broker_url", "cert_expires_at",
+                       "renew_url"} | None,  # never key material, never paths
+          "service": "running" | "paused" | "stopped",
+          "channels": list[dict],  # resolved channel descriptors, [] if no service
+          "status": dict | None,   # FleetService.status()'s §4 counters block, verbatim
+        }
+        ```
+
+    """
+    service = startup.fleet_service()
+    if service is None:
+        service_state = "stopped"
+    elif service.paused:
+        service_state = "paused"
+    else:
+        service_state = "running"
+
+    enrolled = identity.is_enrolled(settings.FLEET_IDENTITY_DIRECTORY)
+    identity_summary = None
+    if enrolled:
+        loaded = identity.load_identity(settings.FLEET_IDENTITY_DIRECTORY)
+        identity_summary = {
+            "tenant": loaded.tenant,
+            "robot_id": loaded.robot_id,
+            "broker_url": loaded.broker_url,
+            "cert_expires_at": loaded.expires_at,
+            "renew_url": loaded.renew_url,
+        }
+
+    return {
+        "enabled": bool(settings.FLEET_ENABLED),
+        "installed": importlib.util.find_spec("paho.mqtt") is not None,
+        "enrolled": enrolled,
+        "identity": identity_summary,
+        "service": service_state,
+        "channels": service.channels if service is not None else [],
+        "status": service.status() if service is not None else None,
+    }
+
+
+def pause_streaming(discard: bool = False) -> dict:
+    """Pause the live `FleetService`, if any: go offline, keep identity + rules.
+
+    `require_fleet()` first -- `FLEET_ENABLED=0` raises `FleetDisabledError`
+    before the holder is touched at all.
+
+    Args:
+        discard: When true, additionally empties the channels spool lane's
+            still-unacked backlog (events/heartbeat are never-drop lanes and
+            are left untouched -- see `FleetService.pause`).
+
+    Returns:
+        `{"service": "stopped", "changed": False}` when no service is
+        running (an idempotent no-op). Otherwise `{"service": "paused",
+        "changed": bool, "discarded": discard}`, where `changed` is `True`
+        only when this call actually transitioned a running service to
+        paused (a second `pause_streaming()` call on an already-paused
+        service reports `changed: False`).
+
+    Raises:
+        FleetDisabledError | FleetNotInstalledError: via `require_fleet()`.
+
+    """
+    require_fleet()
+    service = startup.fleet_service()
+    if service is None:
+        return {"service": "stopped", "changed": False}
+    changed = not service.paused
+    service.pause(discard=discard)
+    return {"service": "paused", "changed": changed, "discarded": discard}
+
+
+def resume_streaming() -> dict:
+    """Resume the live `FleetService`, if any: mirror image of `pause_streaming`.
+
+    `require_fleet()` first -- `FLEET_ENABLED=0` raises `FleetDisabledError`
+    before the holder is touched at all.
+
+    Returns:
+        `{"service": "stopped", "changed": False}` when no service is
+        running (an idempotent no-op). Otherwise `{"service": "running",
+        "changed": bool}`, where `changed` is `True` only when this call
+        actually transitioned a paused service back to running (calling
+        this on an already-running service reports `changed: False`).
+
+    Raises:
+        FleetDisabledError | FleetNotInstalledError: via `require_fleet()`.
+
+    """
+    require_fleet()
+    service = startup.fleet_service()
+    if service is None:
+        return {"service": "stopped", "changed": False}
+    changed = service.paused
+    service.resume()
+    return {"service": "running", "changed": changed}

--- a/src/sink/publish/control.py
+++ b/src/sink/publish/control.py
@@ -10,25 +10,44 @@ sanely whether the `fleet` dependency group is installed, whether
 ruling, it calls NO gate at all, because it IS the tool that reports on
 those first two states rather than assuming them -- a caller diagnosing "why
 won't fleet streaming start" needs an answer even when it's not installed or
-disabled, not an exception. `pause_streaming`/`resume_streaming` call
+disabled, not an exception. `unenroll_identity()` is the other exception
+(ruling): unenrolling only makes the fleet subsystem MORE inert, so it must
+work even with `FLEET_ENABLED=0`. Every other operation here calls
 `require_fleet()` first, so `FLEET_ENABLED=0` raises `FleetDisabledError`
 before the live-service holder (`src.sink.startup.fleet_service()`) is ever
-touched -- there is no code path where a disabled fleet subsystem still
-reaches into the holder.
+touched.
 
-Only `startup` (the live-service holder) and `identity` (enrollment status)
-are needed for the operations this module carries today (status/pause/
-resume); later tasks in this step add `enroll_identity`/`unenroll_identity`/
-`stream_topics`/`stop_streams`, which pull in `connect`, `config`, `spool`,
-and `mqtt` too -- all of those stay just as lazy about paho/cryptography as
-this module is (neither is imported here at module scope).
+`connect`, `config`, `spool`, and `mqtt` are all imported at module scope
+here (alongside `startup` and `identity`) -- none of them import
+paho/cryptography eagerly either (see each module's own docstring), so
+doing so does not trip the package's no-eager-import invariant; a lazy
+regression test for THIS module lives in `test_control.py` alongside the
+existing gate/service ones.
 """
 
 import importlib.util
+import logging
+import os
+import pathlib
+import tempfile
+from collections.abc import Callable
+
+import yaml
 
 from settings import settings
-from src.sink import startup
-from src.sink.publish import identity, require_fleet
+from src.sink import base, startup
+from src.sink.publish import (
+    EnrollmentError,
+    FleetNotEnrolledError,
+    StreamConfigError,
+    config,
+    identity,
+    require_fleet,
+)
+from src.sink.publish.connect import resolve_publisher_kwargs
+from src.sink.publish.mqtt import MqttPublisher
+from src.sink.publish.service import FleetService
+from src.sink.publish.spool import Spool
 
 
 def fleet_status() -> dict:
@@ -61,10 +80,18 @@ def fleet_status() -> dict:
     else:
         service_state = "running"
 
-    enrolled = identity.is_enrolled(settings.FLEET_IDENTITY_DIRECTORY)
-    identity_summary = None
-    if enrolled:
+    # Single load, not `is_enrolled()` followed by a separate `load_identity()`
+    # call -- that two-call shape has a TOCTOU: a corrupt/deleted identity
+    # between the two calls would raise `FleetNotEnrolledError` through this
+    # function's never-raises contract. One `load_identity()` call, caught
+    # here, closes that window structurally.
+    try:
         loaded = identity.load_identity(settings.FLEET_IDENTITY_DIRECTORY)
+    except FleetNotEnrolledError:
+        loaded = None
+
+    identity_summary = None
+    if loaded is not None:
         identity_summary = {
             "tenant": loaded.tenant,
             "robot_id": loaded.robot_id,
@@ -76,7 +103,7 @@ def fleet_status() -> dict:
     return {
         "enabled": bool(settings.FLEET_ENABLED),
         "installed": importlib.util.find_spec("paho.mqtt") is not None,
-        "enrolled": enrolled,
+        "enrolled": loaded is not None,
         "identity": identity_summary,
         "service": service_state,
         "channels": service.channels if service is not None else [],
@@ -140,3 +167,350 @@ def resume_streaming() -> dict:
     changed = service.paused
     service.resume()
     return {"service": "running", "changed": changed}
+
+
+def enroll_identity(token: str, enroll_url: str) -> dict:
+    """Enroll this robot with the fleet cloud: keygen, CSR, store identity (spec §6).
+
+    `require_fleet()` first. Already enrolled -> `EnrollmentError(0, ...)`
+    (ruling: status 0 means "no server was ever contacted", consistent with
+    that code's existing transport-failure meaning) rather than silently
+    re-enrolling over an existing identity.
+
+    Returns:
+        `{"tenant", "robot_id", "broker_url", "expires_at"}` -- NEVER the
+        token, and never key material or paths.
+
+    Raises:
+        FleetDisabledError | FleetNotInstalledError: via `require_fleet()`.
+        EnrollmentError: already enrolled, or any of `identity.enroll()`'s
+            own failure modes (see its docstring).
+
+    """
+    require_fleet()
+    directory = pathlib.Path(settings.FLEET_IDENTITY_DIRECTORY)
+    if identity.is_enrolled(directory):
+        raise EnrollmentError(0, "already enrolled; run unenroll_fleet_identity first")
+    enrolled = identity.enroll(token, enroll_url, directory)
+    return {
+        "tenant": enrolled.tenant,
+        "robot_id": enrolled.robot_id,
+        "broker_url": enrolled.broker_url,
+        "expires_at": enrolled.expires_at,
+    }
+
+
+def unenroll_identity() -> dict:
+    """Unenroll this robot: stop any live service, delete identity, clear manifest streams.
+
+    NO gate (ruling): unenrolling only makes the fleet subsystem MORE
+    inert, so it must work even with `FLEET_ENABLED=0` or paho not
+    installed.
+
+    Best-effort stops the live `FleetService`, if any, and clears the
+    holder regardless of whether the stop itself succeeded.
+    `identity.delete_identity()` is the ONLY deletion path (ruling a) --
+    nothing here unlinks a file directly. The manifest's `streams:` section,
+    if persisted, is removed too (`subscriptions:` and everything else in
+    the manifest is left untouched). Idempotent: a second call finds
+    nothing enrolled and returns `deleted: []` without error.
+
+    Returns:
+        `{"deleted": list[str], "streams_removed": bool, "service": "stopped"}`.
+
+    """
+    service = startup.fleet_service()
+    if service is not None:
+        try:
+            service.stop()
+        except Exception:
+            logging.warning("Best-effort stop of the live FleetService during unenroll failed")
+        finally:
+            startup.set_fleet_service(None)
+    deleted = identity.delete_identity(pathlib.Path(settings.FLEET_IDENTITY_DIRECTORY))
+    streams_removed = _persist_streams(None)
+    return {"deleted": deleted, "streams_removed": streams_removed, "service": "stopped"}
+
+
+def stream_topics(channels: list[dict] | None, events: list[dict] | None) -> dict:
+    """Add/replace channel and event rules at runtime, restart, persist (spec §7).
+
+    `require_fleet()` first. Every entry is validated (`ChannelRule.build`/
+    `EventRule.build`, typed `StreamConfigError`) BEFORE any state changes.
+    The validated rules are merged onto the current config (the running
+    service's `.streams`, else the manifest's persisted streams, else an
+    empty `StreamsConfig`) per the binding merge ruling: a channel rule
+    REPLACES any existing rule for the same `topic`; an event rule replaces
+    by `name`. The merged config becomes the new live service (via
+    `_restart_service`) and is persisted back to the manifest, if one is
+    configured.
+
+    Returns:
+        `{"service": "running", "channels": list[dict], "events":
+        list[str], "persisted": bool}`.
+
+    Raises:
+        FleetDisabledError | FleetNotInstalledError: via `require_fleet()`.
+        StreamConfigError: an invalid rule dict, or `_restart_service`'s own
+            failure modes (no covering sink, no viable broker, etc).
+
+    """
+    require_fleet()
+    new_channels = [
+        config.ChannelRule.build(entry, label=f"channels[{i}]")
+        for i, entry in enumerate(channels or [])
+    ]
+    new_events = [
+        config.EventRule.build(entry, label=f"events[{i}]") for i, entry in enumerate(events or [])
+    ]
+
+    current = _current_streams()
+    merged = config.StreamsConfig(
+        broker=current.broker,
+        flush_interval_s=current.flush_interval_s,
+        channels=_merge_by_key(current.channels, new_channels, key=lambda rule: rule.topic),
+        events=_merge_by_key(current.events, new_events, key=lambda rule: rule.name),
+    )
+
+    _restart_service(merged)
+    persisted = _persist_streams(merged.to_manifest())
+    service = startup.fleet_service()
+    return {
+        "service": "running",
+        "channels": service.channels,
+        "events": [rule.name for rule in merged.events],
+        "persisted": persisted,
+    }
+
+
+def stop_streams(channels: list[str] | None, events: list[str] | None) -> dict:
+    """Remove channel/event rules by name at runtime, restart, persist (spec §7).
+
+    `require_fleet()` first. `channels` names resolved (or renamed) channel
+    names -- see `config.channel_name` -- not field paths or topics; a
+    matched field is dropped from its rule, a rule left with no fields (or a
+    matched geo rule) is dropped entirely. `events` names event rule
+    `name`s. Unknown names are no-ops (idempotency ruling).
+
+    When nothing actually changed, a running service is left completely
+    alone (no restart -- the SAME service object stays in the holder); when
+    something did change, `_restart_service` rebuilds it -- even down to an
+    empty config (heartbeat = liveness; full offline is `pause_streaming`/
+    `unenroll_identity`). When no service is running at all, this never
+    starts one (that is `stream_topics`'s job) -- it only updates the
+    persisted manifest.
+
+    Returns:
+        `{"service": "running" | "stopped", "channels": list[dict],
+        "events": list[str], "changed": bool, "persisted": bool}`.
+
+    Raises:
+        FleetDisabledError | FleetNotInstalledError: via `require_fleet()`.
+        StreamConfigError: via `_restart_service` (no covering sink, etc) --
+            only reachable when something changed and a service is running.
+
+    """
+    require_fleet()
+    channel_names = set(channels or [])
+    event_names = set(events or [])
+    current = _current_streams()
+
+    remaining_channels, channels_changed = _drop_channel_names(current.channels, channel_names)
+    remaining_events = [rule for rule in current.events if rule.name not in event_names]
+    events_changed = len(remaining_events) != len(current.events)
+    changed = channels_changed or events_changed
+
+    remaining = config.StreamsConfig(
+        broker=current.broker,
+        flush_interval_s=current.flush_interval_s,
+        channels=remaining_channels,
+        events=remaining_events,
+    )
+
+    service = startup.fleet_service()
+    if changed and service is not None:
+        _restart_service(remaining)
+        service = startup.fleet_service()
+
+    persisted = _persist_streams(remaining.to_manifest())
+    return {
+        "service": "running" if service is not None else "stopped",
+        "channels": service.channels if service is not None else [],
+        "events": [rule.name for rule in remaining.events],
+        "changed": changed,
+        "persisted": persisted,
+    }
+
+
+def _merge_by_key(current: list, new: list, *, key: Callable[[object], object]) -> list:
+    """Merge `new` rules onto `current` by `key`: a matching key REPLACES, else appends."""
+    merged: dict = {key(rule): rule for rule in current}
+    for rule in new:
+        merged[key(rule)] = rule
+    return list(merged.values())
+
+
+def _drop_channel_names(
+    current: list[config.ChannelRule], names: set[str]
+) -> tuple[list[config.ChannelRule], bool]:
+    """Drop every field (or whole geo rule) whose resolved `config.channel_name` is in `names`.
+
+    A `fields:` rule loses just the matched fields (and their now-orphaned
+    `renames` entries -- an unpruned rename key would fail `_check_renames`
+    on the next `resolve()`); it is dropped entirely once no fields remain.
+    A `geo:` rule is all-or-nothing: matched -> dropped, else untouched.
+
+    Returns:
+        (remaining rules, whether anything actually changed).
+
+    """
+    remaining: list[config.ChannelRule] = []
+    changed = False
+    for rule in current:
+        if rule.fields is not None:
+            kept = [f for f in rule.fields if config.channel_name(rule, f) not in names]
+            if not kept:
+                changed = True
+                continue
+            if kept == rule.fields:
+                remaining.append(rule)
+            else:
+                changed = True
+                remaining.append(
+                    rule.model_copy(
+                        update={
+                            "fields": kept,
+                            "renames": {k: v for k, v in rule.renames.items() if k in kept},
+                        }
+                    )
+                )
+        else:
+            if config.channel_name(rule, "geo") in names:
+                changed = True
+                continue
+            remaining.append(rule)
+    return remaining, changed
+
+
+def _current_streams() -> config.StreamsConfig:
+    """Return the config to merge/drop rules against: running service, else manifest, else empty."""
+    service = startup.fleet_service()
+    if service is not None:
+        return service.streams
+    loaded = config.load_streams(_read_manifest_doc())
+    return loaded if loaded is not None else config.StreamsConfig()
+
+
+def _restart_service(streams: config.StreamsConfig) -> None:
+    """Rebuild path for `stream_topics`/`stop_streams` (mirrors `startup._start_fleet`).
+
+    1. Pick the sink: the CURRENT service's, if one is running (its
+       `FleetService.start()`/`StreamsConfig.resolve()` will itself raise a
+       typed `StreamConfigError` if `streams` now references a topic that
+       sink never subscribed); otherwise the first of `base.live_sinks()`
+       whose `subscribed_topics` cover every source topic (reusing
+       `startup._fleet_source_topics`/`_find_covering_sink`) -- none found
+       raises `StreamConfigError` BEFORE anything else is touched.
+    2. Best-effort stop the old service (if any) and clear the holder.
+    3. Build a fresh publisher/spool/`FleetService` from `streams` and the
+       current enrollment state, start it, and install it as the holder.
+
+    Any failure here propagates typed -- unlike `startup._start_fleet`
+    (a boot-time path that swallows everything into a report), these are
+    interactive tools: a caller needs to see exactly why a restart failed.
+    """
+    old = startup.fleet_service()
+    if old is not None:
+        sink = old.sink
+    else:
+        source_topics = startup._fleet_source_topics(streams)
+        candidates = [(s, s.subscribed_topics) for s in base.live_sinks()]
+        sink = startup._find_covering_sink(source_topics, candidates)
+        if sink is None:
+            raise StreamConfigError(
+                "streams",
+                "all streams: source topics "
+                f"{sorted(source_topics)} must be subscribed within a SINGLE "
+                "startup manifest 'subscriptions:' entry -- fleet streaming "
+                "(v1) cannot span multiple subscription entries' sinks; list "
+                "every one of these topics under one entry's 'topics:'",
+            )
+
+    if old is not None:
+        try:
+            old.stop()
+        except Exception:
+            logging.warning("Failed to stop the previous FleetService before replacing it")
+        finally:
+            startup.set_fleet_service(None)
+
+    directory = settings.FLEET_IDENTITY_DIRECTORY
+    identity_obj = identity.load_identity(directory) if identity.is_enrolled(directory) else None
+    publisher_kwargs = resolve_publisher_kwargs(streams, identity_obj)
+    publisher = MqttPublisher(**publisher_kwargs)
+    spool = Spool.for_robot(identity_obj.robot if identity_obj is not None else "dev/robot")
+    service = FleetService(
+        sink=sink, streams=streams, publisher=publisher, spool=spool, identity=identity_obj
+    )
+    service.start()
+    startup.set_fleet_service(service)
+
+
+def _manifest_path() -> pathlib.Path | None:
+    raw = settings.STARTUP_PIPELINES_FILE
+    return pathlib.Path(raw) if raw else None
+
+
+def _read_manifest_doc() -> dict:
+    """Read the startup manifest into a dict; `{}` when unset, unwritten, or empty.
+
+    Raises:
+        StreamConfigError: the file exists but fails to parse as YAML, or
+            parses to something other than a mapping -- so a corrupt
+            manifest is never silently treated as empty and then clobbered
+            by a subsequent `_persist_streams` write.
+
+    """
+    path = _manifest_path()
+    if path is None or not path.is_file():
+        return {}
+    try:
+        doc = yaml.safe_load(path.read_text())
+    except yaml.YAMLError as exc:
+        raise StreamConfigError("manifest", f"unparsable manifest at {path}: {exc}") from exc
+    if doc is None:
+        return {}
+    if not isinstance(doc, dict):
+        raise StreamConfigError("manifest", f"manifest at {path} must be a mapping, got {doc!r}")
+    return doc
+
+
+def _persist_streams(streams_manifest: dict | None) -> bool:
+    """Set (or, when `None`, remove) the manifest's `streams:` section; return whether written.
+
+    `settings.STARTUP_PIPELINES_FILE` unset -> `False`, no error: the
+    in-memory control-plane change is still fully in effect, there's just
+    no manifest file to persist it to. Otherwise reads the current manifest
+    (`_read_manifest_doc` -- missing -> `{}`, unparsable -> raises rather
+    than clobbering a human-maintained file), updates just the `"streams"`
+    key, and writes the whole document back atomically (sibling tempfile +
+    `os.replace`) so a crash mid-write never corrupts it.
+    """
+    path = _manifest_path()
+    if path is None:
+        return False
+    doc = _read_manifest_doc()
+    if streams_manifest is None:
+        doc.pop("streams", None)
+    else:
+        doc["streams"] = streams_manifest
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    tmp = pathlib.Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w") as handle:
+            yaml.safe_dump(doc, handle, sort_keys=False)
+        os.replace(tmp, path)
+    finally:
+        tmp.unlink(missing_ok=True)
+    return True

--- a/src/sink/publish/heartbeat.py
+++ b/src/sink/publish/heartbeat.py
@@ -44,7 +44,7 @@ def _pyproject_version(root: pathlib.Path | None = None) -> str:
     text = (root / "pyproject.toml").read_text(encoding="utf-8")
     match = _VERSION_LINE_RE.search(text)
     if match is None:
-        raise ValueError(f"no version = \"...\" line found in {root / 'pyproject.toml'}")
+        raise ValueError(f'no version = "..." line found in {root / "pyproject.toml"}')
     return match.group(1)
 
 

--- a/src/sink/publish/identity.py
+++ b/src/sink/publish/identity.py
@@ -40,7 +40,14 @@ never stored, and never embedded in an ``EnrollmentError`` reason.
 of expiry: ``should_attempt_renewal`` decides when it is due, and ``renew``
 does the mTLS POST + atomic pointer swap. See ``renew()``'s docstring for
 the ordering guarantees and what it does NOT do (force a live publisher
-reconnect).
+reconnect). The renew response may itself carry a (new) ``renew_url``,
+rotating the base a future renewal targets -- e.g. a staging->prod cutover --
+without requiring a fresh enrollment.
+
+``delete_identity()`` is the ONLY deletion path ``unenroll`` uses: it removes
+the pointer set from a parsable identity.yaml plus anything on disk matching
+this module's own renewal-orphan naming patterns, all resolved-containment
+checked against the target directory first -- see its own docstring.
 """
 
 import dataclasses
@@ -76,6 +83,23 @@ _RENEWAL_MIN_INTERVAL_S = 86400
 # Statuses the cloud uses to mean "renewal isn't offered on this deployment
 # yet" (the flag is off) rather than "the request failed" -- expected, quiet.
 _RENEWAL_NOT_OFFERED_STATUSES = (404, 501)
+
+# delete_identity()'s pattern-glob sweep: the historical fixed names plus
+# every versioned basename _commit_renewed_files can ever produce
+# (``robot-<version>.key``/``.crt``, ``ca-<version>.crt``) -- this is how a
+# renewal orphan (a superseded pair identity.yaml no longer points at, left
+# behind by e.g. a crash during best-effort cleanup) still gets swept even
+# though identity.yaml's pointer set no longer names it. Non-recursive
+# (``Path.glob``, not ``rglob``) -- this module never nests files under
+# subdirectories of the identity directory.
+_DELETE_GLOB_PATTERNS = (
+    "robot.key",
+    "robot.crt",
+    "ca.crt",
+    "robot-*.key",
+    "robot-*.crt",
+    "ca-*.crt",
+)
 
 
 def _url_passes_scheme_gate(url: str) -> bool:
@@ -476,6 +500,116 @@ def is_enrolled(directory: pathlib.Path) -> bool:
     return True
 
 
+def delete_identity(directory: pathlib.Path) -> list[str]:
+    """Delete a stored identity under ``directory`` -- the ONLY deletion path ``unenroll`` uses.
+
+    ``directory`` is resolved first, and every path this function is about
+    to remove is resolved-containment checked against it (``Spool.for_robot``'s
+    belt-and-braces, applied here to reads-become-deletes) before anything is
+    unlinked:
+
+    1. If ``directory / "identity.yaml"`` doesn't exist, this is a no-op
+       returning ``[]`` -- nothing enrolled, nothing to do, so a repeat
+       ``unenroll`` call never raises.
+    2. ``load_identity(directory)`` is tried. If it parses, the deletion set
+       starts as ``{key_path, cert_path, ca_path}``: each must resolve
+       INSIDE ``directory`` or this raises ``ValueError`` immediately --
+       BEFORE any unlink -- so a hand-edited ``key_file: ../../victim``
+       pointer can never delete outside the directory. If it doesn't parse
+       (``FleetNotEnrolledError`` -- a corrupt identity.yaml), this step is
+       skipped entirely: a corrupt identity must still be removable via the
+       pattern sweep below, not permanently stuck.
+    3. This module's own naming patterns (see ``_DELETE_GLOB_PATTERNS``) are
+       globbed inside ``directory`` (non-recursive) to additionally sweep up
+       renewal orphans identity.yaml no longer points at. The same
+       containment check applies per-entry here too, but a failure here
+       SKIPS just that one entry rather than raising -- a symlink planted at
+       one of these names that resolves outside ``directory`` is left
+       completely alone (neither the link nor its target is touched); it
+       simply isn't included in what gets deleted. Unlike step 2's pointer
+       fields (which come from a trusted, single load), this is an
+       opportunistic best-effort sweep over whatever happens to match a
+       filename pattern, so one bad entry must not block cleanup of
+       everything else.
+    4. The union of steps 2+3, plus ``identity.yaml`` itself, is unlinked
+       (``missing_ok=True``); then ``directory.rmdir()`` is attempted,
+       best-effort (``OSError`` -- e.g. "not empty", because a skipped
+       symlink or an unrelated file is still in there -- is swallowed).
+
+    Never uses ``shutil.rmtree``: only paths derived from steps 2 and 3
+    above are ever touched.
+
+    Returns:
+        Sorted basenames of every file actually targeted for deletion (the
+        pointer set that passed containment, the pattern-set matches that
+        passed containment, and ``identity.yaml``) -- not necessarily the
+        basenames actually removed, since ``missing_ok=True`` tolerates a
+        concurrent removal, but in the ordinary case these coincide.
+
+    Raises:
+        ValueError: a pointer field in a parsable identity.yaml resolves
+            outside ``directory``. Nothing is deleted when this is raised.
+
+    """
+    directory = pathlib.Path(directory).resolve()
+    identity_path = directory / "identity.yaml"
+    if not identity_path.is_file():
+        return []
+
+    to_delete: dict[str, pathlib.Path] = {}
+    to_delete.update(_delete_identity_pointer_set(directory))
+    to_delete.update(_delete_identity_pattern_set(directory))
+    to_delete["identity.yaml"] = identity_path
+
+    for path in to_delete.values():
+        path.unlink(missing_ok=True)
+    try:
+        directory.rmdir()
+    except OSError:
+        pass  # not empty (a skipped entry or unrelated file remains) -- fine, best-effort
+
+    return sorted(to_delete)
+
+
+def _delete_identity_pointer_set(directory: pathlib.Path) -> dict[str, pathlib.Path]:
+    """``delete_identity`` step 2: the parsable identity.yaml's key/cert/ca pointers.
+
+    ``directory`` is already resolved by the caller. Raises ``ValueError``
+    (deleting nothing -- this is called before any unlink) if a pointer
+    resolves outside ``directory``; returns ``{}`` if identity.yaml doesn't
+    parse (``FleetNotEnrolledError``) -- a corrupt identity still falls
+    through to the pattern-set sweep.
+    """
+    try:
+        identity = load_identity(directory)
+    except FleetNotEnrolledError:
+        return {}
+    found: dict[str, pathlib.Path] = {}
+    for path in (identity.key_path, identity.cert_path, identity.ca_path):
+        if not path.resolve().is_relative_to(directory):
+            raise ValueError(f"identity file escapes {directory}: {path}")
+        found[path.name] = path
+    return found
+
+
+def _delete_identity_pattern_set(directory: pathlib.Path) -> dict[str, pathlib.Path]:
+    """``delete_identity`` step 3: sweep this module's own naming patterns.
+
+    ``directory`` is already resolved by the caller. Unlike the pointer set,
+    an entry that fails the containment check (e.g. a symlink resolving
+    outside ``directory``) is simply SKIPPED, not raised -- this is an
+    opportunistic best-effort sweep over whatever matches a filename
+    pattern, so one bad entry must not block cleanup of everything else.
+    """
+    found: dict[str, pathlib.Path] = {}
+    for pattern in _DELETE_GLOB_PATTERNS:
+        for candidate in directory.glob(pattern):
+            if not candidate.resolve().is_relative_to(directory):
+                continue  # e.g. a symlink pointing outside -- skip, don't follow it
+            found[candidate.name] = candidate
+    return found
+
+
 def should_attempt_renewal(now: float, expires_at: str, last_attempt_at: float | None) -> bool:
     """Whether a renewal attempt is due: within 30 days of expiry, rate-limited to once/day.
 
@@ -535,6 +669,7 @@ def _write_identity_yaml(  # noqa: PLR0913 -- one field per identity.yaml key; s
     key_file: str,
     cert_file: str,
     ca_file: str,
+    renew_url: str | None,
 ) -> None:
     """Atomically (re)write ``identity.yaml`` -- THE commit point for a renewal.
 
@@ -547,13 +682,17 @@ def _write_identity_yaml(  # noqa: PLR0913 -- one field per identity.yaml key; s
     ``renew()``'s docstring for the full crash-safety argument.
 
     Used by both the success and failure paths of ``renew()``: on failure,
-    ``key_file``/``cert_file``/``ca_file``/``expires_at`` are ``identity``'s
-    CURRENT (unchanged) pointer/expiry -- only ``last_renewal_attempt_at``
-    moves; on success they are the new pointer and the new expiry. Like
-    ``enroll()``, this rewrites the whole document from known fields rather
-    than reading-modifying-writing the file on disk, so any unknown key a
-    future version added to it is not preserved across a renewal -- same
-    tradeoff ``enroll()`` already makes.
+    ``key_file``/``cert_file``/``ca_file``/``expires_at``/``renew_url`` are
+    ``identity``'s CURRENT (unchanged) pointer/expiry/renew base -- only
+    ``last_renewal_attempt_at`` moves; on success ``key_file``/``cert_file``/
+    ``ca_file``/``expires_at`` are the new pointer and expiry, and
+    ``renew_url`` is the caller-computed value (see ``_commit_renewed_files``:
+    the renew response may itself rotate ``renew_url`` -- absent means no
+    change, present means the new base). Like ``enroll()``, this rewrites
+    the whole document from known fields rather than reading-modifying-
+    writing the file on disk, so any unknown key a future version added to
+    it is not preserved across a renewal -- same tradeoff ``enroll()``
+    already makes.
     """
     directory = identity.key_path.parent
     doc = {
@@ -567,8 +706,8 @@ def _write_identity_yaml(  # noqa: PLR0913 -- one field per identity.yaml key; s
         "cert_file": cert_file,
         "ca_file": ca_file,
     }
-    if identity.renew_url is not None:
-        doc["renew_url"] = identity.renew_url
+    if renew_url is not None:
+        doc["renew_url"] = renew_url
     _atomic_write(directory / "identity.yaml", yaml.safe_dump(doc).encode())
 
 
@@ -587,6 +726,7 @@ def _record_renewal_attempt(identity: Identity, attempt_at: float) -> None:
         key_file=identity.key_path.name,
         cert_file=identity.cert_path.name,
         ca_file=identity.ca_path.name,
+        renew_url=identity.renew_url,
     )
 
 
@@ -645,6 +785,12 @@ def _commit_renewed_files(
     if write_new_ca:
         _atomic_write(directory / new_ca_file, payload["ca_pem"].encode())
 
+    # renew_url is OPTIONAL in the renew response too, same as enroll's (see
+    # the module docstring): absent means "no change" (`.get`'s default
+    # keeps identity's current value, whatever that already was), present
+    # means the server is rotating the renew base -- e.g. a staging->prod
+    # cutover -- without requiring a fresh enrollment.
+    new_renew_url = payload.get("renew_url", identity.renew_url)
     _write_identity_yaml(
         identity,
         expires_at=payload["expires_at"],
@@ -652,6 +798,7 @@ def _commit_renewed_files(
         key_file=new_key_file,
         cert_file=new_cert_file,
         ca_file=new_ca_file,
+        renew_url=new_renew_url,
     )
 
     for old_path in (identity.key_path, identity.cert_path):
@@ -671,6 +818,7 @@ def _commit_renewed_files(
         key_path=directory / new_key_file,
         cert_path=directory / new_cert_file,
         ca_path=directory / new_ca_file,
+        renew_url=new_renew_url,
         last_renewal_attempt_at=now,
     )
 

--- a/src/sink/publish/mqtt.py
+++ b/src/sink/publish/mqtt.py
@@ -232,10 +232,18 @@ class MqttPublisher(Publisher):
         if info.rc != 0 or not info.is_published():
             raise PublishError(f"{topic}: publish failed (rc={info.rc})")
 
-    def close(self) -> None:
+    def close(self, reason: str = "stopped") -> None:
         """Publish a clean-stop heartbeat (best-effort) then stop and disconnect.
 
         Idempotent: safe to call more than once, and safe when never connected.
+
+        Args:
+            reason: Carried verbatim in the clean-stop heartbeat's `reason`
+                field (spec §3). `FleetService.stop()` uses the default
+                `"stopped"`; `FleetService.pause()` passes `"paused"` so a
+                paused robot's last retained heartbeat reads distinctly from
+                a genuinely stopped one.
+
         """
         client, self._client = self._client, None
         if client is None:
@@ -243,7 +251,7 @@ class MqttPublisher(Publisher):
         self._closing = True
         try:
             if client.is_connected():
-                stopped = {"v": 1, "t": time.time(), "online": False, "reason": "stopped"}
+                stopped = {"v": 1, "t": time.time(), "online": False, "reason": reason}
                 try:
                     info = client.publish(
                         wire_topic(self._tenant, self._robot, "heartbeat"),

--- a/src/sink/publish/publisher.py
+++ b/src/sink/publish/publisher.py
@@ -41,8 +41,19 @@ class Publisher(abc.ABC):
         """Publish a message to the broker."""
 
     @abc.abstractmethod
-    def close(self) -> None:
-        """Close the broker connection."""
+    def close(self, reason: str = "stopped") -> None:
+        """Close the broker connection.
+
+        Args:
+            reason: Carried in the clean-stop heartbeat payload by
+                implementations that publish one before disconnecting (see
+                `MqttPublisher.close`) -- spec §3's `{"online": false,
+                "reason": ...}` shape. Defaults to `"stopped"`;
+                `FleetService.pause()` passes `"paused"` so a paused robot's
+                last-known-state is distinguishable from a genuinely stopped
+                one.
+
+        """
 
     @property
     @abc.abstractmethod

--- a/src/sink/publish/selftest.py
+++ b/src/sink/publish/selftest.py
@@ -1,0 +1,280 @@
+"""Fleet conformance selftest: publish a known sequence with no robot (spec §8).
+
+This is the "fleet selftest" helper spec §8 asks for: a fixed, deterministic
+channel/heartbeat/event sequence that a fleet service can subscribe to and
+validate against `doc/fleet_protocol_v1.md` without a real robot in the loop.
+`run_selftest` is the testable core (no CLI, no gate) -- `main` wires it to
+the same production connection policy (`connect.resolve_publisher_kwargs`)
+every other fleet entry point uses, so a selftest run proves the SAME
+dev-insecure/mTLS rules a real robot would hit, not a shortcut around them.
+
+Run this with fleet streaming paused or stopped on the target robot/dev rig:
+a concurrently running `FleetService`/`StreamRouter` writes to the same real
+spool lanes this selftest uses (`Spool.for_robot`), and the spool's
+single-writer invariant means a concurrent writer fails the seq monotonicity
+check (`Spool.append`'s `ValueError`) cleanly rather than corrupting
+anything.
+
+Invocation is `uv run python -m src.sink.publish.selftest` -- there is no
+console-script entry point. This repo ships as a Docker image, not a PyPI
+package (see AGENTS.md), so a `pyproject.toml` `[project.scripts]` entry
+would be dead weight nothing installs.
+"""
+
+import argparse
+import json
+import pathlib
+import sys
+import time
+import uuid
+from collections.abc import Callable
+
+from settings import settings
+from src.sink.publish import (
+    FleetDisabledError,
+    FleetNotEnrolledError,
+    FleetNotInstalledError,
+    StreamConfigError,
+    require_fleet,
+)
+from src.sink.publish.config import StreamsConfig
+from src.sink.publish.connect import resolve_publisher_kwargs
+from src.sink.publish.heartbeat import build_heartbeat, disk_free
+from src.sink.publish.identity import is_enrolled as _is_enrolled
+from src.sink.publish.identity import load_identity
+from src.sink.publish.mqtt import MqttPublisher
+from src.sink.publish.publisher import Publisher, PublishError
+from src.sink.publish.spool import Spool
+
+DEFAULT_BATCHES = 10
+DEFAULT_INTERVAL_S = 0.5
+
+# A fixed, documented four-channel schema covering every §3 wire type
+# (number, bool, string, geo). Never resolved from a real topic/manifest --
+# this IS the conformance fixture, so it must never drift with a real robot's
+# schema.
+SELFTEST_CHANNELS = [
+    {
+        "c": "selftest.number",
+        "type": "number",
+        "unit": "1",
+        "source_topic": "selftest",
+        "source_field": "number",
+    },
+    {
+        "c": "selftest.bool",
+        "type": "bool",
+        "unit": None,
+        "source_topic": "selftest",
+        "source_field": "bool",
+    },
+    {
+        "c": "selftest.string",
+        "type": "string",
+        "unit": None,
+        "source_topic": "selftest",
+        "source_field": "string",
+    },
+    {
+        "c": "selftest.geo",
+        "type": "geo",
+        "unit": None,
+        "source_topic": "selftest",
+        "source_field": "lat=lat,lon=lon",
+    },
+]
+
+
+def _build_batch(i: int, t: float) -> dict:
+    """One deterministic batch's samples for iteration `i` at wall-clock `t`."""
+    return {
+        "v": 1,
+        "t_batch": t,
+        "samples": [
+            {"c": "selftest.number", "t": t, "v": float(i)},
+            {"c": "selftest.bool", "t": t, "v": i % 2 == 0},
+            {"c": "selftest.string", "t": t, "v": f"selftest-{i}"},
+            {
+                "c": "selftest.geo",
+                "t": t,
+                "v": {"lat": 52.0 + i * 0.001, "lon": 13.0 + i * 0.001},
+            },
+        ],
+    }
+
+
+def run_selftest(  # noqa: PLR0913
+    publisher: Publisher,
+    spool: Spool,
+    *,
+    batches: int = DEFAULT_BATCHES,
+    samples_per_batch: int = 4,
+    interval_s: float = 0.0,
+    now: Callable[[], float] = time.time,
+) -> dict:
+    """Publish the conformance fixture end to end: schema, batches, heartbeat, event.
+
+    Uses the robot's REAL spool lanes (`spool.next_seq`/`append`/`ack`), in
+    the exact append -> publish -> ack order `StreamRouter._pump` uses --
+    durable before sent, acked only after the broker has QoS-1 acknowledged
+    it. On any exception once appending has begun, every lane this run wrote
+    to is acked past the last seq it appended (advance-to semantics, per
+    `Spool.ack`) before the exception is re-raised, so nothing this run
+    spooled lingers for the real fleet service to replay later.
+
+    Args:
+        publisher: A connected-or-connectable `Publisher` (typically
+            `MqttPublisher`).
+        spool: The target robot's real `Spool` (see `Spool.for_robot`).
+        batches: Number of channel batches to publish.
+        samples_per_batch: Samples per batch, for the returned summary's
+            `"samples"` count -- the batch content itself is the fixed
+            4-sample fixture regardless of this value.
+        interval_s: Delay between batches (0 in tests; the CLI defaults this
+            to 0.5s so a subscriber can observe batches arriving over time).
+        now: Clock, injectable for deterministic tests.
+
+    Returns:
+        `{"channels": 4, "batches", "samples", "heartbeat": 1, "events": 1,
+        "channels_seq": [first, last], "events_seq": <seq>}`.
+
+    Raises:
+        Whatever `publisher`/`spool` raise (typically `PublishError` or a
+        spool `ValueError`/`SpoolError`) -- always re-raised after the
+        cleanup above.
+
+    """
+    last_channels_seq: int | None = None
+    last_events_seq: int | None = None
+    channels_seqs: list[int] = []
+    t0 = now()
+
+    try:
+        publisher.connect()
+        publisher.publish_schema({"v": 1, "channels": SELFTEST_CHANNELS})
+
+        for i in range(batches):
+            t = now()
+            batch = _build_batch(i, t)
+            seq = spool.next_seq("channels")
+            batch["seq"] = seq
+            spool.append("channels", seq, batch)
+            last_channels_seq = seq
+            publisher.publish_channels(batch)
+            spool.ack("channels", seq)
+            channels_seqs.append(seq)
+            if interval_s:
+                time.sleep(interval_s)
+
+        heartbeat_payload = build_heartbeat(
+            started_at=t0,
+            subscriptions=["selftest"],
+            channels_active=len(SELFTEST_CHANNELS),
+            queue_depth=0,
+            queue_dropped=0,
+            spool_stats=spool.stats(),
+            disk_free_bytes=disk_free(settings.CACHE_DIRECTORY),
+            reconnects=0,
+            now=now(),
+        )
+        publisher.publish_heartbeat(heartbeat_payload)
+
+        events_seq = spool.next_seq("events")
+        event_payload = {
+            "v": 1,
+            "seq": events_seq,
+            "event_id": f"selftest-{uuid.uuid4()}",
+            "name": "selftest",
+            "t_start": t0,
+            "t_end": now(),
+            "source_topic": "selftest",
+            "summary": {"kind": "selftest", "batches": batches},
+        }
+        spool.append("events", events_seq, event_payload)
+        last_events_seq = events_seq
+        publisher.publish_event(event_payload)
+        spool.ack("events", events_seq)
+
+        publisher.close()
+    except Exception:
+        if last_channels_seq is not None:
+            spool.ack("channels", last_channels_seq)
+        if last_events_seq is not None:
+            spool.ack("events", last_events_seq)
+        raise
+
+    return {
+        "channels": len(SELFTEST_CHANNELS),
+        "batches": batches,
+        "samples": batches * samples_per_batch,
+        "heartbeat": 1,
+        "events": 1,
+        "channels_seq": [channels_seqs[0], channels_seqs[-1]] if channels_seqs else [],
+        "events_seq": events_seq,
+    }
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m src.sink.publish.selftest",
+        description=(
+            "Fleet conformance selftest (spec §8): publish a known "
+            "channel/heartbeat/event sequence to prove wire-protocol "
+            "ingestion end to end, with no robot required."
+        ),
+    )
+    parser.add_argument(
+        "--broker",
+        default=None,
+        help="mqtt(s):// broker override, for dev rigs (defaults to the manifest/identity broker)",
+    )
+    parser.add_argument(
+        "--batches", type=int, default=DEFAULT_BATCHES, help="channel batches to publish"
+    )
+    parser.add_argument(
+        "--interval-s",
+        type=float,
+        default=DEFAULT_INTERVAL_S,
+        help="delay between batches, seconds",
+    )
+    return parser
+
+
+_EXPECTED_ERRORS = (
+    FleetDisabledError,
+    FleetNotInstalledError,
+    FleetNotEnrolledError,
+    StreamConfigError,
+    PublishError,
+    ValueError,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point: run the selftest against a resolved fleet publisher.
+
+    Returns 0 and prints the `run_selftest` summary as one line of JSON on
+    success. On any expected failure state (fleet disabled/not installed,
+    unenrolled with no `--broker` override, bad broker config, a publish
+    failure, or a concurrently running service's spool `ValueError`), prints
+    the typed error's message to stderr (no traceback) and returns 1.
+    """
+    args = _build_arg_parser().parse_args(argv)
+    try:
+        require_fleet()
+        directory = pathlib.Path(settings.FLEET_IDENTITY_DIRECTORY)
+        identity = load_identity(directory) if _is_enrolled(directory) else None
+        kwargs = resolve_publisher_kwargs(StreamsConfig(broker=args.broker), identity)
+        publisher = MqttPublisher(**kwargs)
+        spool = Spool.for_robot(identity.robot if identity is not None else "dev/robot")
+        result = run_selftest(publisher, spool, batches=args.batches, interval_s=args.interval_s)
+    except _EXPECTED_ERRORS as exc:
+        print(str(exc), file=sys.stderr)  # noqa: T201 -- the CLI's stderr contract
+        return 1
+
+    print(json.dumps(result))  # noqa: T201 -- the CLI's stdout contract (spec §8)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sink/publish/selftest.py
+++ b/src/sink/publish/selftest.py
@@ -103,12 +103,11 @@ def _build_batch(i: int, t: float) -> dict:
     }
 
 
-def run_selftest(  # noqa: PLR0913
+def run_selftest(
     publisher: Publisher,
     spool: Spool,
     *,
     batches: int = DEFAULT_BATCHES,
-    samples_per_batch: int = 4,
     interval_s: float = 0.0,
     now: Callable[[], float] = time.time,
 ) -> dict:
@@ -127,9 +126,6 @@ def run_selftest(  # noqa: PLR0913
             `MqttPublisher`).
         spool: The target robot's real `Spool` (see `Spool.for_robot`).
         batches: Number of channel batches to publish.
-        samples_per_batch: Samples per batch, for the returned summary's
-            `"samples"` count -- the batch content itself is the fixed
-            4-sample fixture regardless of this value.
         interval_s: Delay between batches (0 in tests; the CLI defaults this
             to 0.5s so a subscriber can observe batches arriving over time).
         now: Clock, injectable for deterministic tests.
@@ -147,6 +143,7 @@ def run_selftest(  # noqa: PLR0913
     last_channels_seq: int | None = None
     last_events_seq: int | None = None
     channels_seqs: list[int] = []
+    total_samples = 0
     t0 = now()
 
     try:
@@ -163,6 +160,7 @@ def run_selftest(  # noqa: PLR0913
             publisher.publish_channels(batch)
             spool.ack("channels", seq)
             channels_seqs.append(seq)
+            total_samples += len(batch["samples"])
             if interval_s:
                 time.sleep(interval_s)
 
@@ -206,7 +204,7 @@ def run_selftest(  # noqa: PLR0913
     return {
         "channels": len(SELFTEST_CHANNELS),
         "batches": batches,
-        "samples": batches * samples_per_batch,
+        "samples": total_samples,
         "heartbeat": 1,
         "events": 1,
         "channels_seq": [channels_seqs[0], channels_seqs[-1]] if channels_seqs else [],

--- a/src/sink/publish/selftest.py
+++ b/src/sink/publish/selftest.py
@@ -40,14 +40,24 @@ from src.sink.publish import (
 from src.sink.publish.config import StreamsConfig
 from src.sink.publish.connect import resolve_publisher_kwargs
 from src.sink.publish.heartbeat import build_heartbeat, disk_free
-from src.sink.publish.identity import is_enrolled as _is_enrolled
-from src.sink.publish.identity import load_identity
+from src.sink.publish.identity import Identity, load_identity
 from src.sink.publish.mqtt import MqttPublisher
 from src.sink.publish.publisher import Publisher, PublishError
 from src.sink.publish.spool import Spool
 
 DEFAULT_BATCHES = 10
 DEFAULT_INTERVAL_S = 0.5
+
+
+class SelftestPreconditionError(ValueError):
+    """Raised when `run_selftest` refuses to start (spec §8 conformance ruling).
+
+    A `ValueError` subclass so it's caught by every existing spool-`ValueError`
+    handler (including this module's own `main()`) without needing a special
+    case. Currently the only precondition: a spool lane with pending unacked
+    backlog (see `_check_no_pending_backlog`).
+    """
+
 
 # A fixed, documented four-channel schema covering every §3 wire type
 # (number, bool, string, geo). Never resolved from a real topic/manifest --
@@ -103,6 +113,28 @@ def _build_batch(i: int, t: float) -> dict:
     }
 
 
+def _check_no_pending_backlog(spool: Spool) -> None:
+    """Refuse to run against a spool lane with pending unacked entries (C1 ruling).
+
+    `run_selftest` allocates real-lane seqs and acks them as it goes
+    (advance-to semantics -- see `Spool.ack`). If either lane already has
+    pending backlog -- e.g. a paused service's queued-but-unsent data --
+    the FIRST ack this run issues would advance that lane's watermark past
+    the pending backlog, silently dropping it, even though this run never
+    touched those specific records. Checked before any connect/append side
+    effect (see `run_selftest`'s call site), so a refusal here leaves the
+    spool completely untouched.
+    """
+    for lane in ("channels", "events"):
+        if next(spool.pending(lane), None) is not None:
+            raise SelftestPreconditionError(
+                f"selftest refused: spool lane '{lane}' has pending unacked entries. "
+                "Running the selftest now would advance this lane's watermark past "
+                "that backlog and silently drop it. Let the service drain it, or "
+                "discard it first via pause_fleet_streaming(discard=True)."
+            )
+
+
 def run_selftest(
     publisher: Publisher,
     spool: Spool,
@@ -121,6 +153,11 @@ def run_selftest(
     `Spool.ack`) before the exception is re-raised, so nothing this run
     spooled lingers for the real fleet service to replay later.
 
+    Before any of that: refuses to start at all if either lane already has
+    pending unacked backlog (`_check_no_pending_backlog`, C1 ruling) --
+    otherwise this run's own first ack would advance the watermark past
+    that pre-existing backlog and silently drop it.
+
     Args:
         publisher: A connected-or-connectable `Publisher` (typically
             `MqttPublisher`).
@@ -135,11 +172,15 @@ def run_selftest(
         "channels_seq": [first, last], "events_seq": <seq>}`.
 
     Raises:
-        Whatever `publisher`/`spool` raise (typically `PublishError` or a
-        spool `ValueError`/`SpoolError`) -- always re-raised after the
-        cleanup above.
+        SelftestPreconditionError: a spool lane has pending unacked backlog
+            -- checked first, before any connect/append side effect.
+        Whatever `publisher`/`spool` raise thereafter (typically
+        `PublishError` or a spool `ValueError`/`SpoolError`) -- always
+        re-raised after the cleanup above.
 
     """
+    _check_no_pending_backlog(spool)
+
     last_channels_seq: int | None = None
     last_events_seq: int | None = None
     channels_seqs: list[int] = []
@@ -248,20 +289,36 @@ _EXPECTED_ERRORS = (
 )
 
 
+def _load_identity_or_none(directory: pathlib.Path) -> Identity | None:
+    """Single-load `load_identity`, `None` on `FleetNotEnrolledError` (M4).
+
+    Mirrors `control._load_identity_or_none` -- NOT an `is_enrolled()` check
+    followed by a separate `load_identity()` call, which has a TOCTOU window:
+    a corrupt/deleted identity between the two calls would raise
+    `FleetNotEnrolledError` uncaught instead of degrading to "unenrolled".
+    One `load_identity()` call, caught here, closes that window structurally.
+    """
+    try:
+        return load_identity(directory)
+    except FleetNotEnrolledError:
+        return None
+
+
 def main(argv: list[str] | None = None) -> int:
     """CLI entry point: run the selftest against a resolved fleet publisher.
 
     Returns 0 and prints the `run_selftest` summary as one line of JSON on
     success. On any expected failure state (fleet disabled/not installed,
     unenrolled with no `--broker` override, bad broker config, a publish
-    failure, or a concurrently running service's spool `ValueError`), prints
-    the typed error's message to stderr (no traceback) and returns 1.
+    failure, a spool lane with pending backlog, or a concurrently running
+    service's spool `ValueError`), prints the typed error's message to
+    stderr (no traceback) and returns 1.
     """
     args = _build_arg_parser().parse_args(argv)
     try:
         require_fleet()
         directory = pathlib.Path(settings.FLEET_IDENTITY_DIRECTORY)
-        identity = load_identity(directory) if _is_enrolled(directory) else None
+        identity = _load_identity_or_none(directory)
         kwargs = resolve_publisher_kwargs(StreamsConfig(broker=args.broker), identity)
         publisher = MqttPublisher(**kwargs)
         spool = Spool.for_robot(identity.robot if identity is not None else "dev/robot")

--- a/src/sink/publish/service.py
+++ b/src/sink/publish/service.py
@@ -90,6 +90,32 @@ class FleetService:
         self._started = False
         self._paused = False
 
+    # -- accessors ---------------------------------------------------------------
+
+    @property
+    def sink(self) -> object:
+        """The `TopicSink` this service taps.
+
+        Lets a caller (e.g. `startup.py`'s close hook) identity-compare a
+        sink against the one this service is running against, without
+        reaching into the private `_sink` attribute.
+        """
+        return self._sink
+
+    @property
+    def streams(self) -> StreamsConfig:
+        """The `StreamsConfig` this service was constructed with."""
+        return self._streams
+
+    @property
+    def channels(self) -> list[dict]:
+        """A copy of the resolved schema payload's `channels` list.
+
+        A copy, not a live reference: mutating the returned list must never
+        affect this service's own schema payload.
+        """
+        return list(self._schema_payload["channels"])
+
     # -- lifecycle -------------------------------------------------------------
 
     def start(self) -> None:
@@ -111,12 +137,8 @@ class FleetService:
             raise RuntimeError("FleetService already started")
         require_fleet()
         configured_topics = {rule.topic for rule in self._streams.channels}
-        # TopicSink exposes no public per-topic buffer accessor (only the
-        # aggregate `subscribed_topics` list), so this reaches into `_buffers`
-        # directly -- same attribute name a real TopicSink and this module's
-        # FakeSink test doubles both use.
         structs = {
-            topic: self._sink._buffers[topic].struct
+            topic: self._sink.buffer_writer(topic).struct
             for topic in configured_topics
             if topic in self._sink.subscribed_topics
         }
@@ -137,7 +159,7 @@ class FleetService:
             ],
         }
         self._writers = {
-            topic: self._sink._buffers[topic]
+            topic: self._sink.buffer_writer(topic)
             for topic in sorted({channel.source_topic for channel in resolved})
         }
 

--- a/src/sink/publish/service.py
+++ b/src/sink/publish/service.py
@@ -12,11 +12,10 @@ thread-lifecycle precedent: every long-running fleet thread is
 `daemon=True`, stops via a `threading.Event` (so `stop()`/`join()` never
 requires a sleep-based poll and returns as soon as the event is observed),
 and its `stop()` joins with a bounded timeout (5s) so a slow or stuck thread
-can never hang the caller -- mirrored from `TopicSink.close()`
-(`src/sink/base.py:323`)'s try/finally shape: `stop()`/`pause()` do their
-teardown in a `try` and always release the publisher session in a `finally`,
-so a failure partway through still leaves the service in a consistent,
-re-enterable state.
+can never hang the caller -- mirrored from `TopicSink.close()`'s try/finally
+shape: `stop()`/`pause()` do their teardown in a `try` and always release
+the publisher session in a `finally`, so a failure partway through still
+leaves the service in a consistent, re-enterable state.
 
 Startup/manifest wiring (deciding *when* to call `start()`) is explicitly
 out of scope here -- step 6 ruling, since it's conditioned on identity

--- a/src/sink/publish/service.py
+++ b/src/sink/publish/service.py
@@ -116,6 +116,19 @@ class FleetService:
         """
         return list(self._schema_payload["channels"])
 
+    @property
+    def paused(self) -> bool:
+        """Whether this service is started AND currently paused.
+
+        `self._started and self._paused` rather than `self._paused` alone: a
+        fresh, never-started service also has `_paused = False`, so that bit
+        alone can't distinguish "never started" from "resumed" -- both would
+        read `False` either way here, but requiring `_started` too keeps this
+        property's contract explicit for `control.fleet_status()`, which
+        derives its `"running"` vs `"paused"` service state from this.
+        """
+        return self._started and self._paused
+
     # -- lifecycle -------------------------------------------------------------
 
     def start(self) -> None:
@@ -195,7 +208,9 @@ class FleetService:
         Idempotent: a no-op if not started or already paused. `discard=True`
         additionally acks the channels lane up to its last written seq,
         dropping any still-unacked backlog (events/heartbeat are never-drop
-        lanes and are left untouched).
+        lanes and are left untouched). Closes the publisher with
+        `reason="paused"` (spec §3), so the retained clean-stop heartbeat a
+        broker-side subscriber sees reads distinctly from a genuine `stop()`.
         """
         if not self._started or self._paused:
             return
@@ -204,7 +219,7 @@ class FleetService:
             self._heartbeat.stop()
         if self._router is not None:
             self._router.stop()
-        self._publisher.close()
+        self._publisher.close(reason="paused")
         if discard:
             last_seq = self._spool.next_seq("channels") - 1
             self._spool.ack("channels", last_seq)

--- a/src/sink/publish/spool.py
+++ b/src/sink/publish/spool.py
@@ -23,6 +23,7 @@ from collections.abc import Iterator
 import filelock
 
 SEGMENT_MAX_BYTES = 4 * 1024 * 1024
+NEVER_CAPPED_LANES = ("heartbeat",)
 
 
 class SpoolError(Exception):
@@ -131,6 +132,11 @@ class Spool:
         self._root = pathlib.Path(root)
         self._root.mkdir(parents=True, exist_ok=True)
         self._capped = dict(capped_lanes or {})
+        forbidden = set(self._capped) & set(NEVER_CAPPED_LANES)
+        if forbidden:
+            raise ValueError(
+                f"lanes {sorted(forbidden)} are never-drop (spec §4) and cannot be byte-capped"
+            )
         self._lock = filelock.FileLock(str(self._root / ".lock"))
         self._last_seq: dict[str, int] = {}
         self._evicted: dict[str, int] = {}
@@ -244,14 +250,13 @@ class Spool:
             # byte cap. Refuse to write it instead: consume the seq (so the
             # caller's sequencing stays monotonic and no retry re-attempts
             # the same doomed record) and count it as evicted. EXCEPTION:
-            # never drop on the never-drop "heartbeat" lane -- its payloads
-            # are tiny, so this is in practice unreachable, but the
-            # never-drop ruling still applies if it somehow were.
-            if lane != "heartbeat" and len(line.encode("utf-8")) > SEGMENT_MAX_BYTES:
+            # never drop on never-drop lanes (spec §4) -- their payloads are
+            # tiny, so this is in practice unreachable, but the never-drop
+            # ruling still applies if it somehow were.
+            if lane not in NEVER_CAPPED_LANES and len(line.encode("utf-8")) > SEGMENT_MAX_BYTES:
                 self._evicted[lane] = self._evicted.get(lane, 0) + 1
                 logging.getLogger(__name__).warning(
-                    "lane '%s': dropping oversized record seq=%d (%d bytes > "
-                    "SEGMENT_MAX_BYTES=%d)",
+                    "lane '%s': dropping oversized record seq=%d (%d bytes > SEGMENT_MAX_BYTES=%d)",
                     lane,
                     seq,
                     len(line.encode("utf-8")),

--- a/src/sink/startup.py
+++ b/src/sink/startup.py
@@ -53,10 +53,11 @@ taps one sink's topic buffers, and each entry's sink is a fresh instance
 (``module.provide`` never shares one across entries), so a ``streams:``
 block whose topics span two different subscription entries cannot be
 served; it produces a failed fleet report entry naming the limitation
-instead. RULING B (v1, binding): there is no ``TopicSink.close()`` ->
-``FleetService.stop()`` coupling -- the fleet service, once started, runs
-for the process's lifetime (daemon threads, a publisher LWT, and its
-finalizer cover process exit; see ``src/sink/publish/service.py``).
+instead. RULING B (v1, superseded by step 7): a ``TopicSink.close()`` ->
+``FleetService.stop()`` coupling now exists -- closing the sink a fleet
+service taps stops that service too, via a ``base.register_close_hook``
+callback registered at this module's import time (see
+``_stop_fleet_on_sink_close`` below).
 
 The result is one additional report entry, ``{"fleet": "started" | "disabled"
 | "failed", ...}``, alongside the per-subscription ones -- or none at all
@@ -74,6 +75,7 @@ from src.di import module
 from src.di.types.base_module import BaseModule
 from src.di.types.topic_sink import TopicSink, guess_host, guess_port
 from src.pipeline import base
+from src.sink import base as sink_base
 from src.sink.publish import StreamConfigError
 from src.sink.publish import identity as identity_mod
 from src.sink.publish.config import StreamsConfig, load_streams
@@ -82,9 +84,45 @@ from src.sink.publish.mqtt import MqttPublisher
 from src.sink.publish.service import FleetService
 from src.sink.publish.spool import Spool
 
-# Step 7's fleet status/control tools read and (for tests) stop this; None
-# until/unless a manifest's `streams:` section successfully starts one.
+# Private holder; `fleet_service()`/`set_fleet_service()` below are its public
+# face. Step 7's fleet status/control tools read and (for tests) stop it via
+# those two functions; None until/unless a manifest's `streams:` section
+# successfully starts one.
 _FLEET_SERVICE: FleetService | None = None
+
+
+def fleet_service() -> FleetService | None:
+    """Return the live `FleetService`, if any -- step 7's tools read this."""
+    return _FLEET_SERVICE
+
+
+def set_fleet_service(service: FleetService | None) -> None:
+    """Replace the live `FleetService` holder -- step 7's tools stop via this."""
+    global _FLEET_SERVICE  # noqa: PLW0603 -- the module-level holder step 7's tools read/stop
+    _FLEET_SERVICE = service
+
+
+def _stop_fleet_on_sink_close(sink: object) -> None:
+    """`TopicSink.close()` -> `FleetService.stop()` coupling (spec §2).
+
+    Registered below as a `base` close hook. Runs on every sink close, so it
+    first checks whether the closing sink is even the one the live fleet
+    service (if any) is tapping.
+    """
+    service = fleet_service()
+    if service is None or service.sink is not sink:
+        return
+    try:
+        service.stop()
+    finally:
+        set_fleet_service(None)
+
+
+# Guard against double-registration on module reload (e.g. test suites that
+# re-import this module): register once, by checking membership of this
+# named function rather than a separate module-level flag.
+if _stop_fleet_on_sink_close not in sink_base._close_hooks:
+    sink_base.register_close_hook(_stop_fleet_on_sink_close)
 
 
 def subscribe_with_pipeline(
@@ -275,7 +313,6 @@ def _start_fleet(
         entry is added in that case); otherwise the fleet report entry.
 
     """
-    global _FLEET_SERVICE  # noqa: PLW0603 -- the module-level holder step 7's tools read/stop
     try:
         streams = load_streams(manifest)
         if streams is None:
@@ -299,7 +336,8 @@ def _start_fleet(
                 "every one of these topics under one entry's 'topics:'",
             )
 
-        if _FLEET_SERVICE is not None:
+        previous = fleet_service()
+        if previous is not None:
             # A second startup.start() in the same process is about to
             # replace the holder: FleetService.start()'s double-start guard
             # is per-instance, so nothing else would ever stop the PREVIOUS
@@ -309,7 +347,7 @@ def _start_fleet(
             # may tap the very same sink/buffers) wires its own. Best-effort:
             # a broken old service must not block the new one from starting.
             try:
-                _FLEET_SERVICE.stop()
+                previous.stop()
             except Exception as stop_error:
                 logging.warning(
                     "Failed to stop the previous FleetService before replacing it: %s",
@@ -320,7 +358,7 @@ def _start_fleet(
             # holder must not keep pointing at this now-stopped instance as
             # if it were still the live one (a caller reading it -- step 7's
             # status/control tools -- would see a dead service as live).
-            _FLEET_SERVICE = None
+            set_fleet_service(None)
 
         directory = settings.FLEET_IDENTITY_DIRECTORY
         identity = (
@@ -333,7 +371,7 @@ def _start_fleet(
             sink=sink, streams=streams, publisher=publisher, spool=spool, identity=identity
         )
         service.start()
-        _FLEET_SERVICE = service
+        set_fleet_service(service)
         logging.info(
             "Fleet streaming started: tenant=%s robot=%s",
             identity.tenant if identity is not None else "dev",

--- a/test/plugin/test_skill_routes.py
+++ b/test/plugin/test_skill_routes.py
@@ -12,8 +12,8 @@ SKILL_FILES = sorted(pathlib.Path("plugin/skills").glob("*/SKILL.md"))
 POML_ROUTE_PATTERN = re.compile(r"src/agent/[\w/]+\.poml")
 
 
-def test_exactly_four_skills_exist() -> None:
-    assert len(SKILL_FILES) == 4
+def test_exactly_five_skills_exist() -> None:
+    assert len(SKILL_FILES) == 5
 
 
 def test_every_skill_has_frontmatter_name_and_description() -> None:

--- a/test/sink/publish/conftest.py
+++ b/test/sink/publish/conftest.py
@@ -1,0 +1,164 @@
+"""Shared fakes for `src.sink.publish` tests: FleetService's Publisher/TopicSink doubles.
+
+`FakeWriter`/`FakeSink`/`FakeSinkNoPrivateBuffers`/`FakePublisher` and the small
+IMU-shaped `StreamsConfig`/`pa.StructType` builders started life duplicated in
+`test_service.py` (and, separately, in `test_router.py` -- that copy stays
+where it is: it carries router-specific behavior -- `fail_next_channel_publishes`,
+`channel_publish_delay_s` -- this shared one does not need). `test_control.py`
+needs the same FleetService-building doubles `test_service.py` already had, so
+rather than importing test-module-to-test-module (fragile, and pytest
+collection order shouldn't matter to what a test can import), both modules
+import these from here.
+"""
+
+import pathlib
+import time
+
+import pyarrow as pa
+
+from src.sink.publish.config import StreamsConfig
+from src.sink.publish.identity import Identity
+from src.sink.publish.publisher import Publisher, PublishError
+
+
+class FakeWriter:
+    """Duck-typed stand-in for TopicBufferWriter: struct + set_tap recording."""
+
+    def __init__(self, struct: pa.StructType) -> None:
+        self._struct = struct
+        self._tap = None
+        self.tap_calls: list[object] = []
+
+    @property
+    def struct(self) -> pa.StructType:
+        return self._struct
+
+    def set_tap(self, tap: object) -> None:
+        self._tap = tap
+        self.tap_calls.append(tap)
+
+    def feed(self, topic: str, t: float, msg: dict) -> None:
+        """Simulate a live message arriving: fire the tap, like buffer.append() does."""
+        if self._tap is not None:
+            self._tap(topic, t, msg)
+
+
+class FakeSink:
+    """Duck-typed stand-in for TopicSink: a `_buffers` dict, like the real sink."""
+
+    def __init__(self, buffers: dict[str, FakeWriter]) -> None:
+        self._buffers = buffers
+
+    @property
+    def subscribed_topics(self) -> list[str]:
+        return list(self._buffers)
+
+    def buffer_writer(self, topic: str) -> FakeWriter:
+        return self._buffers[topic]
+
+
+class FakeSinkNoPrivateBuffers:
+    """Duck-typed TopicSink WITHOUT a `_buffers` attribute -- only the public
+    `buffer_writer`/`subscribed_topics` seam. Proves `FleetService.start()` no
+    longer reaches into `_buffers` directly."""
+
+    def __init__(self, buffers: dict[str, FakeWriter]) -> None:
+        self._writers_by_topic = buffers  # deliberately NOT named `_buffers`
+
+    @property
+    def subscribed_topics(self) -> list[str]:
+        return list(self._writers_by_topic)
+
+    def buffer_writer(self, topic: str) -> FakeWriter:
+        return self._writers_by_topic[topic]
+
+
+class FakePublisher(Publisher):
+    """In-memory Publisher double: records every kind of publish; can fail on demand.
+
+    `close_reasons` records the `reason` kwarg of every `close()` call, in
+    order -- Task 4's pause/stop reason plumbing (spec §3) is asserted
+    against this rather than a single last-reason field, so a test can also
+    check a call never happened.
+    """
+
+    def __init__(self, *, connect_should_fail: bool = False) -> None:
+        self.connect_should_fail = connect_should_fail
+        self.connect_calls = 0
+        self.schema_calls: list[dict] = []
+        self.channel_calls: list[dict] = []
+        self.heartbeat_calls: list[dict] = []
+        self.close_calls = 0
+        self.close_reasons: list[str] = []
+        self.reconnects = 0
+        self._connected = False
+
+    def connect(self) -> None:
+        self.connect_calls += 1
+        if self.connect_should_fail:
+            raise PublishError("connect failed")
+        self._connected = True
+
+    def publish(
+        self, kind: str, payload: dict, *, retain: bool = False, timeout_s: float = 10.0
+    ) -> None:
+        if kind == "schema":
+            self.schema_calls.append(payload)
+        elif kind == "channels":
+            self.channel_calls.append(payload)
+        elif kind == "heartbeat":
+            self.heartbeat_calls.append(payload)
+        else:
+            raise AssertionError(f"FakePublisher: unexpected kind {kind!r}")
+
+    def close(self, reason: str = "stopped") -> None:
+        self.close_calls += 1
+        self.close_reasons.append(reason)
+        self._connected = False
+
+    @property
+    def connected(self) -> bool:
+        return self._connected
+
+
+def _imu_streams(**overrides: object) -> StreamsConfig:
+    config = {
+        "flush_interval_s": overrides.pop("flush_interval_s", 0.05),
+        "channels": [{"topic": "/imu", "fields": ["x"], "rate_hz": 50.0}],
+    }
+    config.update(overrides)
+    return StreamsConfig.build(config)
+
+
+def _imu_struct() -> pa.StructType:
+    return pa.struct([pa.field("x", pa.float64())])
+
+
+def _wait_until(predicate: object, timeout_s: float = 2.0) -> bool:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return predicate()
+
+
+def _fake_identity(tmp_path: pathlib.Path, expires_at: str = "2027-01-01T00:00:00Z") -> Identity:
+    """A well-formed Identity pointing at files that don't need to exist for these tests.
+
+    Nothing here does a live mTLS POST -- these tests monkeypatch
+    `service_mod.renew`/`service_mod.should_attempt_renewal` directly rather
+    than exercising the real transport (that's `test_identity.py`'s job), so
+    the cert/key/ca paths never actually need to be read.
+    """
+    directory = tmp_path / "identity"
+    return Identity(
+        tenant="acme",
+        robot_id="robot-42",
+        broker_url="mqtts://fleet.example.com:8883",
+        enroll_url="https://enroll.example.com",
+        expires_at=expires_at,
+        key_path=directory / "robot.key",
+        cert_path=directory / "robot.crt",
+        ca_path=directory / "ca.crt",
+    )

--- a/test/sink/publish/conftest.py
+++ b/test/sink/publish/conftest.py
@@ -80,20 +80,38 @@ class FakePublisher(Publisher):
     order -- Task 4's pause/stop reason plumbing (spec §3) is asserted
     against this rather than a single last-reason field, so a test can also
     check a call never happened.
+
+    `event_calls` records every `publish_event`/`publish("events", ...)`
+    call (Task 7's selftest is the first caller to exercise the events lane
+    end-to-end). `fail_at_channel_call`, when set, makes the Nth
+    `publish_channels` call (1-indexed) raise `PublishError` instead of
+    being recorded -- Task 7's selftest cleanup-on-failure test uses this to
+    force a mid-run failure without a real broker.
+
+    `calls` is a single ordered log of every method invocation (`"connect"`,
+    `"schema"`/`"channels"`/`"heartbeat"`/`"events"` from `publish()`, and
+    `"close"`) -- Task 7's selftest call-order test asserts against this
+    rather than trying to interleave the separate per-kind lists.
     """
 
-    def __init__(self, *, connect_should_fail: bool = False) -> None:
+    def __init__(
+        self, *, connect_should_fail: bool = False, fail_at_channel_call: int | None = None
+    ) -> None:
         self.connect_should_fail = connect_should_fail
+        self.fail_at_channel_call = fail_at_channel_call
         self.connect_calls = 0
         self.schema_calls: list[dict] = []
         self.channel_calls: list[dict] = []
         self.heartbeat_calls: list[dict] = []
+        self.event_calls: list[dict] = []
         self.close_calls = 0
         self.close_reasons: list[str] = []
         self.reconnects = 0
+        self.calls: list[str] = []
         self._connected = False
 
     def connect(self) -> None:
+        self.calls.append("connect")
         self.connect_calls += 1
         if self.connect_should_fail:
             raise PublishError("connect failed")
@@ -102,16 +120,23 @@ class FakePublisher(Publisher):
     def publish(
         self, kind: str, payload: dict, *, retain: bool = False, timeout_s: float = 10.0
     ) -> None:
+        self.calls.append(kind)
         if kind == "schema":
             self.schema_calls.append(payload)
         elif kind == "channels":
+            call_index = len(self.channel_calls) + 1
+            if self.fail_at_channel_call == call_index:
+                raise PublishError(f"forced failure at channel batch {call_index}")
             self.channel_calls.append(payload)
         elif kind == "heartbeat":
             self.heartbeat_calls.append(payload)
+        elif kind == "events":
+            self.event_calls.append(payload)
         else:
             raise AssertionError(f"FakePublisher: unexpected kind {kind!r}")
 
     def close(self, reason: str = "stopped") -> None:
+        self.calls.append("close")
         self.close_calls += 1
         self.close_reasons.append(reason)
         self._connected = False

--- a/test/sink/publish/test_config.py
+++ b/test/sink/publish/test_config.py
@@ -535,3 +535,235 @@ streams:
     def test_invalid_streams_raises_not_swallows(self) -> None:
         with pytest.raises(StreamConfigError):
             config.load_streams({"streams": {"channels": [{"topic": "/t", "rate_hz": 1}]}})
+
+
+class TestChannelName:
+    """`config.channel_name` -- the single formula both `resolve()` and
+    `control.stop_streams` derive a channel's name from, so it lives in one
+    place rather than being duplicated."""
+
+    def test_default_name_is_stem_dot_field(self) -> None:
+        rule = config.ChannelRule.build({"topic": "/nav/imu", "fields": ["x"], "rate_hz": 1})
+        assert config.channel_name(rule, "x") == "imu.x"
+
+    def test_renamed_field_uses_the_rename(self) -> None:
+        rule = config.ChannelRule.build(
+            {"topic": "/imu", "fields": ["x", "y"], "rate_hz": 1, "as": {"x": "accel.x"}}
+        )
+        assert config.channel_name(rule, "x") == "accel.x"
+        assert config.channel_name(rule, "y") == "imu.y"
+
+    def test_geo_default_name_uses_literal_geo_key(self) -> None:
+        rule = config.ChannelRule.build(
+            {"topic": "/nav/odom", "geo": {"lat": "a", "lon": "b"}, "rate_hz": 1}
+        )
+        assert config.channel_name(rule, "geo") == "odom.geo"
+
+    def test_geo_renamed_uses_the_rename(self) -> None:
+        rule = config.ChannelRule.build(
+            {
+                "topic": "/nav/odom",
+                "geo": {"lat": "a", "lon": "b"},
+                "rate_hz": 1,
+                "as": {"geo": "position"},
+            }
+        )
+        assert config.channel_name(rule, "geo") == "position"
+
+    def test_matches_resolve_s_own_names(self) -> None:
+        struct = pa.struct([pa.field("x", pa.float64())])
+        rule = config.ChannelRule.build(
+            {"topic": "/imu", "fields": ["x"], "rate_hz": 1, "as": {"x": "accel.x"}}
+        )
+        cfg = config.StreamsConfig(channels=[rule])
+        (resolved,) = cfg.resolve({"/imu": struct})
+        assert resolved.name == config.channel_name(rule, "x")
+
+
+class TestChannelRuleToManifest:
+    def test_fields_rule_round_trips(self) -> None:
+        rule = config.ChannelRule.build(
+            {"topic": "/imu", "fields": ["linear_acceleration.x"], "rate_hz": 5}
+        )
+        doc = rule.to_manifest()
+        assert doc == {"topic": "/imu", "fields": ["linear_acceleration.x"], "rate_hz": 5.0}
+        assert config.ChannelRule.build(doc) == rule
+
+    def test_geo_rule_with_alt_round_trips(self) -> None:
+        rule = config.ChannelRule.build(
+            {
+                "topic": "/nav/odom",
+                "geo": {"lat": "pose.x", "lon": "pose.y", "alt": "pose.z"},
+                "rate_hz": 1,
+            }
+        )
+        doc = rule.to_manifest()
+        assert doc == {
+            "topic": "/nav/odom",
+            "geo": {"lat": "pose.x", "lon": "pose.y", "alt": "pose.z"},
+            "rate_hz": 1.0,
+        }
+        assert config.ChannelRule.build(doc) == rule
+
+    def test_renamed_rule_carries_as(self) -> None:
+        rule = config.ChannelRule.build(
+            {
+                "topic": "/odom",
+                "geo": {"lat": "pose.x", "lon": "pose.y"},
+                "rate_hz": 1,
+                "as": {"geo": "position"},
+            }
+        )
+        doc = rule.to_manifest()
+        assert doc["as"] == {"geo": "position"}
+        assert config.ChannelRule.build(doc) == rule
+
+    def test_as_absent_when_no_renames(self) -> None:
+        rule = config.ChannelRule.build({"topic": "/imu", "fields": ["x"], "rate_hz": 1})
+        assert "as" not in rule.to_manifest()
+
+    def test_output_contains_only_manifest_shape_keys(self) -> None:
+        rule = config.ChannelRule.build(
+            {
+                "topic": "/imu",
+                "fields": ["x", "y"],
+                "rate_hz": 1,
+                "as": {"x": "accel.x"},
+            }
+        )
+        doc = rule.to_manifest()
+        assert set(doc) <= {"topic", "fields", "geo", "rate_hz", "as"}
+        config.ChannelRule.build(doc)  # unknown keys would raise
+
+
+class TestEventRuleToManifest:
+    def test_full_event_round_trips(self) -> None:
+        rule = config.EventRule.build(
+            {
+                "name": "hard_decel",
+                "topic": "/imu",
+                "predicate": "true",
+                "pre_seconds": 10,
+                "post_seconds": 10,
+                "debounce_seconds": 2,
+                "artifact": "mcap",
+            }
+        )
+        doc = rule.to_manifest()
+        assert doc == {
+            "name": "hard_decel",
+            "topic": "/imu",
+            "predicate": "true",
+            "pre_seconds": 10.0,
+            "post_seconds": 10.0,
+            "debounce_seconds": 2.0,
+            "artifact": "mcap",
+        }
+        assert config.EventRule.build(doc) == rule
+
+    def test_minimal_event_omits_zero_windows_and_artifact(self) -> None:
+        rule = config.EventRule.build({"name": "n", "topic": "/t", "predicate": "true"})
+        doc = rule.to_manifest()
+        assert doc == {"name": "n", "topic": "/t", "predicate": "true"}
+        assert config.EventRule.build(doc) == rule
+
+    def test_output_contains_only_manifest_shape_keys(self) -> None:
+        rule = config.EventRule.build(
+            {"name": "n", "topic": "/t", "predicate": "true", "pre_seconds": 1}
+        )
+        doc = rule.to_manifest()
+        assert set(doc) <= {
+            "name",
+            "topic",
+            "predicate",
+            "pre_seconds",
+            "post_seconds",
+            "debounce_seconds",
+            "artifact",
+        }
+        config.EventRule.build(doc)  # unknown keys would raise
+
+
+class TestStreamsConfigToManifest:
+    def test_empty_config_round_trips(self) -> None:
+        cfg = config.StreamsConfig()
+        doc = cfg.to_manifest()
+        assert doc == {"channels": [], "events": []}
+        assert config.StreamsConfig.build(doc) == cfg
+
+    def test_non_default_broker_and_flush_round_trip(self) -> None:
+        cfg = config.StreamsConfig.build(
+            {"broker": "mqtts://fleet.example.com:8883", "flush_interval_s": 2, "channels": []}
+        )
+        doc = cfg.to_manifest()
+        assert doc["broker"] == "mqtts://fleet.example.com:8883"
+        assert doc["flush_interval_s"] == 2.0
+        assert config.StreamsConfig.build(doc) == cfg
+
+    def test_default_broker_and_flush_are_omitted(self) -> None:
+        cfg = config.StreamsConfig.build({"channels": []})
+        doc = cfg.to_manifest()
+        assert "broker" not in doc
+        assert "flush_interval_s" not in doc
+
+    @pytest.mark.parametrize(
+        "cfg_dict",
+        [
+            {"channels": [{"topic": "/imu", "fields": ["x"], "rate_hz": 5}]},
+            {
+                "channels": [
+                    {
+                        "topic": "/nav/odom",
+                        "geo": {"lat": "pose.x", "lon": "pose.y", "alt": "pose.z"},
+                        "rate_hz": 1,
+                    }
+                ]
+            },
+            {
+                "channels": [
+                    {
+                        "topic": "/imu",
+                        "fields": ["x"],
+                        "rate_hz": 5,
+                        "as": {"x": "accel.x"},
+                    }
+                ]
+            },
+            {
+                "channels": [],
+                "events": [
+                    {
+                        "name": "hard_decel",
+                        "topic": "/imu",
+                        "predicate": "true",
+                        "pre_seconds": 10,
+                        "post_seconds": 10,
+                        "debounce_seconds": 2,
+                        "artifact": "mcap",
+                    }
+                ],
+            },
+            {"channels": [], "events": []},
+            {
+                "broker": "mqtts://fleet.example.com:8883",
+                "flush_interval_s": 3,
+                "channels": [{"topic": "/imu", "fields": ["x"], "rate_hz": 5}],
+            },
+        ],
+    )
+    def test_build_to_manifest_round_trips_for_any_built_config(self, cfg_dict: dict) -> None:
+        cfg = config.StreamsConfig.build(cfg_dict)
+        assert config.StreamsConfig.build(cfg.to_manifest()) == cfg
+
+    def test_output_contains_only_manifest_shape_keys(self) -> None:
+        cfg = config.StreamsConfig.build(
+            {
+                "broker": "mqtts://fleet.example.com:8883",
+                "flush_interval_s": 2,
+                "channels": [{"topic": "/imu", "fields": ["x"], "rate_hz": 5}],
+                "events": [{"name": "n", "topic": "/imu", "predicate": "true"}],
+            }
+        )
+        doc = cfg.to_manifest()
+        assert set(doc) <= {"broker", "flush_interval_s", "channels", "events"}
+        config.StreamsConfig.build(doc)  # unknown keys would raise

--- a/test/sink/publish/test_control.py
+++ b/test/sink/publish/test_control.py
@@ -11,6 +11,7 @@ import importlib
 import pathlib
 import stat
 import sys
+import threading
 
 import pyarrow as pa
 import pytest
@@ -444,6 +445,37 @@ class TestEnrollIdentity:
         with pytest.raises(FleetDisabledError, match="FLEET_ENABLED"):
             control.enroll_identity("some-token", "https://enroll.example.com")
 
+    def test_not_installed_raises_before_any_keygen(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """M1: paho not installed raises via require_fleet(), before any keygen."""
+
+        def poison(*_a: object, **_kw: object) -> None:
+            raise AssertionError(
+                "generate_key_and_csr must not be reached: paho not installed gates first"
+            )
+
+        monkeypatch.setattr(identity, "generate_key_and_csr", poison)
+        _simulate_paho_not_installed(monkeypatch)
+
+        with pytest.raises(FleetNotInstalledError):
+            control.enroll_identity("some-token", "https://enroll.example.com")
+
+    def test_enroll_while_dev_service_running_leaves_it_unchanged(
+        self, tmp_path: pathlib.Path, fake_server: str
+    ) -> None:
+        """M2: enrolling while a dev-identity service is already running (an
+        unenrolled robot's placeholder `dev/robot` service) must not
+        retroactively touch it -- the new identity only takes effect on the
+        next restart/rule change (stream_topics/stop_streams)."""
+        service, _pub = _running_service(tmp_path)
+        startup.set_fleet_service(service)
+        assert service.status()["cert_expires_at"] is None
+
+        result = control.enroll_identity(VALID_TOKEN, fake_server)
+
+        assert result["robot_id"] == "robot-42"
+        assert startup.fleet_service() is service  # unchanged, same object
+        assert service.status()["cert_expires_at"] is None  # still the dev-identity service
+
 
 class TestUnenrollIdentity:
     def test_running_service_stopped_and_holder_cleared(self, tmp_path: pathlib.Path) -> None:
@@ -780,6 +812,55 @@ class TestStreamTopics:
         assert new_service.streams.events[0].pre_seconds == 5.0
         assert result["events"] == ["hard_decel"]
 
+    def test_disabled_raises_before_any_state_change(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """M1: FLEET_ENABLED=0 raises before touching the holder/validation at all."""
+        old_service = self._running_multi_topic_service(tmp_path)
+        monkeypatch.setattr(settings, "FLEET_ENABLED", False)
+
+        with pytest.raises(FleetDisabledError, match="FLEET_ENABLED"):
+            control.stream_topics(
+                channels=[{"topic": "/odom", "fields": ["y"], "rate_hz": 2}], events=None
+            )
+
+        assert startup.fleet_service() is old_service
+
+    def test_not_installed_raises(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """M1: paho not installed raises via require_fleet(), before any state change."""
+        old_service = self._running_multi_topic_service(tmp_path)
+        _simulate_paho_not_installed(monkeypatch)
+
+        with pytest.raises(FleetNotInstalledError):
+            control.stream_topics(
+                channels=[{"topic": "/odom", "fields": ["y"], "rate_hz": 2}], events=None
+            )
+
+        assert startup.fleet_service() is old_service
+
+    def test_paused_service_stays_paused_across_a_rule_change(self, tmp_path: pathlib.Path) -> None:
+        """I1 (important): a rule change must not silently un-pause a paused
+        service -- the brief reconnect-to-republish-schema blip is accepted,
+        but the service must land back in `paused`, not `running`."""
+        old_service = self._running_multi_topic_service(tmp_path)
+        old_service.pause()
+        assert old_service.paused is True
+
+        result = control.stream_topics(
+            channels=[{"topic": "/odom", "fields": ["y"], "rate_hz": 2}], events=None
+        )
+
+        new_service = startup.fleet_service()
+        assert new_service is not old_service
+        assert new_service.paused is True
+        assert result["service"] == "paused"
+
+        resume_result = control.resume_streaming()
+        assert resume_result == {"service": "running", "changed": True}
+        assert new_service.paused is False
+
 
 class TestStopStreams:
     """`stop_streams` removes rules by resolved name; unknown names are idempotent no-ops."""
@@ -913,3 +994,135 @@ class TestStopStreams:
         assert doc["streams"]["channels"] == []
         assert doc["streams"]["events"] == []
         assert config.load_streams(doc) is not None
+
+    def test_paused_service_stays_paused_across_a_rule_removal(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        """I1 (important): same ruling as stream_topics's -- a paused service
+        must still be paused after stop_streams restarts it."""
+        streams = config.StreamsConfig.build(
+            {"channels": [{"topic": "/imu", "fields": ["x", "y"], "rate_hz": 50}]}
+        )
+        old_service = self._service_with_streams(tmp_path, streams)
+        old_service.pause()
+        assert old_service.paused is True
+
+        result = control.stop_streams(channels=["imu.x"], events=None)
+
+        new_service = startup.fleet_service()
+        assert new_service is not old_service
+        assert new_service.paused is True
+        assert result["service"] == "paused"
+
+        resume_result = control.resume_streaming()
+        assert resume_result == {"service": "running", "changed": True}
+        assert new_service.paused is False
+
+    def test_no_service_persist_only_reports_stopped(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """M1: with no service running, stop_streams only updates the
+        persisted manifest -- it never starts one -- and reports "stopped"."""
+        manifest_path = tmp_path / "manifest.yaml"
+        manifest_path.write_text(
+            yaml.safe_dump(
+                {
+                    "subscriptions": [],
+                    "streams": {
+                        "channels": [{"topic": "/imu", "fields": ["x"], "rate_hz": 50}],
+                        "events": [],
+                    },
+                }
+            )
+        )
+        monkeypatch.setattr(settings, "STARTUP_PIPELINES_FILE", str(manifest_path))
+        startup.set_fleet_service(None)
+
+        result = control.stop_streams(channels=["imu.x"], events=None)
+
+        assert result == {
+            "service": "stopped",
+            "channels": [],
+            "events": [],
+            "changed": True,
+            "persisted": True,
+        }
+        assert startup.fleet_service() is None
+        doc = yaml.safe_load(manifest_path.read_text())
+        assert doc["streams"]["channels"] == []
+
+
+class TestControlLock:
+    """I2 (important): one module-level lock serializes tool-driven lifecycle
+    transitions across the mutating control-plane operations. `fleet_status`
+    stays deliberately unlocked (read-only, must never block) -- not tested
+    here since it never touches `_control_lock` at all.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _enrolled(self) -> None:
+        _write_identity(pathlib.Path(settings.FLEET_IDENTITY_DIRECTORY))
+
+    def test_second_mutating_call_blocks_until_the_first_releases_the_lock(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        writer = FakeWriter(_imu_struct())
+        sink = FakeSink({"/imu": writer})
+        monkeypatch.setattr(sink_base, "live_sinks", lambda: [sink])
+        startup.set_fleet_service(None)
+
+        original_restart = control._restart_service
+        entered = threading.Event()
+        release = threading.Event()
+
+        def blocking_restart(streams: object) -> None:
+            entered.set()
+            assert release.wait(timeout=5), "test setup: release was never signaled"
+            original_restart(streams)
+
+        monkeypatch.setattr(control, "_restart_service", blocking_restart)
+
+        first_done = threading.Event()
+
+        def call_stream_topics() -> None:
+            control.stream_topics(
+                channels=[{"topic": "/imu", "fields": ["x"], "rate_hz": 5}], events=None
+            )
+            first_done.set()
+
+        first = threading.Thread(target=call_stream_topics)
+        first.start()
+        assert entered.wait(timeout=2), "first call never reached the blocked _restart_service"
+
+        # A second mutating call (stop_streams, resolved as a no-op -- it never
+        # itself calls _restart_service) must still block on the module lock
+        # `stream_topics` is holding, proving the lock spans the whole
+        # mutating body, not just the _restart_service call.
+        second_done = threading.Event()
+
+        def call_stop_streams() -> None:
+            control.stop_streams(channels=["nope.x"], events=None)
+            second_done.set()
+
+        second = threading.Thread(target=call_stop_streams)
+        second.start()
+        second.join(timeout=0.3)
+        assert not second_done.is_set(), (
+            "second mutating call ran before the first released the lock"
+        )
+
+        release.set()
+        first.join(timeout=5)
+        second.join(timeout=5)
+        assert first_done.is_set()
+        assert second_done.is_set()
+
+    def test_fleet_status_never_blocks_on_a_held_lock(self, tmp_path: pathlib.Path) -> None:
+        assert control._control_lock.acquire(blocking=False)
+        try:
+            # fleet_status is read-only and must not try to acquire the lock
+            # at all -- if it did, this call would deadlock right here.
+            status = control.fleet_status()
+        finally:
+            control._control_lock.release()
+        assert status["service"] == "stopped"

--- a/test/sink/publish/test_control.py
+++ b/test/sink/publish/test_control.py
@@ -1,0 +1,301 @@
+"""control.py: status/pause/resume lifecycle control (fleet streaming step 7, Task 4).
+
+`fleet_status()` calls NO gate -- it is the local source of truth in every
+state (uninstalled, disabled, unenrolled, service down); `pause_streaming`/
+`resume_streaming` call `require_fleet()` first, so `FLEET_ENABLED=0` raises
+before the holder is ever touched.
+"""
+
+import pathlib
+import sys
+
+import pytest
+import yaml
+
+from publish.conftest import FakePublisher, FakeSink, FakeWriter, _imu_streams, _imu_struct
+from settings import settings
+from src.sink import startup
+from src.sink.publish import FleetDisabledError, FleetNotInstalledError, control
+from src.sink.publish.service import FleetService
+from src.sink.publish.spool import Spool
+
+
+def _simulate_paho_not_installed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make both `find_spec("paho.mqtt")` and `import paho.mqtt.client` behave as uninstalled.
+
+    Blanking `sys.modules["paho.mqtt"]` alone is enough for
+    `importlib.util.find_spec("paho.mqtt")` (`fleet_status()`'s check) to
+    return `None` -- but `require_fleet()`'s plain `import paho.mqtt.client`
+    statement resolves straight from `sys.modules["paho.mqtt.client"]` if
+    THAT'S already cached (e.g. by an earlier test in this same session that
+    really imported paho), bypassing the parent's `None` entirely. Both keys
+    need blanking together for a reliable "not installed" simulation
+    regardless of what an earlier test already imported -- this is the same
+    idiom `test_gate.py` uses (it blanks all three of `paho`/`paho.mqtt`/
+    `paho.mqtt.client`; `paho` itself is left alone here since neither check
+    this module makes ever resolves through it).
+    """
+    monkeypatch.setitem(sys.modules, "paho.mqtt", None)
+    monkeypatch.setitem(sys.modules, "paho.mqtt.client", None)
+
+
+def _write_identity(  # noqa: PLR0913 -- one field per identity.yaml key, matching enroll()'s own shape
+    directory: pathlib.Path,
+    *,
+    tenant: str = "acme",
+    robot_id: str = "robot-1",
+    broker_url: str = "mqtts://fleet.example.com:8883",
+    enroll_url: str = "https://enroll.example.com",
+    expires_at: str = "2030-01-01T00:00:00Z",
+    renew_url: str | None = None,
+) -> None:
+    """Write a complete, `is_enrolled()`-satisfying identity directly to disk.
+
+    Mirrors `test/sink/test_startup_streams.py`'s `_write_identity` helper:
+    these tests only need `is_enrolled()`/`load_identity()` to see a
+    complete identity, not a real enrollment round trip (that's
+    `test_identity.py`'s job).
+    """
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "robot.key").write_bytes(b"fake-key-material")
+    (directory / "robot.crt").write_bytes(b"fake-cert-material")
+    (directory / "ca.crt").write_bytes(b"fake-ca-material")
+    doc = {
+        "tenant": tenant,
+        "robot_id": robot_id,
+        "broker_url": broker_url,
+        "enroll_url": enroll_url,
+        "expires_at": expires_at,
+    }
+    if renew_url is not None:
+        doc["renew_url"] = renew_url
+    (directory / "identity.yaml").write_text(yaml.safe_dump(doc))
+
+
+def _running_service(
+    tmp_path: pathlib.Path, publisher: FakePublisher | None = None
+) -> tuple[FleetService, FakePublisher]:
+    writer = FakeWriter(_imu_struct())
+    sink = FakeSink({"/imu": writer})
+    pub = publisher if publisher is not None else FakePublisher()
+    service = FleetService(
+        sink=sink, streams=_imu_streams(), publisher=pub, spool=Spool(tmp_path / "spool")
+    )
+    service.start()
+    return service, pub
+
+
+@pytest.fixture(autouse=True)
+def _isolated_fleet_state(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "FLEET_IDENTITY_DIRECTORY", str(tmp_path / "identity"))
+    monkeypatch.setattr(settings, "FLEET_ENABLED", True)
+    startup.set_fleet_service(None)
+    yield
+    service = startup.fleet_service()
+    if service is not None:
+        service.stop()
+    startup.set_fleet_service(None)
+
+
+class TestFleetStatusNoGate:
+    """`fleet_status()` must never raise -- it REPORTS every state instead."""
+
+    def test_not_installed_reports_false_without_raising(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Same idiom the gate tests rely on (test_gate.py): the leaf submodule
+        # set to None in sys.modules makes both `importlib.util.find_spec`
+        # (control.fleet_status) and a plain `import paho.mqtt.client`
+        # (require_fleet, exercised by the pause/resume tests below) behave
+        # as "not installed" -- without needing a real uninstall.
+        _simulate_paho_not_installed(monkeypatch)
+        status = control.fleet_status()
+        assert status["installed"] is False
+
+    def test_disabled_reports_false_without_raising(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(settings, "FLEET_ENABLED", False)
+        status = control.fleet_status()
+        assert status["enabled"] is False
+
+    def test_unenrolled_reports_no_identity(self) -> None:
+        status = control.fleet_status()
+        assert status["enrolled"] is False
+        assert status["identity"] is None
+
+    def test_no_service_reports_stopped_and_empty(self) -> None:
+        status = control.fleet_status()
+        assert status["service"] == "stopped"
+        assert status["channels"] == []
+        assert status["status"] is None
+
+    def test_enrolled_and_running_reports_identity_and_status(self, tmp_path: pathlib.Path) -> None:
+        _write_identity(
+            pathlib.Path(settings.FLEET_IDENTITY_DIRECTORY),
+            expires_at="2030-06-01T00:00:00Z",
+            renew_url="https://renew.example.com",
+        )
+        service, _pub = _running_service(tmp_path)
+        startup.set_fleet_service(service)
+
+        status = control.fleet_status()
+
+        assert status["enrolled"] is True
+        assert set(status["identity"]) == {
+            "tenant",
+            "robot_id",
+            "broker_url",
+            "cert_expires_at",
+            "renew_url",
+        }
+        assert status["identity"]["tenant"] == "acme"
+        assert status["identity"]["robot_id"] == "robot-1"
+        assert status["identity"]["broker_url"] == "mqtts://fleet.example.com:8883"
+        assert status["identity"]["cert_expires_at"] == "2030-06-01T00:00:00Z"
+        assert status["identity"]["renew_url"] == "https://renew.example.com"
+
+        assert status["service"] == "running"
+        assert status["channels"] == service.channels
+        assert "queue" in status["status"]
+        assert "spool" in status["status"]
+
+    def test_identity_never_carries_key_material_or_paths(self, tmp_path: pathlib.Path) -> None:
+        _write_identity(pathlib.Path(settings.FLEET_IDENTITY_DIRECTORY))
+        status = control.fleet_status()
+        blob = repr(status["identity"])
+        assert "key_path" not in blob
+        assert "cert_path" not in blob
+        assert "ca_path" not in blob
+        assert "fake-key-material" not in blob
+
+    def test_paused_service_reports_paused(self, tmp_path: pathlib.Path) -> None:
+        service, _pub = _running_service(tmp_path)
+        startup.set_fleet_service(service)
+        service.pause()
+
+        status = control.fleet_status()
+
+        assert status["service"] == "paused"
+
+
+class TestPauseStreaming:
+    def test_running_service_pauses_and_records_reason(self, tmp_path: pathlib.Path) -> None:
+        service, pub = _running_service(tmp_path)
+        startup.set_fleet_service(service)
+
+        result = control.pause_streaming()
+
+        assert result == {"service": "paused", "changed": True, "discarded": False}
+        assert pub.close_reasons == ["paused"]
+
+    def test_second_pause_is_a_no_op(self, tmp_path: pathlib.Path) -> None:
+        service, pub = _running_service(tmp_path)
+        startup.set_fleet_service(service)
+
+        control.pause_streaming()
+        result = control.pause_streaming()
+
+        assert result == {"service": "paused", "changed": False, "discarded": False}
+        assert pub.close_reasons == ["paused"]  # no second close
+
+    def test_discard_true_passes_through_and_empties_channels_lane(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        service, _pub = _running_service(tmp_path)
+        spool = service._spool
+        seq = spool.next_seq("channels")
+        spool.append("channels", seq, {"v": 1, "samples": []})
+        assert list(spool.pending("channels"))
+        startup.set_fleet_service(service)
+
+        result = control.pause_streaming(discard=True)
+
+        assert result == {"service": "paused", "changed": True, "discarded": True}
+        assert list(spool.pending("channels")) == []
+
+    def test_no_service_is_idempotent_no_op(self) -> None:
+        assert control.pause_streaming() == {"service": "stopped", "changed": False}
+
+    def test_disabled_raises_before_holder_access(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        service, _pub = _running_service(tmp_path)
+
+        def poison(*_a: object, **_kw: object) -> None:
+            raise AssertionError("pause() must not be reached: FLEET_ENABLED=0 gates first")
+
+        service.pause = poison  # type: ignore[method-assign]
+        startup.set_fleet_service(service)
+        monkeypatch.setattr(settings, "FLEET_ENABLED", False)
+
+        with pytest.raises(FleetDisabledError, match="FLEET_ENABLED"):
+            control.pause_streaming()
+
+    def test_not_installed_raises(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        service, _pub = _running_service(tmp_path)
+        startup.set_fleet_service(service)
+        _simulate_paho_not_installed(monkeypatch)
+
+        with pytest.raises(FleetNotInstalledError):
+            control.pause_streaming()
+
+
+class TestResumeStreaming:
+    def test_paused_service_resumes(self, tmp_path: pathlib.Path) -> None:
+        service, pub = _running_service(tmp_path)
+        service.pause()
+        startup.set_fleet_service(service)
+
+        result = control.resume_streaming()
+
+        assert result == {"service": "running", "changed": True}
+        assert pub.close_reasons == ["paused"]  # resume doesn't close
+
+    def test_already_running_service_is_a_no_op(self, tmp_path: pathlib.Path) -> None:
+        service, _pub = _running_service(tmp_path)
+        startup.set_fleet_service(service)
+
+        result = control.resume_streaming()
+
+        assert result == {"service": "running", "changed": False}
+
+    def test_second_resume_is_a_no_op(self, tmp_path: pathlib.Path) -> None:
+        service, _pub = _running_service(tmp_path)
+        service.pause()
+        startup.set_fleet_service(service)
+
+        control.resume_streaming()
+        result = control.resume_streaming()
+
+        assert result == {"service": "running", "changed": False}
+
+    def test_no_service_is_idempotent_no_op(self) -> None:
+        assert control.resume_streaming() == {"service": "stopped", "changed": False}
+
+    def test_disabled_raises_before_holder_access(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        service, _pub = _running_service(tmp_path)
+        service.pause()
+
+        def poison(*_a: object, **_kw: object) -> None:
+            raise AssertionError("resume() must not be reached: FLEET_ENABLED=0 gates first")
+
+        service.resume = poison  # type: ignore[method-assign]
+        startup.set_fleet_service(service)
+        monkeypatch.setattr(settings, "FLEET_ENABLED", False)
+
+        with pytest.raises(FleetDisabledError, match="FLEET_ENABLED"):
+            control.resume_streaming()
+
+    def test_not_installed_raises(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        service, _pub = _running_service(tmp_path)
+        service.pause()
+        startup.set_fleet_service(service)
+        _simulate_paho_not_installed(monkeypatch)
+
+        with pytest.raises(FleetNotInstalledError):
+            control.resume_streaming()

--- a/test/sink/publish/test_control.py
+++ b/test/sink/publish/test_control.py
@@ -1,23 +1,42 @@
-"""control.py: status/pause/resume lifecycle control (fleet streaming step 7, Task 4).
+"""control.py: enroll/unenroll/status/pause/resume/stream-rule control (fleet streaming step 7).
 
 `fleet_status()` calls NO gate -- it is the local source of truth in every
-state (uninstalled, disabled, unenrolled, service down); `pause_streaming`/
-`resume_streaming` call `require_fleet()` first, so `FLEET_ENABLED=0` raises
-before the holder is ever touched.
+state (uninstalled, disabled, unenrolled, service down); `unenroll_identity()`
+is the other gate-free operation (it only makes the subsystem MORE inert).
+Every other operation here calls `require_fleet()` first, so `FLEET_ENABLED=0`
+raises before the holder is ever touched.
 """
 
+import importlib
 import pathlib
 import sys
 
+import pyarrow as pa
 import pytest
 import yaml
 
 from publish.conftest import FakePublisher, FakeSink, FakeWriter, _imu_streams, _imu_struct
+from publish.test_identity import VALID_TOKEN, fake_server
 from settings import settings
+from src.sink import base as sink_base
 from src.sink import startup
-from src.sink.publish import FleetDisabledError, FleetNotInstalledError, control
+from src.sink.publish import (
+    EnrollmentError,
+    FleetDisabledError,
+    FleetNotEnrolledError,
+    FleetNotInstalledError,
+    StreamConfigError,
+    config,
+    control,
+    identity,
+)
 from src.sink.publish.service import FleetService
 from src.sink.publish.spool import Spool
+
+# `fake_server` is imported only to be re-exported as a pytest fixture (used
+# by parameter name in TestEnrollIdentity, never referenced by name in this
+# module's own code) -- see test_service.py's identical idiom.
+__all__ = ["fake_server"]
 
 
 def _simulate_paho_not_installed(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -89,12 +108,30 @@ def _running_service(
 def _isolated_fleet_state(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "FLEET_IDENTITY_DIRECTORY", str(tmp_path / "identity"))
     monkeypatch.setattr(settings, "FLEET_ENABLED", True)
+    monkeypatch.setattr(settings, "STARTUP_PIPELINES_FILE", None)
     startup.set_fleet_service(None)
     yield
     service = startup.fleet_service()
     if service is not None:
         service.stop()
     startup.set_fleet_service(None)
+
+
+@pytest.fixture(autouse=True)
+def _fake_mqtt_publisher(monkeypatch: pytest.MonkeyPatch) -> list[FakePublisher]:
+    """`control._restart_service` builds a real `MqttPublisher` -- swap it for a
+    `FakePublisher` so `stream_topics`/`stop_streams` tests never touch a real
+    socket. Harmless (never invoked) for tests that don't trigger a restart.
+    """
+    built: list[FakePublisher] = []
+
+    def factory(**_kwargs: object) -> FakePublisher:
+        pub = FakePublisher()
+        built.append(pub)
+        return pub
+
+    monkeypatch.setattr(control, "MqttPublisher", factory)
+    return built
 
 
 class TestFleetStatusNoGate:
@@ -175,6 +212,57 @@ class TestFleetStatusNoGate:
         status = control.fleet_status()
 
         assert status["service"] == "paused"
+
+    def test_load_identity_raising_between_checks_degrades_gracefully(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """TOCTOU regression: `fleet_status()` must single-load `identity.load_identity`,
+        not check `is_enrolled()` and then separately `load_identity()`.
+
+        A stale `is_enrolled() -> True` immediately followed by a
+        `load_identity()` that raises (the identity was deleted/corrupted in
+        between) must never surface as an unhandled `FleetNotEnrolledError` --
+        `fleet_status()` never raises. Proven structurally: `is_enrolled` is
+        made to return a stale `True` while `load_identity` always raises --
+        a two-call implementation would propagate that raise; a single-load
+        try/except cannot, since it never consults `is_enrolled` at all.
+        """
+        monkeypatch.setattr(identity, "is_enrolled", lambda *_a, **_kw: True)
+
+        def _raise(*_a: object, **_kw: object) -> None:
+            raise FleetNotEnrolledError("deleted between checks")
+
+        monkeypatch.setattr(identity, "load_identity", _raise)
+
+        status = control.fleet_status()
+
+        assert status["enrolled"] is False
+        assert status["identity"] is None
+
+
+def test_control_module_does_not_import_paho_or_cryptography_eagerly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Lazy-import regression for control.py itself -- mirrors test_gate.py's/
+    test_service.py's idiom. control.py imports `connect`/`config`/`spool`/`mqtt`
+    (and `service`) at module scope; none of those may drag paho or cryptography
+    in eagerly either.
+    """
+    for name in [
+        m
+        for m in sys.modules
+        if m == "paho"
+        or m.startswith("paho.")
+        or m == "cryptography"
+        or m.startswith("cryptography.")
+    ]:
+        monkeypatch.delitem(sys.modules, name)
+    monkeypatch.delitem(sys.modules, "src.sink.publish.control", raising=False)
+    importlib.import_module("src.sink.publish.control")
+    assert not any(
+        m == "paho" or m.startswith("paho.") or m == "cryptography" or m.startswith("cryptography.")
+        for m in sys.modules
+    )
 
 
 class TestPauseStreaming:
@@ -299,3 +387,406 @@ class TestResumeStreaming:
 
         with pytest.raises(FleetNotInstalledError):
             control.resume_streaming()
+
+
+def _assert_no_token_anywhere(obj: object, token: str) -> None:
+    """Recursively assert `token` never appears -- as a dict key or a substring
+    of any string value -- anywhere in `obj`."""
+    if isinstance(obj, dict):
+        assert "token" not in obj
+        for value in obj.values():
+            _assert_no_token_anywhere(value, token)
+    elif isinstance(obj, list):
+        for value in obj:
+            _assert_no_token_anywhere(value, token)
+    elif isinstance(obj, str):
+        assert token not in obj
+
+
+class TestEnrollIdentity:
+    def test_happy_path_writes_identity_under_tmp_directory(self, fake_server: str) -> None:
+        result = control.enroll_identity(VALID_TOKEN, fake_server)
+
+        directory = pathlib.Path(settings.FLEET_IDENTITY_DIRECTORY)
+        assert (directory / "robot.key").is_file()
+        assert (directory / "robot.crt").is_file()
+        assert (directory / "ca.crt").is_file()
+        assert (directory / "identity.yaml").is_file()
+        assert result == {
+            "tenant": "acme",
+            "robot_id": "robot-42",
+            "broker_url": "mqtts://fleet.example.com:8883",
+            "expires_at": "2027-01-01T00:00:00Z",
+        }
+
+    def test_already_enrolled_raises_with_the_ruling_message(self) -> None:
+        _write_identity(pathlib.Path(settings.FLEET_IDENTITY_DIRECTORY))
+
+        with pytest.raises(EnrollmentError, match="already enrolled") as exc_info:
+            control.enroll_identity("some-token", "https://enroll.example.com")
+
+        assert exc_info.value.status == 0
+
+    def test_result_dict_never_carries_the_token(self, fake_server: str) -> None:
+        result = control.enroll_identity(VALID_TOKEN, fake_server)
+        _assert_no_token_anywhere(result, VALID_TOKEN)
+
+    def test_disabled_raises_before_any_keygen(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def poison(*_a: object, **_kw: object) -> None:
+            raise AssertionError(
+                "generate_key_and_csr must not be reached: FLEET_ENABLED=0 gates first"
+            )
+
+        monkeypatch.setattr(identity, "generate_key_and_csr", poison)
+        monkeypatch.setattr(settings, "FLEET_ENABLED", False)
+
+        with pytest.raises(FleetDisabledError, match="FLEET_ENABLED"):
+            control.enroll_identity("some-token", "https://enroll.example.com")
+
+
+class TestUnenrollIdentity:
+    def test_running_service_stopped_and_holder_cleared(self, tmp_path: pathlib.Path) -> None:
+        _write_identity(pathlib.Path(settings.FLEET_IDENTITY_DIRECTORY))
+        service, pub = _running_service(tmp_path)
+        startup.set_fleet_service(service)
+
+        result = control.unenroll_identity()
+
+        assert pub.close_calls >= 1
+        assert startup.fleet_service() is None
+        assert result["service"] == "stopped"
+
+    def test_delete_identity_is_the_only_deletion_path(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Replace `identity.delete_identity` with a no-op fake that never touches
+        disk: if `unenroll_identity()` did its own separate unlinking, the files
+        would still be gone; since it must go ONLY through `delete_identity`,
+        they must survive untouched."""
+        directory = pathlib.Path(settings.FLEET_IDENTITY_DIRECTORY)
+        _write_identity(directory)
+        calls: list[pathlib.Path] = []
+
+        def fake_delete(dir_arg: pathlib.Path) -> list[str]:
+            calls.append(pathlib.Path(dir_arg))
+            return ["identity.yaml"]
+
+        monkeypatch.setattr(identity, "delete_identity", fake_delete)
+
+        result = control.unenroll_identity()
+
+        assert calls == [directory]
+        assert result["deleted"] == ["identity.yaml"]
+        assert (directory / "identity.yaml").is_file()  # untouched by unenroll_identity itself
+        assert (directory / "robot.key").is_file()
+
+    def test_manifest_streams_section_removed_subscriptions_preserved(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _write_identity(pathlib.Path(settings.FLEET_IDENTITY_DIRECTORY))
+        manifest_path = tmp_path / "startup.yaml"
+        subscriptions = [{"sink": "mqtt", "topics": ["/imu"]}]
+        manifest_path.write_text(
+            yaml.safe_dump(
+                {
+                    "subscriptions": subscriptions,
+                    "streams": {"channels": [{"topic": "/imu", "fields": ["x"], "rate_hz": 5}]},
+                },
+                sort_keys=False,
+            )
+        )
+        monkeypatch.setattr(settings, "STARTUP_PIPELINES_FILE", str(manifest_path))
+
+        result = control.unenroll_identity()
+
+        assert result["streams_removed"] is True
+        doc = yaml.safe_load(manifest_path.read_text())
+        assert "streams" not in doc
+        assert doc["subscriptions"] == subscriptions
+
+    def test_second_call_is_idempotent_no_error(self) -> None:
+        assert control.unenroll_identity()["deleted"] == []
+        assert control.unenroll_identity()["deleted"] == []
+
+    def test_works_with_fleet_disabled(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _write_identity(pathlib.Path(settings.FLEET_IDENTITY_DIRECTORY))
+        monkeypatch.setattr(settings, "FLEET_ENABLED", False)
+
+        result = control.unenroll_identity()  # must not raise
+
+        assert result["deleted"]
+        assert control.fleet_status()["enrolled"] is False
+
+
+class TestPersistStreamsManifestHandling:
+    """`_persist_streams`/`_read_manifest_doc`: the shared manifest read/write path."""
+
+    def test_unset_manifest_file_returns_false_without_error(self) -> None:
+        assert control._persist_streams({"channels": [], "events": []}) is False
+
+    def test_unparsable_existing_manifest_raises_without_clobbering(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        manifest_path = tmp_path / "manifest.yaml"
+        original_text = "not: valid: yaml: ["
+        manifest_path.write_text(original_text)
+        monkeypatch.setattr(settings, "STARTUP_PIPELINES_FILE", str(manifest_path))
+
+        with pytest.raises(StreamConfigError, match="manifest"):
+            control._persist_streams({"channels": [], "events": []})
+
+        assert manifest_path.read_text() == original_text
+
+    def test_missing_manifest_file_persists_from_empty(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        manifest_path = tmp_path / "manifest.yaml"
+        monkeypatch.setattr(settings, "STARTUP_PIPELINES_FILE", str(manifest_path))
+
+        result = control._persist_streams({"channels": [], "events": []})
+
+        assert result is True
+        doc = yaml.safe_load(manifest_path.read_text())
+        assert doc == {"streams": {"channels": [], "events": []}}
+
+
+class TestStreamTopics:
+    """`stream_topics` validates, merges onto the current config, restarts, persists."""
+
+    @pytest.fixture(autouse=True)
+    def _enrolled(self) -> None:
+        _write_identity(pathlib.Path(settings.FLEET_IDENTITY_DIRECTORY))
+
+    def _running_multi_topic_service(self, tmp_path: pathlib.Path) -> FleetService:
+        writer_imu = FakeWriter(_imu_struct())
+        writer_odom = FakeWriter(pa.struct([pa.field("y", pa.float64())]))
+        sink = FakeSink({"/imu": writer_imu, "/odom": writer_odom})
+        service = FleetService(
+            sink=sink,
+            streams=_imu_streams(),
+            publisher=FakePublisher(),
+            spool=Spool(tmp_path / "spool"),
+        )
+        service.start()
+        startup.set_fleet_service(service)
+        return service
+
+    def test_running_service_with_new_channel_restarts_and_merges(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        old_service = self._running_multi_topic_service(tmp_path)
+
+        result = control.stream_topics(
+            channels=[{"topic": "/odom", "fields": ["y"], "rate_hz": 2}], events=None
+        )
+
+        new_service = startup.fleet_service()
+        assert new_service is not None
+        assert new_service is not old_service
+        names = {c["c"] for c in new_service.channels}
+        assert {"imu.x", "odom.y"} <= names
+        assert result["service"] == "running"
+        assert result["events"] == []
+
+    def test_same_topic_rule_is_replaced_not_duplicated(self, tmp_path: pathlib.Path) -> None:
+        self._running_multi_topic_service(tmp_path)
+
+        control.stream_topics(
+            channels=[{"topic": "/imu", "fields": ["x"], "rate_hz": 10}], events=None
+        )
+
+        new_service = startup.fleet_service()
+        assert len(new_service.streams.channels) == 1
+        assert new_service.streams.channels[0].rate_hz == 10.0
+
+    def test_manifest_persisted_and_reloadable(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        manifest_path = tmp_path / "manifest.yaml"
+        manifest_path.write_text(yaml.safe_dump({"subscriptions": []}))
+        monkeypatch.setattr(settings, "STARTUP_PIPELINES_FILE", str(manifest_path))
+        self._running_multi_topic_service(tmp_path)
+
+        result = control.stream_topics(
+            channels=[{"topic": "/odom", "fields": ["y"], "rate_hz": 2}], events=None
+        )
+
+        assert result["persisted"] is True
+        doc = yaml.safe_load(manifest_path.read_text())
+        reloaded = config.load_streams(doc)
+        assert reloaded is not None
+        topics = {rule.topic for rule in reloaded.channels}
+        assert {"/imu", "/odom"} <= topics
+
+    def test_no_service_but_a_covering_live_sink_starts_one(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        writer = FakeWriter(_imu_struct())
+        sink = FakeSink({"/imu": writer})
+        monkeypatch.setattr(sink_base, "live_sinks", lambda: [sink])
+        startup.set_fleet_service(None)
+
+        result = control.stream_topics(
+            channels=[{"topic": "/imu", "fields": ["x"], "rate_hz": 5}], events=None
+        )
+
+        assert result["service"] == "running"
+        assert startup.fleet_service() is not None
+
+    def test_no_covering_sink_raises_and_leaves_holder_and_manifest_untouched(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(sink_base, "live_sinks", lambda: [])
+        manifest_path = tmp_path / "manifest.yaml"
+        original = {"subscriptions": [{"sink": "mqtt"}]}
+        manifest_path.write_text(yaml.safe_dump(original))
+        monkeypatch.setattr(settings, "STARTUP_PIPELINES_FILE", str(manifest_path))
+        startup.set_fleet_service(None)
+
+        with pytest.raises(StreamConfigError):
+            control.stream_topics(
+                channels=[{"topic": "/imu", "fields": ["x"], "rate_hz": 5}], events=None
+            )
+
+        assert startup.fleet_service() is None
+        assert yaml.safe_load(manifest_path.read_text()) == original
+
+    def test_invalid_rule_dict_raises_before_any_restart(self, tmp_path: pathlib.Path) -> None:
+        service = self._running_multi_topic_service(tmp_path)
+
+        with pytest.raises(StreamConfigError):
+            control.stream_topics(channels=[{"topic": "/imu", "rate_hz": 5}], events=None)
+
+        assert startup.fleet_service() is service
+
+    def test_no_manifest_file_configured_persisted_false_but_rules_live(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(settings, "STARTUP_PIPELINES_FILE", None)
+        writer = FakeWriter(_imu_struct())
+        sink = FakeSink({"/imu": writer})
+        monkeypatch.setattr(sink_base, "live_sinks", lambda: [sink])
+
+        result = control.stream_topics(
+            channels=[{"topic": "/imu", "fields": ["x"], "rate_hz": 5}], events=None
+        )
+
+        assert result["persisted"] is False
+        assert startup.fleet_service() is not None
+
+
+class TestStopStreams:
+    """`stop_streams` removes rules by resolved name; unknown names are idempotent no-ops."""
+
+    @pytest.fixture(autouse=True)
+    def _enrolled(self) -> None:
+        _write_identity(pathlib.Path(settings.FLEET_IDENTITY_DIRECTORY))
+
+    def _service_with_streams(
+        self, tmp_path: pathlib.Path, streams: object, topic: str = "/imu"
+    ) -> FleetService:
+        struct = pa.struct([pa.field("x", pa.float64()), pa.field("y", pa.float64())])
+        sink = FakeSink({topic: FakeWriter(struct)})
+        service = FleetService(
+            sink=sink, streams=streams, publisher=FakePublisher(), spool=Spool(tmp_path / "spool")
+        )
+        service.start()
+        startup.set_fleet_service(service)
+        return service
+
+    def test_removes_renamed_channel_by_its_renamed_name(self, tmp_path: pathlib.Path) -> None:
+        streams = config.StreamsConfig.build(
+            {
+                "channels": [
+                    {"topic": "/imu", "fields": ["x"], "rate_hz": 50, "as": {"x": "accel.x"}}
+                ]
+            }
+        )
+        self._service_with_streams(tmp_path, streams)
+
+        result = control.stop_streams(channels=["accel.x"], events=None)
+
+        new_service = startup.fleet_service()
+        assert new_service.streams.channels == []
+        assert result["changed"] is True
+
+    def test_partial_field_removal_keeps_rule_with_remaining_field(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        streams = config.StreamsConfig.build(
+            {"channels": [{"topic": "/imu", "fields": ["x", "y"], "rate_hz": 50}]}
+        )
+        self._service_with_streams(tmp_path, streams)
+
+        result = control.stop_streams(channels=["imu.x"], events=None)
+
+        new_service = startup.fleet_service()
+        assert len(new_service.streams.channels) == 1
+        assert new_service.streams.channels[0].fields == ["y"]
+        assert result["changed"] is True
+
+    def test_rule_dropped_when_all_its_fields_go(self, tmp_path: pathlib.Path) -> None:
+        streams = config.StreamsConfig.build(
+            {"channels": [{"topic": "/imu", "fields": ["x", "y"], "rate_hz": 50}]}
+        )
+        self._service_with_streams(tmp_path, streams)
+
+        control.stop_streams(channels=["imu.x", "imu.y"], events=None)
+
+        assert startup.fleet_service().streams.channels == []
+
+    def test_geo_rule_removed_by_its_name(self, tmp_path: pathlib.Path) -> None:
+        streams = config.StreamsConfig.build(
+            {"channels": [{"topic": "/nav/odom", "geo": {"lat": "x", "lon": "y"}, "rate_hz": 1}]}
+        )
+        self._service_with_streams(tmp_path, streams, topic="/nav/odom")
+
+        result = control.stop_streams(channels=["odom.geo"], events=None)
+
+        assert startup.fleet_service().streams.channels == []
+        assert result["changed"] is True
+
+    def test_event_removed_by_name(self, tmp_path: pathlib.Path) -> None:
+        streams = config.StreamsConfig.build(
+            {
+                "channels": [],
+                "events": [{"name": "hard_decel", "topic": "/imu", "predicate": "true"}],
+            }
+        )
+        self._service_with_streams(tmp_path, streams)
+
+        result = control.stop_streams(channels=None, events=["hard_decel"])
+
+        assert startup.fleet_service().streams.events == []
+        assert result["changed"] is True
+
+    def test_unknown_name_is_a_no_op_and_does_not_restart(self, tmp_path: pathlib.Path) -> None:
+        service, _pub = _running_service(tmp_path)
+        startup.set_fleet_service(service)
+
+        result = control.stop_streams(channels=["nope.x"], events=["nope"])
+
+        assert result["changed"] is False
+        assert startup.fleet_service() is service
+
+    def test_emptying_config_keeps_service_running_with_alive_heartbeat(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        manifest_path = tmp_path / "manifest.yaml"
+        manifest_path.write_text(yaml.safe_dump({"subscriptions": []}))
+        monkeypatch.setattr(settings, "STARTUP_PIPELINES_FILE", str(manifest_path))
+        service, _pub = _running_service(tmp_path)
+        startup.set_fleet_service(service)
+
+        result = control.stop_streams(channels=["imu.x"], events=None)
+
+        new_service = startup.fleet_service()
+        assert new_service is not None
+        assert new_service.status()["heartbeat_alive"] is True
+        assert result["service"] == "running"
+        doc = yaml.safe_load(manifest_path.read_text())
+        assert doc["streams"]["channels"] == []
+        assert doc["streams"]["events"] == []
+        assert config.load_streams(doc) is not None

--- a/test/sink/publish/test_control.py
+++ b/test/sink/publish/test_control.py
@@ -9,6 +9,7 @@ raises before the holder is ever touched.
 
 import importlib
 import pathlib
+import stat
 import sys
 
 import pyarrow as pa
@@ -551,6 +552,22 @@ class TestPersistStreamsManifestHandling:
         doc = yaml.safe_load(manifest_path.read_text())
         assert doc == {"streams": {"channels": [], "events": []}}
 
+    def test_preserves_the_manifest_files_existing_permission_mode(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`tempfile.mkstemp` creates at 0600 by default -- without copying the
+        pre-existing file's mode onto the tempfile before `os.replace`, a
+        manifest a human left more permissive (or read-only) would silently
+        end up 0600 after its first control-plane write."""
+        manifest_path = tmp_path / "manifest.yaml"
+        manifest_path.write_text(yaml.safe_dump({"subscriptions": []}))
+        manifest_path.chmod(0o644)
+        monkeypatch.setattr(settings, "STARTUP_PIPELINES_FILE", str(manifest_path))
+
+        control._persist_streams({"channels": [], "events": []})
+
+        assert stat.S_IMODE(manifest_path.stat().st_mode) == 0o644
+
 
 class TestStreamTopics:
     """`stream_topics` validates, merges onto the current config, restarts, persists."""
@@ -676,6 +693,93 @@ class TestStreamTopics:
         assert result["persisted"] is False
         assert startup.fleet_service() is not None
 
+    def test_uncovered_topic_raises_and_leaves_the_original_service_running(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        """Codex review (F1): the coverage check must run BEFORE the old service
+        is stopped -- a typo'd/uncovered topic must not destroy a working
+        service. The OLD service object stays in the holder (identity check,
+        not just "a" service) and is still fully functional afterward."""
+        old_service = self._running_multi_topic_service(tmp_path)
+
+        with pytest.raises(StreamConfigError):
+            control.stream_topics(
+                channels=[{"topic": "/typo/topic", "fields": ["x"], "rate_hz": 5}], events=None
+            )
+
+        assert startup.fleet_service() is old_service
+        assert startup.fleet_service().status() is not None
+
+    def test_load_identity_or_none_is_a_single_load_not_check_then_load(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Codex review (F2): `_restart_service` must not reintroduce the
+        `is_enrolled()` + separate `load_identity()` TOCTOU that Task 4's
+        carried finding removed from `fleet_status()`. `is_enrolled` lying
+        `True` while `load_identity` always raises proves this helper never
+        consults `is_enrolled` at all -- a two-call implementation would
+        propagate the raise."""
+        monkeypatch.setattr(identity, "is_enrolled", lambda *_a, **_kw: True)
+
+        def _raise(*_a: object, **_kw: object) -> None:
+            raise FleetNotEnrolledError("deleted between checks")
+
+        monkeypatch.setattr(identity, "load_identity", _raise)
+
+        assert control._load_identity_or_none() is None
+
+    def test_identity_resolution_failure_never_stops_the_old_service_first(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Codex review (F2): identity resolution must happen BEFORE the old
+        service is stopped, combined with F1's pre-checks. Forcing
+        `load_identity` to degrade to `None` (a deleted/corrupt identity)
+        means `resolve_publisher_kwargs` itself then raises
+        `FleetNotEnrolledError` (no broker configured, no identity) -- and
+        that must still leave the OLD service running, untouched."""
+        old_service = self._running_multi_topic_service(tmp_path)
+
+        def _raise(*_a: object, **_kw: object) -> None:
+            raise FleetNotEnrolledError("deleted between checks")
+
+        monkeypatch.setattr(identity, "load_identity", _raise)
+
+        with pytest.raises(FleetNotEnrolledError):
+            control.stream_topics(
+                channels=[{"topic": "/odom", "fields": ["y"], "rate_hz": 2}], events=None
+            )
+
+        assert startup.fleet_service() is old_service
+        assert startup.fleet_service().status() is not None
+
+    def test_event_rule_merge_by_name_through_stream_topics(self, tmp_path: pathlib.Path) -> None:
+        """Integration-level (F5c): the merge-by-name ruling for events, exercised
+        through the public `stream_topics` entry point rather than the
+        `_merge_by_key` unit alone."""
+        self._running_multi_topic_service(tmp_path)
+
+        control.stream_topics(
+            channels=None,
+            events=[{"name": "hard_decel", "topic": "/imu", "predicate": "x < -10"}],
+        )
+        result = control.stream_topics(
+            channels=None,
+            events=[
+                {
+                    "name": "hard_decel",
+                    "topic": "/imu",
+                    "predicate": "x < -20",
+                    "pre_seconds": 5,
+                }
+            ],
+        )
+
+        new_service = startup.fleet_service()
+        assert len(new_service.streams.events) == 1
+        assert new_service.streams.events[0].predicate == "x < -20"
+        assert new_service.streams.events[0].pre_seconds == 5.0
+        assert result["events"] == ["hard_decel"]
+
 
 class TestStopStreams:
     """`stop_streams` removes rules by resolved name; unknown names are idempotent no-ops."""
@@ -770,6 +874,25 @@ class TestStopStreams:
 
         assert result["changed"] is False
         assert startup.fleet_service() is service
+
+    def test_unknown_name_no_op_does_not_touch_a_manifest_with_no_streams_section(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Codex review (F3): a pure no-op must skip `_persist_streams` entirely --
+        not just skip the restart -- so a manifest with no `streams:` section
+        stays byte-identical and `persisted` truthfully reports `False`."""
+        manifest_path = tmp_path / "manifest.yaml"
+        original_text = yaml.safe_dump({"subscriptions": []})
+        manifest_path.write_text(original_text)
+        monkeypatch.setattr(settings, "STARTUP_PIPELINES_FILE", str(manifest_path))
+        service, _pub = _running_service(tmp_path)
+        startup.set_fleet_service(service)
+
+        result = control.stop_streams(channels=["nope.x"], events=["nope"])
+
+        assert result["changed"] is False
+        assert result["persisted"] is False
+        assert manifest_path.read_text() == original_text
 
     def test_emptying_config_keeps_service_running_with_alive_heartbeat(
         self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch

--- a/test/sink/publish/test_heartbeat.py
+++ b/test/sink/publish/test_heartbeat.py
@@ -194,9 +194,7 @@ class TestPyprojectVersionRegexFallback:
         )
         assert heartbeat_mod._pyproject_version(root=tmp_path) == "9.9.9"
 
-    def test_finds_the_version_line_among_surrounding_content(
-        self, tmp_path: pathlib.Path
-    ) -> None:
+    def test_finds_the_version_line_among_surrounding_content(self, tmp_path: pathlib.Path) -> None:
         (tmp_path / "pyproject.toml").write_text(
             '[project]\nname = "bagel"\nversion = "2.3.0"\n\n[tool.other]\nfoo = "bar"\n'
         )

--- a/test/sink/publish/test_identity.py
+++ b/test/sink/publish/test_identity.py
@@ -202,13 +202,19 @@ class _FakeRenewHandler(http.server.BaseHTTPRequestHandler):
             return
 
         robot_cert_pem, ca_cert_pem = _build_ca_and_robot_cert("renewed-cn", csr.public_key())
-        body = json.dumps(
-            {
-                "cert_pem": robot_cert_pem.decode(),
-                "ca_pem": ca_cert_pem.decode(),
-                "expires_at": "2028-01-01T00:00:00Z",
-            }
-        ).encode()
+        response_fields = {
+            "cert_pem": robot_cert_pem.decode(),
+            "ca_pem": ca_cert_pem.decode(),
+            "expires_at": "2028-01-01T00:00:00Z",
+        }
+        # A "renew-url:<base>" scenario (mirroring the enroll fake server's
+        # "renew-url:<base>" token convention) additionally returns that
+        # base as `renew_url` -- proves a renew response can itself rotate
+        # the renew base (staging->prod cutover) without re-enrollment. See
+        # TestRenewUrl's rotation tests.
+        if scenario.startswith("renew-url:"):
+            response_fields["renew_url"] = scenario[len("renew-url:") :]
+        body = json.dumps(response_fields).encode()
         self._respond(200, body)
 
     def _respond(self, status: int, body: bytes) -> None:
@@ -658,9 +664,7 @@ class TestMaybeEnrollOnFirstBootKillSwitch:
         with caplog.at_level(logging.DEBUG):
             identity_mod.maybe_enroll_on_first_boot()
 
-        assert any(
-            "FLEET_ENABLED" in record.getMessage() for record in caplog.records
-        )
+        assert any("FLEET_ENABLED" in record.getMessage() for record in caplog.records)
 
 
 class TestMaybeEnrollOnFirstBootNeverRaisesOnCorruptIdentity:
@@ -857,6 +861,120 @@ class TestRenewUrl:
         doc = yaml.safe_load((directory / "identity.yaml").read_text())
         assert doc["renew_url"] == fake_renew_server
 
+    def test_renew_response_can_rotate_renew_url_to_a_new_base(
+        self, fake_server: str, fake_renew_server: str, tmp_path: object
+    ) -> None:
+        # `_FakeRenewHandler` recognizes a "renew-url:<base>" scenario CN
+        # (mirroring the enroll fake server's "renew-url:<base>" token
+        # convention) and echoes that base back as the response's
+        # `renew_url` -- proving a renew response can itself rotate the
+        # base (e.g. a staging->prod cutover) without a fresh enrollment.
+        new_base = "https://renew2.example"
+        identity = _identity_for_renew(
+            fake_server, fake_renew_server, tmp_path, f"renew-url:{new_base}"
+        )
+        assert identity.renew_url is None  # starting state: no renew_url yet
+
+        result = identity_mod.renew(identity)
+
+        assert result is not None
+        assert result.renew_url == new_base
+        doc = yaml.safe_load((result.key_path.parent / "identity.yaml").read_text())
+        assert doc["renew_url"] == new_base
+
+    def test_renew_response_rotated_renew_url_is_targeted_by_the_next_renewal(
+        self,
+        fake_server: str,
+        fake_renew_server: str,
+        tmp_path: object,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        new_base = "https://renew2.example"
+        identity = _identity_for_renew(
+            fake_server, fake_renew_server, tmp_path, f"renew-url:{new_base}"
+        )
+        result = identity_mod.renew(identity)
+        assert result is not None
+        assert result.renew_url == new_base
+
+        # A follow-up renewal must target the NEW base, not the old
+        # fake_renew_server (identity.enroll_url) -- new_base is
+        # unreachable in this test (no real listener), so the POST itself
+        # fails, but the constructed request URL proves which host+path it
+        # targeted before that failure (same spy-on-Request technique as
+        # TestBaseUrlTrailingSlash/TestRenewUrlSchemeGate elsewhere in this
+        # file).
+        request_calls: list[str] = []
+        real_request = identity_mod.urllib.request.Request
+
+        def spy_request(url: str, *a: object, **kw: object) -> object:
+            request_calls.append(url)
+            return real_request(url, *a, **kw)
+
+        monkeypatch.setattr(identity_mod.urllib.request, "Request", spy_request)
+
+        follow_up = identity_mod.renew(result)
+
+        assert follow_up is None  # new_base is unreachable -- expected
+        assert request_calls == [f"{new_base}/v1/renew"]
+
+    def test_renew_without_renew_url_in_response_leaves_absent_value_unchanged(
+        self, fake_server: str, fake_renew_server: str, tmp_path: object
+    ) -> None:
+        # The "renew-ok" scenario's response never carries renew_url -- a
+        # renewal must not invent one when the identity never had one.
+        identity = _identity_for_renew(fake_server, fake_renew_server, tmp_path, "renew-ok")
+        assert identity.renew_url is None
+
+        result = identity_mod.renew(identity)
+
+        assert result is not None
+        assert result.renew_url is None
+        doc = yaml.safe_load((result.key_path.parent / "identity.yaml").read_text())
+        assert "renew_url" not in doc
+
+    def test_renew_without_renew_url_in_response_preserves_existing_value(
+        self, fake_server: str, fake_renew_server: str, tmp_path: object
+    ) -> None:
+        # Now the identity already HAS a renew_url (from a prior rotation);
+        # a subsequent renewal whose response omits renew_url entirely must
+        # not wipe it back to None -- absent means "no change", not "clear".
+        # The rotation target is fake_renew_server's OWN base (reachable),
+        # not an inert example.com host, so the follow-up renewal below can
+        # actually complete and prove the value survives it unchanged.
+        identity = _identity_for_renew(
+            fake_server, fake_renew_server, tmp_path, f"renew-url:{fake_renew_server}"
+        )
+        rotated = identity_mod.renew(identity)
+        assert rotated is not None
+        assert rotated.renew_url == fake_renew_server
+
+        again = dataclasses.replace(rotated, robot_id="renew-ok")
+        result = identity_mod.renew(again)
+
+        assert result is not None
+        assert result.renew_url == fake_renew_server  # unchanged, not wiped
+        doc = yaml.safe_load((result.key_path.parent / "identity.yaml").read_text())
+        assert doc["renew_url"] == fake_renew_server
+
+    def test_failed_renewal_leaves_renew_url_untouched(
+        self, fake_server: str, fake_renew_server: str, tmp_path: object
+    ) -> None:
+        new_base = "https://renew2.example"
+        identity = _identity_for_renew(
+            fake_server, fake_renew_server, tmp_path, f"renew-url:{new_base}"
+        )
+        rotated = identity_mod.renew(identity)
+        assert rotated is not None
+        assert rotated.renew_url == new_base
+
+        failing = dataclasses.replace(rotated, robot_id="renew-501", enroll_url=fake_renew_server)
+        result = identity_mod.renew(failing)
+
+        assert result is None
+        doc = yaml.safe_load((failing.key_path.parent / "identity.yaml").read_text())
+        assert doc["renew_url"] == new_base  # a failed attempt never touches it
+
 
 class TestEnrollUrlSchemeGate:
     """Codex review (3909074259): enroll() only checked that enroll_url was
@@ -998,9 +1116,7 @@ class TestBaseUrlTrailingSlash:
         tmp_path: object,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        identity = _identity_for_renew(
-            fake_server, f"{fake_renew_server}/", tmp_path, "renew-ok"
-        )
+        identity = _identity_for_renew(fake_server, f"{fake_renew_server}/", tmp_path, "renew-ok")
         assert identity.enroll_url == f"{fake_renew_server}/"  # renew_url absent -> falls back
 
         captured_urls: list[str] = []
@@ -1504,6 +1620,143 @@ class TestRenewNeverRaises:
         assert "last_renewal_attempt_at" in doc  # even an unexpected failure records the attempt
         warnings_ = [r for r in caplog.records if r.levelno == logging.WARNING]
         assert warnings_
+
+
+class TestDeleteIdentity:
+    """delete_identity() is the ONLY deletion path unenroll uses (see the brief).
+
+    It must: (1) be idempotent on a directory with no identity.yaml, (2)
+    sweep both the pointer set (from identity.yaml, when parsable) and the
+    module's own renewal-orphan naming patterns, (3) never unlink anything
+    before every pointer-set path has passed a resolved-containment check
+    against `directory`, and (4) tolerate a corrupt identity.yaml (still
+    remove what it safely can).
+    """
+
+    def test_delete_after_enroll_removes_all_four_files_and_the_empty_directory(
+        self, fake_server: str, tmp_path: object
+    ) -> None:
+        directory = tmp_path / "identity"
+        identity_mod.enroll(VALID_TOKEN, fake_server, directory)
+        assert directory.is_dir()
+
+        deleted = identity_mod.delete_identity(directory)
+
+        assert deleted == sorted(["robot.key", "robot.crt", "ca.crt", "identity.yaml"])
+        assert not directory.exists()
+
+    def test_delete_after_renewal_and_planted_orphans_removes_versioned_and_orphan_files(
+        self, fake_server: str, fake_renew_server: str, tmp_path: object
+    ) -> None:
+        identity = _identity_for_renew(fake_server, fake_renew_server, tmp_path, "renew-ok")
+        directory = identity.key_path.parent
+        result = identity_mod.renew(identity)
+        assert result is not None
+
+        # Renewal orphans identity.yaml no longer points at (e.g. left
+        # behind by a crash between step 1 and step 2 of a DIFFERENT
+        # renewal attempt) -- planted directly here rather than relying on
+        # renew()'s own best-effort cleanup, which already removes its own
+        # superseded files.
+        (directory / "robot-111.key").write_bytes(b"orphan-key")
+        (directory / "ca-222.crt").write_bytes(b"orphan-ca")
+
+        deleted = identity_mod.delete_identity(directory)
+
+        assert result.key_path.name in deleted
+        assert result.cert_path.name in deleted
+        assert result.ca_path.name in deleted
+        assert "identity.yaml" in deleted
+        assert "robot-111.key" in deleted
+        assert "ca-222.crt" in deleted
+        assert not directory.exists()
+
+    def test_traversal_pointer_raises_and_deletes_nothing(
+        self, fake_server: str, tmp_path: object
+    ) -> None:
+        directory = tmp_path / "identity"
+        identity_mod.enroll(VALID_TOKEN, fake_server, directory)
+        victim = tmp_path / "victim.key"
+        victim.write_bytes(b"victim-data")
+        doc = yaml.safe_load((directory / "identity.yaml").read_text())
+        doc["key_file"] = "../victim.key"
+        (directory / "identity.yaml").write_text(yaml.safe_dump(doc))
+
+        with pytest.raises(ValueError, match="escapes"):
+            identity_mod.delete_identity(directory)
+
+        assert victim.exists()
+        assert victim.read_bytes() == b"victim-data"
+        assert (directory / "identity.yaml").exists()
+        assert (directory / "robot.crt").exists()
+        assert (directory / "ca.crt").exists()
+
+    def test_symlinked_orphan_pattern_file_pointing_outside_is_skipped_target_intact(
+        self, fake_server: str, tmp_path: object
+    ) -> None:
+        directory = tmp_path / "identity"
+        identity_mod.enroll(VALID_TOKEN, fake_server, directory)
+        outside_target = tmp_path / "outside.key"
+        outside_target.write_bytes(b"outside-data")
+        escaping_symlink = directory / "robot-333.key"
+        escaping_symlink.symlink_to(outside_target)
+
+        deleted = identity_mod.delete_identity(directory)
+
+        assert outside_target.exists()
+        assert outside_target.read_bytes() == b"outside-data"
+        assert escaping_symlink.is_symlink()  # the escaping link itself is left alone
+        assert "robot-333.key" not in deleted
+        # The legitimate identity files are still cleaned up -- one
+        # escaping pattern-glob entry doesn't block the rest.
+        assert "robot.key" in deleted
+        assert "robot.crt" in deleted
+        assert "ca.crt" in deleted
+        assert "identity.yaml" in deleted
+        # The leftover symlink keeps the directory non-empty, so the
+        # best-effort rmdir() is a no-op (swallowed OSError).
+        assert directory.exists()
+
+    def test_missing_identity_yaml_returns_empty_list_and_does_not_raise(
+        self, tmp_path: object
+    ) -> None:
+        assert identity_mod.delete_identity(tmp_path / "never-enrolled") == []
+
+    def test_missing_identity_yaml_is_idempotent_on_repeat_calls(
+        self, fake_server: str, tmp_path: object
+    ) -> None:
+        directory = tmp_path / "identity"
+        identity_mod.enroll(VALID_TOKEN, fake_server, directory)
+        identity_mod.delete_identity(directory)
+        assert identity_mod.delete_identity(directory) == []  # unenroll's repeat call
+
+    def test_corrupt_identity_yaml_still_deletes_pattern_set_files_no_raise(
+        self, fake_server: str, tmp_path: object
+    ) -> None:
+        directory = tmp_path / "identity"
+        identity_mod.enroll(VALID_TOKEN, fake_server, directory)
+        (directory / "identity.yaml").write_text("not: valid: yaml: [")
+
+        deleted = identity_mod.delete_identity(directory)
+
+        assert "identity.yaml" in deleted
+        assert "robot.key" in deleted
+        assert "robot.crt" in deleted
+        assert "ca.crt" in deleted
+        assert not directory.exists()
+
+    def test_never_uses_shutil_rmtree(self, fake_server: str, tmp_path: object) -> None:
+        # Belt-and-braces against a future edit reaching for the "easy" full
+        # tree wipe -- delete_identity must only ever remove files it
+        # derived from the pointer set or the naming-pattern sweep.
+        directory = tmp_path / "identity"
+        identity_mod.enroll(VALID_TOKEN, fake_server, directory)
+        (directory / "unrelated-file.txt").write_bytes(b"leave me alone")
+
+        identity_mod.delete_identity(directory)
+
+        assert directory.exists()  # not empty (unrelated file survives) -- rmdir is a no-op
+        assert (directory / "unrelated-file.txt").exists()
 
 
 class TestFailedRenewalLeavesIdentityIntact:

--- a/test/sink/publish/test_mqtt_publisher.py
+++ b/test/sink/publish/test_mqtt_publisher.py
@@ -251,6 +251,16 @@ class TestClose:
         fake["client"].next_info = FakeMsgInfo(published=False)
         p.close()  # must not raise
 
+    @pytest.mark.parametrize("reason", ["stopped", "paused"])
+    def test_close_reason_flows_into_clean_stop_payload(
+        self, fake: dict[str, FakeFleetPaho], reason: str
+    ) -> None:
+        p = _publisher()
+        p.connect()
+        p.close(reason=reason)
+        stop = [c for c in fake["client"].calls if c[0] == "publish"][-1]
+        assert json.loads(stop[2])["reason"] == reason
+
 
 class TestSetTls:
     """CRITICAL fix: a post-renewal reconnect must pick up the NEW cert/key paths.
@@ -272,9 +282,7 @@ class TestSetTls:
         )
         old_tls = p._tls
 
-        p.set_tls(
-            tls_ca_certs="/new-ca.pem", tls_certfile="/new-c.pem", tls_keyfile="/new-k.pem"
-        )
+        p.set_tls(tls_ca_certs="/new-ca.pem", tls_certfile="/new-c.pem", tls_keyfile="/new-k.pem")
 
         assert p._tls is not old_tls  # a NEW dict, not an in-place mutation
         assert p._tls == {
@@ -303,9 +311,7 @@ class TestSetTls:
             "keyfile": "/old-k.pem",
         }
 
-        p.set_tls(
-            tls_ca_certs="/new-ca.pem", tls_certfile="/new-c.pem", tls_keyfile="/new-k.pem"
-        )
+        p.set_tls(tls_ca_certs="/new-ca.pem", tls_certfile="/new-c.pem", tls_keyfile="/new-k.pem")
         p.connect()  # forced reconnect, e.g. after a broker drop
 
         assert fake["client"].tls == {

--- a/test/sink/publish/test_router.py
+++ b/test/sink/publish/test_router.py
@@ -456,9 +456,7 @@ class TestStreamRouterThread:
 
 
 class TestTickChunksOversizedFlush:
-    def test_tick_spools_each_chunk_with_its_own_seq_in_order(
-        self, tmp_path: pathlib.Path
-    ) -> None:
+    def test_tick_spools_each_chunk_with_its_own_seq_in_order(self, tmp_path: pathlib.Path) -> None:
         # Codex review (3909414784): every chunk of a capped flush must get
         # its own seq and its own spool append within one tick, not just the
         # first chunk. connect_should_fail keeps _pump from acking anything,

--- a/test/sink/publish/test_selftest.py
+++ b/test/sink/publish/test_selftest.py
@@ -142,11 +142,63 @@ class TestRunSelftest:
         spool = Spool(tmp_path / "spool")
         spool.append("channels", 1, {"pre": 1})
         spool.append("channels", 2, {"pre": 2})
+        spool.ack("channels", 2)
 
         pub = FakePublisher()
         run_selftest(pub, spool, batches=2, interval_s=0.0)
 
         assert [b["seq"] for b in pub.channel_calls] == [3, 4]
+
+    def test_pending_channels_backlog_refuses_before_any_side_effect(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        """C1 (critical): a paused service's queued-but-unsent channels backlog
+        must never be silently advanced-past by the selftest's own acks."""
+        from src.sink.publish.selftest import SelftestPreconditionError, run_selftest
+
+        spool = Spool(tmp_path / "spool")
+        spool.append("channels", 1, {"pre": 1})  # pending: never acked
+
+        pub = FakePublisher()
+
+        with pytest.raises(SelftestPreconditionError, match="channels"):
+            run_selftest(pub, spool, batches=2, interval_s=0.0)
+
+        # Nothing appended/acked/connected -- the precondition check runs
+        # before any side effect.
+        assert pub.calls == []
+        assert list(spool.pending("channels")) == [(1, {"pre": 1})]
+        assert list(spool.pending("events")) == []
+
+    def test_pending_events_backlog_refuses_before_any_side_effect(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        """C1 (critical): same ruling for the events lane."""
+        from src.sink.publish.selftest import SelftestPreconditionError, run_selftest
+
+        spool = Spool(tmp_path / "spool")
+        spool.append("events", 1, {"pre": 1})  # pending: never acked
+
+        pub = FakePublisher()
+
+        with pytest.raises(SelftestPreconditionError, match="events"):
+            run_selftest(pub, spool, batches=2, interval_s=0.0)
+
+        assert pub.calls == []
+        assert list(spool.pending("channels")) == []
+        assert list(spool.pending("events")) == [(1, {"pre": 1})]
+
+    def test_empty_lanes_runs_without_a_precondition_error(self, tmp_path: pathlib.Path) -> None:
+        """C1: the precondition check must not false-positive on a fresh/fully-
+        acked spool -- the common case."""
+        from src.sink.publish.selftest import run_selftest
+
+        spool = Spool(tmp_path / "spool")
+        pub = FakePublisher()
+
+        result = run_selftest(pub, spool, batches=1, interval_s=0.0)
+
+        assert result["batches"] == 1
 
 
 class TestMain:
@@ -216,6 +268,24 @@ class TestMain:
         assert captured["publisher"] is sentinel
         assert captured["kwargs"]["batches"] == 3
         assert captured["kwargs"]["interval_s"] == 0.0
+
+    def test_load_identity_or_none_is_a_single_load_not_check_then_load(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """M4 (mirrors control._load_identity_or_none's identical regression
+        test): a corrupt/deleted identity must degrade to `None` via a single
+        `load_identity()` call caught here, not a separate `is_enrolled()`
+        check followed by a `load_identity()` call that could TOCTOU-race it.
+        """
+        import src.sink.publish.selftest as selftest_mod
+        from src.sink.publish import FleetNotEnrolledError
+
+        def _raise(*_a: object, **_kw: object) -> None:
+            raise FleetNotEnrolledError("deleted between checks")
+
+        monkeypatch.setattr(selftest_mod, "load_identity", _raise)
+
+        assert selftest_mod._load_identity_or_none(pathlib.Path("/nonexistent")) is None
 
 
 # -- e2e: gated on a real broker, same idiom as test_mqtt_integration.py. --------

--- a/test/sink/publish/test_selftest.py
+++ b/test/sink/publish/test_selftest.py
@@ -1,0 +1,279 @@
+"""Fleet selftest: conformance-checks the wire protocol without a robot (spec §8)."""
+
+import importlib
+import json
+import os
+import pathlib
+import queue
+import sys
+import time
+import uuid
+from urllib.parse import urlparse
+
+import pytest
+
+from publish.conftest import FakePublisher
+from settings import settings
+from src.sink.publish.publisher import PublishError
+from src.sink.publish.spool import Spool
+
+BROKER = os.environ.get("MQTT_TEST_BROKER")
+
+REQUIRED_EVENT_KEYS = {
+    "v",
+    "seq",
+    "event_id",
+    "name",
+    "t_start",
+    "t_end",
+    "source_topic",
+    "summary",
+}
+
+
+def test_selftest_module_does_not_import_paho_or_cryptography_eagerly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for name in [
+        m
+        for m in sys.modules
+        if m == "paho"
+        or m.startswith("paho.")
+        or m == "cryptography"
+        or m.startswith("cryptography.")
+    ]:
+        monkeypatch.delitem(sys.modules, name)
+    monkeypatch.delitem(sys.modules, "src.sink.publish.selftest", raising=False)
+    importlib.import_module("src.sink.publish.selftest")
+    assert not any(
+        m == "paho" or m.startswith("paho.") or m == "cryptography" or m.startswith("cryptography.")
+        for m in sys.modules
+    )
+
+
+class TestRunSelftest:
+    def test_happy_path_call_order_and_payloads(self, tmp_path: pathlib.Path) -> None:
+        from src.sink.publish.selftest import SELFTEST_CHANNELS, run_selftest
+
+        pub = FakePublisher()
+        spool = Spool(tmp_path / "spool")
+
+        result = run_selftest(pub, spool, batches=5, interval_s=0.0, now=lambda: 1000.0)
+
+        # -- call order: connect, schema first, then 5 channel batches, then
+        # heartbeat, then one event, then close last.
+        assert pub.calls == ["connect", "schema"] + ["channels"] * 5 + [
+            "heartbeat",
+            "events",
+            "close",
+        ]
+
+        # -- schema payload is the fixed four-channel conformance schema.
+        assert pub.schema_calls == [{"v": 1, "channels": SELFTEST_CHANNELS}]
+
+        # -- batches: strictly monotonic seqs, deterministic values.
+        seqs = [batch["seq"] for batch in pub.channel_calls]
+        assert seqs == sorted(seqs)
+        assert len(set(seqs)) == len(seqs)
+        for i, batch in enumerate(pub.channel_calls):
+            assert batch["v"] == 1
+            assert batch["t_batch"] == 1000.0
+            assert batch["samples"] == [
+                {"c": "selftest.number", "t": 1000.0, "v": float(i)},
+                {"c": "selftest.bool", "t": 1000.0, "v": i % 2 == 0},
+                {"c": "selftest.string", "t": 1000.0, "v": f"selftest-{i}"},
+                {
+                    "c": "selftest.geo",
+                    "t": 1000.0,
+                    "v": {"lat": 52.0 + i * 0.001, "lon": 13.0 + i * 0.001},
+                },
+            ]
+
+        # -- one retained heartbeat, with spool.evicted present.
+        assert len(pub.heartbeat_calls) == 1
+        assert "evicted" in pub.heartbeat_calls[0]["spool"]
+
+        # -- one events payload with every §3 required key.
+        assert len(pub.event_calls) == 1
+        assert REQUIRED_EVENT_KEYS <= set(pub.event_calls[0])
+        assert pub.event_calls[0]["name"] == "selftest"
+
+        # -- close last, spool left with zero pending on both lanes (acks ran).
+        assert pub.close_calls == 1
+        assert list(spool.pending("channels")) == []
+        assert list(spool.pending("events")) == []
+
+        # -- return summary.
+        assert result["channels"] == 4
+        assert result["batches"] == 5
+        assert result["heartbeat"] == 1
+        assert result["events"] == 1
+        assert result["channels_seq"] == [seqs[0], seqs[-1]]
+        assert result["events_seq"] == pub.event_calls[0]["seq"]
+
+    def test_cleanup_on_failure_acks_past_last_appended_seq(self, tmp_path: pathlib.Path) -> None:
+        from src.sink.publish.selftest import run_selftest
+
+        pub = FakePublisher(fail_at_channel_call=3)
+        spool = Spool(tmp_path / "spool")
+
+        with pytest.raises(PublishError):
+            run_selftest(pub, spool, batches=5, interval_s=0.0)
+
+        # Batches 1-2 fully acked already; batch 3's append must be cleaned
+        # up (acked away) too -- nothing lingers for the real service.
+        assert list(spool.pending("channels")) == []
+        assert list(spool.pending("events")) == []
+        # Never reached the heartbeat/events/close steps.
+        assert pub.heartbeat_calls == []
+        assert pub.event_calls == []
+        assert pub.close_calls == 0
+
+    def test_seqs_continue_from_preseeded_spool(self, tmp_path: pathlib.Path) -> None:
+        from src.sink.publish.selftest import run_selftest
+
+        spool = Spool(tmp_path / "spool")
+        spool.append("channels", 1, {"pre": 1})
+        spool.append("channels", 2, {"pre": 2})
+
+        pub = FakePublisher()
+        run_selftest(pub, spool, batches=2, interval_s=0.0)
+
+        assert [b["seq"] for b in pub.channel_calls] == [3, 4]
+
+
+class TestMain:
+    def test_fleet_disabled_returns_1_no_publisher_constructed(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        import src.sink.publish.selftest as selftest_mod
+
+        monkeypatch.setattr(settings, "FLEET_ENABLED", False)
+
+        def _boom(*args: object, **kwargs: object) -> None:
+            raise AssertionError("MqttPublisher must not be constructed")
+
+        monkeypatch.setattr(selftest_mod, "MqttPublisher", _boom)
+
+        rc = selftest_mod.main([])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "FLEET_ENABLED" in err
+
+    def test_unenrolled_no_broker_returns_1(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        import src.sink.publish.selftest as selftest_mod
+
+        monkeypatch.setattr(settings, "FLEET_ENABLED", True)
+        monkeypatch.setattr(settings, "FLEET_IDENTITY_DIRECTORY", str(tmp_path / "identity"))
+
+        rc = selftest_mod.main([])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert err.strip() != ""
+
+    def test_dev_broker_returns_0_and_prints_summary(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        import src.sink.publish.selftest as selftest_mod
+
+        monkeypatch.setattr(settings, "FLEET_ENABLED", True)
+        monkeypatch.setattr(settings, "FLEET_DEV_INSECURE", True)
+        monkeypatch.setattr(settings, "FLEET_IDENTITY_DIRECTORY", str(tmp_path / "identity"))
+        monkeypatch.setattr(settings, "CACHE_DIRECTORY", str(tmp_path))
+
+        sentinel = object()
+        summary = {"channels": 4, "batches": 3, "samples": 12, "heartbeat": 1, "events": 1}
+        captured: dict = {}
+
+        def fake_mqtt_publisher(*args: object, **kwargs: object) -> object:
+            captured["publisher_args"] = (args, kwargs)
+            return sentinel
+
+        def fake_run_selftest(publisher: object, spool: object, **kwargs: object) -> dict:
+            captured["publisher"] = publisher
+            captured["spool"] = spool
+            captured["kwargs"] = kwargs
+            return summary
+
+        monkeypatch.setattr(selftest_mod, "MqttPublisher", fake_mqtt_publisher)
+        monkeypatch.setattr(selftest_mod, "run_selftest", fake_run_selftest)
+
+        rc = selftest_mod.main(
+            ["--broker", "mqtt://localhost:1883", "--batches", "3", "--interval-s", "0"]
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert json.loads(out) == summary
+        assert captured["publisher"] is sentinel
+        assert captured["kwargs"]["batches"] == 3
+        assert captured["kwargs"]["interval_s"] == 0.0
+
+
+# -- e2e: gated on a real broker, same idiom as test_mqtt_integration.py. --------
+
+
+@pytest.mark.skipif(not BROKER, reason="MQTT_TEST_BROKER not set")
+def test_selftest_e2e_round_trip(monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path) -> None:
+    import paho.mqtt.client as paho
+
+    import src.sink.publish.selftest as selftest_mod
+
+    inbox: queue.Queue[tuple[str, bytes, bool]] = queue.Queue()
+    client = paho.Client(
+        callback_api_version=paho.CallbackAPIVersion.VERSION2,
+        client_id=f"sub-{uuid.uuid4().hex[:8]}",
+        protocol=paho.MQTTv5,
+    )
+    client.on_message = lambda cl, ud, msg: inbox.put((msg.topic, msg.payload, msg.retain))
+    parsed = urlparse(BROKER)
+    client.connect(parsed.hostname, parsed.port or 1883)
+    client.loop_start()
+    client.subscribe("bagel/v1/dev/robot/#", qos=1)
+    time.sleep(0.3)
+
+    monkeypatch.setattr(settings, "FLEET_ENABLED", True)
+    monkeypatch.setattr(settings, "FLEET_DEV_INSECURE", True)
+    monkeypatch.setattr(settings, "FLEET_IDENTITY_DIRECTORY", str(tmp_path / "identity"))
+    monkeypatch.setattr(settings, "CACHE_DIRECTORY", str(tmp_path))
+
+    try:
+        rc = selftest_mod.main(["--broker", BROKER, "--batches", "3", "--interval-s", "0"])
+        assert rc == 0
+
+        got: dict[str, list[tuple[bytes, bool]]] = {}
+
+        def _drain_all(timeout: float = 5.0) -> None:
+            deadline = time.time() + timeout
+            while time.time() < deadline:
+                try:
+                    topic, payload, retain = inbox.get(timeout=max(0.0, deadline - time.time()))
+                except queue.Empty:
+                    return
+                got.setdefault(topic, []).append((payload, retain))
+
+        _drain_all()
+
+        schema_topic = "bagel/v1/dev/robot/schema"
+        channels_topic = "bagel/v1/dev/robot/channels"
+        heartbeat_topic = "bagel/v1/dev/robot/heartbeat"
+        events_topic = "bagel/v1/dev/robot/events"
+
+        assert schema_topic in got
+        assert channels_topic in got and len(got[channels_topic]) == 3
+        seqs = [json.loads(p)["seq"] for p, _ in got[channels_topic]]
+        assert seqs == sorted(seqs)
+        assert heartbeat_topic in got
+        assert events_topic in got and len(got[events_topic]) == 1
+
+        heartbeats = [json.loads(p) for p, _ in got[heartbeat_topic]]
+        assert heartbeats[-1] == {
+            "v": 1,
+            "t": heartbeats[-1]["t"],
+            "online": False,
+            "reason": "stopped",
+        }
+    finally:
+        client.loop_stop()
+        client.disconnect()

--- a/test/sink/publish/test_selftest.py
+++ b/test/sink/publish/test_selftest.py
@@ -111,6 +111,13 @@ class TestRunSelftest:
         assert result["channels_seq"] == [seqs[0], seqs[-1]]
         assert result["events_seq"] == pub.event_calls[0]["seq"]
 
+        # -- "samples" counts what was actually published, not a formula:
+        # pin it against the real per-batch sample counts captured on the
+        # FakePublisher, not just the expected 5*4 total.
+        total_captured_samples = sum(len(batch["samples"]) for batch in pub.channel_calls)
+        assert result["samples"] == 5 * 4
+        assert result["samples"] == total_captured_samples
+
     def test_cleanup_on_failure_acks_past_last_appended_seq(self, tmp_path: pathlib.Path) -> None:
         from src.sink.publish.selftest import run_selftest
 

--- a/test/sink/publish/test_service.py
+++ b/test/sink/publish/test_service.py
@@ -68,6 +68,25 @@ class FakeSink:
     def subscribed_topics(self) -> list[str]:
         return list(self._buffers)
 
+    def buffer_writer(self, topic: str) -> FakeWriter:
+        return self._buffers[topic]
+
+
+class FakeSinkNoPrivateBuffers:
+    """Duck-typed TopicSink WITHOUT a `_buffers` attribute -- only the public
+    `buffer_writer`/`subscribed_topics` seam. Proves `FleetService.start()` no
+    longer reaches into `_buffers` directly."""
+
+    def __init__(self, buffers: dict[str, FakeWriter]) -> None:
+        self._writers_by_topic = buffers  # deliberately NOT named `_buffers`
+
+    @property
+    def subscribed_topics(self) -> list[str]:
+        return list(self._writers_by_topic)
+
+    def buffer_writer(self, topic: str) -> FakeWriter:
+        return self._writers_by_topic[topic]
+
 
 class FakePublisher(Publisher):
     """In-memory Publisher double: records every kind of publish; can fail on demand."""
@@ -222,6 +241,81 @@ class TestStart:
         try:
             with pytest.raises(RuntimeError, match="already started"):
                 service.start()
+        finally:
+            service.stop()
+
+
+class TestSinkSurface:
+    """Task 3: `start()` builds taps via `sink.buffer_writer()`, never `sink._buffers`
+    directly, plus the `sink`/`streams`/`channels` accessors Task 4 needs."""
+
+    def test_start_works_with_a_sink_that_has_no_private_buffers_attribute(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        writer = FakeWriter(_imu_struct())
+        sink = FakeSinkNoPrivateBuffers({"/imu": writer})
+        service = FleetService(
+            sink=sink,
+            streams=_imu_streams(),
+            publisher=FakePublisher(),
+            spool=Spool(tmp_path / "spool"),
+        )
+        service.start()
+        try:
+            assert writer._tap is not None
+        finally:
+            service.stop()
+
+    def test_sink_property_returns_the_constructor_sink(self, tmp_path: pathlib.Path) -> None:
+        sink = FakeSink({})
+        service = FleetService(
+            sink=sink,
+            streams=_imu_streams(),
+            publisher=FakePublisher(),
+            spool=Spool(tmp_path / "spool"),
+        )
+        assert service.sink is sink
+
+    def test_streams_property_returns_the_constructor_streams(self, tmp_path: pathlib.Path) -> None:
+        streams = _imu_streams()
+        service = FleetService(
+            sink=FakeSink({}),
+            streams=streams,
+            publisher=FakePublisher(),
+            spool=Spool(tmp_path / "spool"),
+        )
+        assert service.streams is streams
+
+    def test_channels_returns_the_resolved_schema_channels(self, tmp_path: pathlib.Path) -> None:
+        writer = FakeWriter(_imu_struct())
+        sink = FakeSink({"/imu": writer})
+        service = FleetService(
+            sink=sink,
+            streams=_imu_streams(),
+            publisher=FakePublisher(),
+            spool=Spool(tmp_path / "spool"),
+        )
+        service.start()
+        try:
+            assert service.channels == service._schema_payload["channels"]
+        finally:
+            service.stop()
+
+    def test_channels_returns_a_copy_not_a_live_reference(self, tmp_path: pathlib.Path) -> None:
+        writer = FakeWriter(_imu_struct())
+        sink = FakeSink({"/imu": writer})
+        service = FleetService(
+            sink=sink,
+            streams=_imu_streams(),
+            publisher=FakePublisher(),
+            spool=Spool(tmp_path / "spool"),
+        )
+        service.start()
+        try:
+            channels = service.channels
+            channels.append({"bogus": "entry"})
+            assert service.channels == service._schema_payload["channels"]
+            assert {"bogus": "entry"} not in service._schema_payload["channels"]
         finally:
             service.stop()
 

--- a/test/sink/publish/test_service.py
+++ b/test/sink/publish/test_service.py
@@ -8,18 +8,25 @@ import sys
 import time
 import types
 
-import pyarrow as pa
 import pytest
 
+from publish.conftest import (
+    FakePublisher,
+    FakeSink,
+    FakeSinkNoPrivateBuffers,
+    FakeWriter,
+    _fake_identity,
+    _imu_streams,
+    _imu_struct,
+    _wait_until,
+)
 from publish.test_identity import VALID_TOKEN, fake_renew_server, fake_server
 from src.sink.publish import StreamConfigError
 from src.sink.publish import identity as identity_mod
 from src.sink.publish import mqtt as publish_mqtt
 from src.sink.publish import service as service_mod
-from src.sink.publish.config import StreamsConfig
 from src.sink.publish.identity import Identity
 from src.sink.publish.mqtt import MqttPublisher
-from src.sink.publish.publisher import Publisher, PublishError
 from src.sink.publish.service import FleetService
 from src.sink.publish.spool import Spool
 
@@ -34,141 +41,6 @@ def test_service_module_does_not_import_paho_eagerly(monkeypatch: pytest.MonkeyP
     monkeypatch.delitem(sys.modules, "src.sink.publish.service", raising=False)
     importlib.import_module("src.sink.publish.service")
     assert not any(m == "paho" or m.startswith("paho.") for m in sys.modules)
-
-
-class FakeWriter:
-    """Duck-typed stand-in for TopicBufferWriter: struct + set_tap recording."""
-
-    def __init__(self, struct: pa.StructType) -> None:
-        self._struct = struct
-        self._tap = None
-        self.tap_calls: list[object] = []
-
-    @property
-    def struct(self) -> pa.StructType:
-        return self._struct
-
-    def set_tap(self, tap: object) -> None:
-        self._tap = tap
-        self.tap_calls.append(tap)
-
-    def feed(self, topic: str, t: float, msg: dict) -> None:
-        """Simulate a live message arriving: fire the tap, like buffer.append() does."""
-        if self._tap is not None:
-            self._tap(topic, t, msg)
-
-
-class FakeSink:
-    """Duck-typed stand-in for TopicSink: a `_buffers` dict, like the real sink."""
-
-    def __init__(self, buffers: dict[str, FakeWriter]) -> None:
-        self._buffers = buffers
-
-    @property
-    def subscribed_topics(self) -> list[str]:
-        return list(self._buffers)
-
-    def buffer_writer(self, topic: str) -> FakeWriter:
-        return self._buffers[topic]
-
-
-class FakeSinkNoPrivateBuffers:
-    """Duck-typed TopicSink WITHOUT a `_buffers` attribute -- only the public
-    `buffer_writer`/`subscribed_topics` seam. Proves `FleetService.start()` no
-    longer reaches into `_buffers` directly."""
-
-    def __init__(self, buffers: dict[str, FakeWriter]) -> None:
-        self._writers_by_topic = buffers  # deliberately NOT named `_buffers`
-
-    @property
-    def subscribed_topics(self) -> list[str]:
-        return list(self._writers_by_topic)
-
-    def buffer_writer(self, topic: str) -> FakeWriter:
-        return self._writers_by_topic[topic]
-
-
-class FakePublisher(Publisher):
-    """In-memory Publisher double: records every kind of publish; can fail on demand."""
-
-    def __init__(self, *, connect_should_fail: bool = False) -> None:
-        self.connect_should_fail = connect_should_fail
-        self.connect_calls = 0
-        self.schema_calls: list[dict] = []
-        self.channel_calls: list[dict] = []
-        self.heartbeat_calls: list[dict] = []
-        self.close_calls = 0
-        self.reconnects = 0
-        self._connected = False
-
-    def connect(self) -> None:
-        self.connect_calls += 1
-        if self.connect_should_fail:
-            raise PublishError("connect failed")
-        self._connected = True
-
-    def publish(
-        self, kind: str, payload: dict, *, retain: bool = False, timeout_s: float = 10.0
-    ) -> None:
-        if kind == "schema":
-            self.schema_calls.append(payload)
-        elif kind == "channels":
-            self.channel_calls.append(payload)
-        elif kind == "heartbeat":
-            self.heartbeat_calls.append(payload)
-        else:
-            raise AssertionError(f"FakePublisher: unexpected kind {kind!r}")
-
-    def close(self) -> None:
-        self.close_calls += 1
-        self._connected = False
-
-    @property
-    def connected(self) -> bool:
-        return self._connected
-
-
-def _imu_streams(**overrides: object) -> StreamsConfig:
-    config = {
-        "flush_interval_s": overrides.pop("flush_interval_s", 0.05),
-        "channels": [{"topic": "/imu", "fields": ["x"], "rate_hz": 50.0}],
-    }
-    config.update(overrides)
-    return StreamsConfig.build(config)
-
-
-def _imu_struct() -> pa.StructType:
-    return pa.struct([pa.field("x", pa.float64())])
-
-
-def _wait_until(predicate: object, timeout_s: float = 2.0) -> bool:
-    deadline = time.monotonic() + timeout_s
-    while time.monotonic() < deadline:
-        if predicate():
-            return True
-        time.sleep(0.01)
-    return predicate()
-
-
-def _fake_identity(tmp_path: pathlib.Path, expires_at: str = "2027-01-01T00:00:00Z") -> Identity:
-    """A well-formed Identity pointing at files that don't need to exist for these tests.
-
-    Nothing here does a live mTLS POST -- these tests monkeypatch
-    `service_mod.renew`/`service_mod.should_attempt_renewal` directly rather
-    than exercising the real transport (that's `test_identity.py`'s job), so
-    the cert/key/ca paths never actually need to be read.
-    """
-    directory = tmp_path / "identity"
-    return Identity(
-        tenant="acme",
-        robot_id="robot-42",
-        broker_url="mqtts://fleet.example.com:8883",
-        enroll_url="https://enroll.example.com",
-        expires_at=expires_at,
-        key_path=directory / "robot.key",
-        cert_path=directory / "robot.crt",
-        ca_path=directory / "ca.crt",
-    )
 
 
 class TestStart:
@@ -431,6 +303,72 @@ class TestPauseResume:
             assert service._router.is_alive()
         finally:
             service.stop()
+
+
+class TestPauseReasonAndPausedProperty:
+    """Task 4: `pause()`'s clean-stop heartbeat carries `reason="paused"` (spec §3);
+    `stop()` keeps the default `"stopped"`. `paused` exposes `_started and _paused`
+    for `control.fleet_status()`'s "running"/"paused"/"stopped" service state."""
+
+    def test_pause_closes_with_reason_paused(self, tmp_path: pathlib.Path) -> None:
+        writer = FakeWriter(_imu_struct())
+        sink = FakeSink({"/imu": writer})
+        pub = FakePublisher()
+        service = FleetService(
+            sink=sink, streams=_imu_streams(), publisher=pub, spool=Spool(tmp_path / "spool")
+        )
+        service.start()
+        try:
+            service.pause()
+            assert pub.close_reasons == ["paused"]
+        finally:
+            service.stop()
+
+    def test_stop_closes_with_reason_stopped(self, tmp_path: pathlib.Path) -> None:
+        writer = FakeWriter(_imu_struct())
+        sink = FakeSink({"/imu": writer})
+        pub = FakePublisher()
+        service = FleetService(
+            sink=sink, streams=_imu_streams(), publisher=pub, spool=Spool(tmp_path / "spool")
+        )
+        service.start()
+        service.stop()
+        assert pub.close_reasons == ["stopped"]
+
+    def test_pause_then_stop_records_both_reasons_in_order(self, tmp_path: pathlib.Path) -> None:
+        writer = FakeWriter(_imu_struct())
+        sink = FakeSink({"/imu": writer})
+        pub = FakePublisher()
+        service = FleetService(
+            sink=sink, streams=_imu_streams(), publisher=pub, spool=Spool(tmp_path / "spool")
+        )
+        service.start()
+        service.pause()
+        service.resume()
+        service.stop()
+        assert pub.close_reasons == ["paused", "stopped"]
+
+    def test_paused_property_truth_table(self, tmp_path: pathlib.Path) -> None:
+        writer = FakeWriter(_imu_struct())
+        sink = FakeSink({"/imu": writer})
+        pub = FakePublisher()
+        service = FleetService(
+            sink=sink, streams=_imu_streams(), publisher=pub, spool=Spool(tmp_path / "spool")
+        )
+        assert service.paused is False  # fresh: never started
+
+        service.start()
+        try:
+            assert service.paused is False  # started, not paused
+
+            service.pause()
+            assert service.paused is True  # paused
+
+            service.resume()
+            assert service.paused is False  # resumed
+        finally:
+            service.stop()
+        assert service.paused is False  # stopped
 
 
 class TestStatus:

--- a/test/sink/publish/test_spool.py
+++ b/test/sink/publish/test_spool.py
@@ -483,6 +483,75 @@ class TestStats:
         assert st.bytes > 0
 
 
+class TestNeverCappedLanes:
+    def test_init_rejects_heartbeat_in_capped_lanes(self, root: pathlib.Path) -> None:
+        """Spool.__init__ must reject heartbeat in capped_lanes."""
+        with pytest.raises(ValueError, match="heartbeat") as exc_info:
+            Spool(root, capped_lanes={"heartbeat": 1024})
+        assert "never-drop" in str(exc_info.value)
+
+    def test_init_accepts_channels_in_capped_lanes(self, root: pathlib.Path) -> None:
+        """Spool.__init__ must accept channels in capped_lanes."""
+        s = Spool(root, capped_lanes={"channels": 1024})
+        assert s._capped == {"channels": 1024}
+
+    def test_init_rejects_mixed_heartbeat_and_channels_in_capped_lanes(
+        self,
+        root: pathlib.Path,
+    ) -> None:
+        """Spool.__init__ must reject when heartbeat is mixed with other capped lanes."""
+        with pytest.raises(ValueError, match="heartbeat") as exc_info:
+            Spool(root, capped_lanes={"channels": 1024, "heartbeat": 1})
+        assert "never-drop" in str(exc_info.value)
+
+    def test_oversized_heartbeat_record_is_written_not_dropped(
+        self, root: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Oversized record on heartbeat lane must be written, not dropped."""
+        monkeypatch.setattr(spool_mod, "SEGMENT_MAX_BYTES", 200)
+        s = Spool(root)
+        giant = {"pad": "x" * 1000}
+        s.append("heartbeat", 1, giant)
+        assert [seq for seq, _ in s.pending("heartbeat")] == [1]
+        assert s.stats()["heartbeat"].evicted == 0
+
+    def test_oversized_capped_lane_record_is_dropped(
+        self, root: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Oversized record on capped lane must be dropped (existing behavior)."""
+        monkeypatch.setattr(spool_mod, "SEGMENT_MAX_BYTES", 200)
+        s = Spool(root, capped_lanes={"channels": 1000})
+        giant = {"pad": "x" * 1000}
+        s.append("channels", 1, giant)
+        assert [seq for seq, _ in s.pending("channels")] == []
+        assert s.stats()["channels"].evicted == 1
+
+    def test_heartbeat_lane_not_evicted_when_other_lanes_capped(
+        self, root: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Heartbeat records must never be evicted, even when other lanes are capped."""
+        monkeypatch.setattr(spool_mod, "SEGMENT_MAX_BYTES", 120)
+        s = Spool(root, capped_lanes={"channels": 300})
+        # Write heartbeat records far exceeding the channels cap
+        for i in range(1, 30):
+            s.append("heartbeat", i, {"pad": "x" * 40, "n": i})
+        # Every heartbeat record should still be pending
+        assert len([seq for seq, _ in s.pending("heartbeat")]) == 29
+        # No eviction should have occurred
+        assert s.stats()["heartbeat"].evicted == 0
+
+    def test_for_robot_caps_only_channels(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """for_robot must cap only channels, never heartbeat or events."""
+        monkeypatch.setattr("settings.settings.CACHE_DIRECTORY", str(tmp_path))
+        monkeypatch.setattr("settings.settings.FLEET_SPOOL_MAX_BYTES", 500)
+        s = Spool.for_robot("r7")
+        assert s._capped == {"channels": 500}
+        assert "heartbeat" not in s._capped
+        assert "events" not in s._capped
+
+
 class TestForRobot:
     def test_for_robot_single_segment_nests_correctly(
         self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch

--- a/test/sink/publish/test_stream_e2e.py
+++ b/test/sink/publish/test_stream_e2e.py
@@ -105,7 +105,7 @@ def _drain(inbox: Inbox, topic: str, timeout_s: float = 10.0) -> tuple[str, byte
 
 
 class FakeSink:
-    """Minimal TopicSink double: the `_buffers`/`subscribed_topics` seam FleetService uses."""
+    """Minimal TopicSink double: the `buffer_writer`/`subscribed_topics` seam FleetService uses."""
 
     def __init__(self, buffers: dict[str, "TopicBufferWriter"]) -> None:
         self._buffers = buffers
@@ -113,6 +113,9 @@ class FakeSink:
     @property
     def subscribed_topics(self) -> list[str]:
         return list(self._buffers)
+
+    def buffer_writer(self, topic: str) -> "TopicBufferWriter":
+        return self._buffers[topic]
 
 
 def _real_writer(tmp_path: pathlib.Path, topic: str = "/imu") -> "TopicBufferWriter":

--- a/test/sink/test_sink_surface.py
+++ b/test/sink/test_sink_surface.py
@@ -1,0 +1,136 @@
+"""Sink surface for fleet taps (spec §2): public buffer accessor, live-sink listing,
+and close hooks.
+
+Uses a minimal `base.TopicSink` subclass (mirrors test_admission.py's `_FakeSink`)
+rather than the MQTT `make_sink` fixture, since none of this needs a live broker.
+"""
+
+import itertools
+import logging
+import pathlib
+
+import pyarrow as pa
+import pytest
+
+from settings import settings
+from src.sink import base
+from src.sink.base import TopicNotFoundError
+from src.sink.buffer import TopicBufferWriter
+
+_port_counter = itertools.count(21000)
+
+
+class _FakeSink(base.TopicSink):
+    def _connect(self) -> None:
+        pass
+
+    def _disconnect(self) -> None:
+        pass
+
+    def _available_topics(self) -> list[str]:
+        return ["/a", "/b"]
+
+    def _type_name(self, topic: str) -> str:
+        return "test/type"
+
+    def _definition(self, topic: str) -> str:
+        return "float64 x"
+
+    def _struct(self, topic: str) -> pa.StructType:
+        return pa.struct([pa.field("x", pa.float64())])
+
+    def _subscribe(self, writer: TopicBufferWriter) -> None:
+        pass
+
+    def _unsubscribe(self, writer: TopicBufferWriter) -> None:
+        pass
+
+
+@pytest.fixture
+def sink(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> _FakeSink:
+    monkeypatch.setattr(settings, "CACHE_DIRECTORY", str(tmp_path))
+    return _FakeSink("localhost", next(_port_counter))
+
+
+@pytest.fixture(autouse=True)
+def _clear_close_hooks() -> None:
+    """Isolate each test's hook registrations from the others (and from startup.py's
+    own module-scope registration, which is not imported by this test module)."""
+    saved = list(base._close_hooks)
+    base._close_hooks.clear()
+    yield
+    base._close_hooks[:] = saved
+
+
+class TestBufferWriter:
+    def test_returns_the_same_object_as_buffers(self, sink: _FakeSink) -> None:
+        sink.subscribe("/a")
+        assert sink.buffer_writer("/a") is sink._buffers["/a"]
+
+    def test_unknown_topic_raises_topic_not_found_error(self, sink: _FakeSink) -> None:
+        with pytest.raises(TopicNotFoundError):
+            sink.buffer_writer("/nope")
+
+
+class TestLiveSinks:
+    def test_returns_all_live_singletons(
+        self, sink: _FakeSink, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(settings, "CACHE_DIRECTORY", str(sink.directory.parent))
+        other = _FakeSink("localhost", next(_port_counter))
+        try:
+            live = base.live_sinks()
+            assert sink in live
+            assert other in live
+        finally:
+            other.close()
+
+    def test_is_a_snapshot_copy(self, sink: _FakeSink) -> None:
+        live = base.live_sinks()
+        live.append("not-a-real-sink")
+        assert "not-a-real-sink" not in base.live_sinks()
+
+
+class TestCloseHooks:
+    def test_fires_on_close_with_the_sink_instance(self, sink: _FakeSink) -> None:
+        seen = []
+        base.register_close_hook(seen.append)
+        sink.close()
+        assert seen == [sink]
+
+    def test_raising_hook_is_swallowed_and_close_still_completes(
+        self, sink: _FakeSink, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        def boom(_sink: object) -> None:
+            raise RuntimeError("hook exploded")
+
+        base.register_close_hook(boom)
+        with caplog.at_level(logging.WARNING):
+            sink.close()  # must not raise
+        assert any("hook exploded" in record.getMessage() for record in caplog.records) or any(
+            record.exc_info for record in caplog.records
+        )
+
+    def test_unregister_stops_delivery(self, sink: _FakeSink) -> None:
+        seen = []
+        unregister = base.register_close_hook(seen.append)
+        unregister()
+        sink.close()
+        assert seen == []
+
+    def test_unregister_is_idempotent(self, sink: _FakeSink) -> None:
+        unregister = base.register_close_hook(lambda _s: None)
+        unregister()
+        unregister()  # must not raise
+
+    def test_hooks_fire_before_buffers_are_popped(self, sink: _FakeSink) -> None:
+        sink.subscribe("/a")
+        seen_subscribed_topics = []
+
+        def hook(s: object) -> None:
+            seen_subscribed_topics.append(list(s.subscribed_topics))
+
+        base.register_close_hook(hook)
+        sink.close()
+
+        assert seen_subscribed_topics == [["/a"]]

--- a/test/sink/test_sink_surface.py
+++ b/test/sink/test_sink_surface.py
@@ -107,8 +107,14 @@ class TestCloseHooks:
         base.register_close_hook(boom)
         with caplog.at_level(logging.WARNING):
             sink.close()  # must not raise
-        assert any("hook exploded" in record.getMessage() for record in caplog.records) or any(
-            record.exc_info for record in caplog.records
+        # Pin the actual log message base.py emits ("Close hook %r raised
+        # while closing sink %r", exc_info=True) -- not a looser "either the
+        # message or exc_info" check, which would also pass a message that
+        # says nothing useful as long as SOME record carried a traceback.
+        assert any(
+            "Close hook" in record.getMessage()
+            and "raised while closing sink" in record.getMessage()
+            for record in caplog.records
         )
 
     def test_unregister_stops_delivery(self, sink: _FakeSink) -> None:

--- a/test/sink/test_startup_streams.py
+++ b/test/sink/test_startup_streams.py
@@ -458,6 +458,90 @@ class TestFleetFailures:
         assert startup._FLEET_SERVICE is None
 
 
+class TestSinkCloseStopsFleetService:
+    """Task 3: `TopicSink.close()` -> `FleetService.stop()` coupling (spec §2; step 6's
+    ruling B retired) -- wired via `base.register_close_hook`."""
+
+    def test_closing_the_fleet_sink_stops_the_service(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _write_identity(pathlib.Path(settings.FLEET_IDENTITY_DIRECTORY))
+        monkeypatch.setattr(startup.MqttPublisher, "connect", lambda self: None)
+
+        closed_publishers: list[object] = []
+        real_close = startup.MqttPublisher.close
+
+        def spy_close(self: object) -> None:
+            closed_publishers.append(self)
+            real_close(self)
+
+        monkeypatch.setattr(startup.MqttPublisher, "close", spy_close)
+
+        fake = FakePahoClient()
+        fake.retained = {"robot/telemetry": [b'{"speed": 1.5, "t": 100.0}']}
+        monkeypatch.setattr(sink_mqtt.paho, "Client", lambda **_: fake)
+
+        entry = _subscription_entry("manifest.test", "robot/telemetry")
+        manifest = {
+            "subscriptions": [entry],
+            "streams": {
+                "channels": [{"topic": "robot/telemetry", "fields": ["speed"], "rate_hz": 1}]
+            },
+        }
+        manifest_file = _write_manifest(tmp_path, manifest)
+
+        reports = startup.start(manifest_file)
+        assert reports[-1] == {"fleet": "started"}
+        service = startup.fleet_service()
+        assert service is not None
+        sink = service.sink
+
+        sink.close()
+
+        assert startup.fleet_service() is None
+        assert service._publisher in closed_publishers
+
+    def test_closing_an_unrelated_sink_leaves_the_service_running(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _write_identity(pathlib.Path(settings.FLEET_IDENTITY_DIRECTORY))
+        monkeypatch.setattr(startup.MqttPublisher, "connect", lambda self: None)
+
+        fake = FakePahoClient()
+        fake.retained = {"robot/telemetry": [b'{"speed": 1.5, "t": 100.0}']}
+        monkeypatch.setattr(sink_mqtt.paho, "Client", lambda **_: fake)
+
+        entry = _subscription_entry("manifest.test", "robot/telemetry")
+        manifest = {
+            "subscriptions": [entry],
+            "streams": {
+                "channels": [{"topic": "robot/telemetry", "fields": ["speed"], "rate_hz": 1}]
+            },
+        }
+        manifest_file = _write_manifest(tmp_path, manifest)
+
+        reports = startup.start(manifest_file)
+        assert reports[-1] == {"fleet": "started"}
+        service = startup.fleet_service()
+        assert service is not None
+
+        other_fake = FakePahoClient()
+        monkeypatch.setattr(sink_mqtt.paho, "Client", lambda **_: other_fake)
+        unrelated_sink = sink_mqtt.TopicSink(
+            host="unrelated.test",
+            port=next(_PORT_COUNTER),
+            discovery_seconds=0.0,
+            timestamp_field="t",
+        )
+        try:
+            unrelated_sink.close()
+
+            assert startup.fleet_service() is service
+            assert service._started is True
+        finally:
+            service.stop()
+
+
 class TestNoStreamsKey:
     def test_manifest_without_streams_key_produces_no_fleet_report_entry(
         self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch

--- a/test/test_tool_annotations.py
+++ b/test/test_tool_annotations.py
@@ -7,6 +7,11 @@ whether caller-selected external endpoints can be reached (open-world).
 A new tool fails here until it classifies itself.
 """
 
+import importlib
+import sys
+
+import pytest
+
 import server
 
 # name: (read_only, idempotent, destructive, open_world)
@@ -30,6 +35,13 @@ EXPECTED = {
     "export_for_lichtblick": (False, True, False, False),
     "export_for_lerobot": (False, True, False, False),
     "snap_hardware": (False, False, False, False),
+    "enroll_fleet_identity": (False, False, False, True),
+    "stream_live_topics": (False, False, False, True),
+    "stop_live_streams": (False, True, False, True),
+    "pause_fleet_streaming": (False, True, False, True),
+    "resume_fleet_streaming": (False, True, False, True),
+    "describe_stream_status": (True, True, False, False),
+    "unenroll_fleet_identity": (False, True, True, False),
 }
 
 
@@ -52,3 +64,30 @@ def test_annotations_match_the_declared_matrix() -> None:
             annotations.openWorldHint,
         )
         assert got == (read_only, idempotent, destructive, open_world), name
+
+
+def test_server_module_does_not_import_paho_or_cryptography_eagerly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Lazy-import regression: server.py now imports `control` at module scope
+    (alongside the existing `fleet_identity` import) to register the fleet
+    tools below -- neither drags paho or cryptography in eagerly (see each
+    module's own docstring), mirroring test_control.py's/test_service.py's
+    sweep idiom.
+    """
+    stray = [
+        m
+        for m in sys.modules
+        if m == "paho"
+        or m.startswith("paho.")
+        or m == "cryptography"
+        or m.startswith("cryptography.")
+    ]
+    if stray:
+        pytest.skip(f"paho/cryptography already preloaded by another plugin: {stray}")
+    monkeypatch.delitem(sys.modules, "server", raising=False)
+    importlib.import_module("server")
+    assert not any(
+        m == "paho" or m.startswith("paho.") or m == "cryptography" or m.startswith("cryptography.")
+        for m in sys.modules
+    )


### PR DESCRIPTION
## Summary

Fleet step 7: the fleet subsystem becomes operable conversationally and verifiable without a robot.

**Seven MCP tools** (annotations per spec §5's matrix, all classified in `test/test_tool_annotations.py`):
`enroll_fleet_identity`, `stream_live_topics`, `stop_live_streams`, `pause_fleet_streaming`, `resume_fleet_streaming`, `describe_stream_status`, `unenroll_fleet_identity` — thin passthroughs over a new `src/sink/publish/control.py`, with a module-level lock serializing lifecycle transitions (MCP workers may run tools concurrently).

**Rulings encoded** (full trail in the internal ledger):
- `describe_stream_status` and `unenroll_fleet_identity` bypass the fleet gate: status is §7's local source of truth and must answer in every state (not-installed / disabled / unenrolled / stopped — all report, never raise); unenroll only makes the subsystem more inert and must work to decommission a robot.
- `delete_identity()` is the ONLY deletion path for unenroll — resolve+containment checks before any unlink (refusal deletes nothing), pattern sweep limited to the module's own filenames, symlink targets never followed, no recursive deletes.
- Renew-response `renew_url` handling: the `/v1/renew` 200 body may rotate the renewal base (BASE semantics, absent = no change) — enables renewal-endpoint cutover without re-enrollment (client side; documented as pending on the fleet-service side in the runbook).
- Rule changes restart the service (validate-everything-before-stopping-the-old ordering; a validation failure leaves the running service untouched); paused state survives rule changes (brief reconnect to republish the retained schema, then re-pause).
- Heartbeat lane structurally cannot be byte-capped (`NEVER_CAPPED_LANES` constructor refusal) — never-drop is unreachable-by-construction, not a branch.
- Clean pause publishes `{"online": false, "reason": "paused"}` per §3 (as-built deviation fixed to spec).
- Selftest refuses to run over a pending spool backlog (advance-to acks would silently discard unsent data; drain or explicitly discard first).

**Selftest** (`uv run python -m src.sink.publish.selftest`): publishes a fixed 4-type schema, deterministic batches, a heartbeat, and an event through the real spool lanes — a fleet service can validate ingestion end-to-end without a robot.

**Docs**: `doc/fleet_protocol_v1.md` (full public v1 wire contract as built — every field cross-checked against code; independently re-verified by a second review), `doc/runbooks/fleet_streaming.md` (token pitfalls incl. crash-after-200 burn, kill-switch scope incl. first-boot enrollment, rotation interim, selftest procedure), `plugin/skills/operating-fleet-streams/SKILL.md`.

**Sink surface** (carried step-6 concerns, both addressed): public `TopicSink.buffer_writer()` retires the `_buffers` reach-in; `register_close_hook()` + a startup hook stops the fleet service when its sink closes (spec §2).

## Testing

- `uv run pytest test/*.py test/pipeline test/sink -q` — 727+ passed; publish tree 572 passed, 13 skipped after the final fix wave.
- Selftest e2e verified against a live mosquitto (8/8).
- Two pre-existing `test_preview_pipeline.py` failures reproduce on main — unrelated, tracked separately.
- Every task went through implementer → scoped review (fix rounds where needed) → final whole-branch review on the full range → one fix wave → scoped re-review (ALL ADDRESSED).

Merge order note: this PR follows #212 (both target `beta/fleet-streaming`; #212 touches the same identity/compose region).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
