### PR TITLE
fix(fleet): Codex final-round fixes — selftest spool lock, event-rule honesty, compose identity guard

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -20,11 +20,10 @@ services:
       # unconditionally like FLEET_ENABLED itself so flipping FLEET_ENABLED
       # at runtime never also requires editing this file. Unset host vars
       # resolve to Settings' own defaults inside the container (empty
-      # string is falsy for the two optional str fields; the identity
-      # directory default below matches the volume mount below).
+      # string is falsy for the two optional str fields). FLEET_IDENTITY_DIRECTORY
+      # is deliberately NOT forwarded -- see the volume mount below.
       FLEET_ENROLL_TOKEN: ${FLEET_ENROLL_TOKEN:-}
       FLEET_ENROLL_URL: ${FLEET_ENROLL_URL:-}
-      FLEET_IDENTITY_DIRECTORY: ${FLEET_IDENTITY_DIRECTORY:-/home/ubuntu/.bagel/identity}
       FLEET_DEV_INSECURE: ${FLEET_DEV_INSECURE:-false}
       MCP_SERVER_PORT: ${MCP_SERVER_PORT}
       # Containers must listen on all container interfaces for Docker port
@@ -54,9 +53,11 @@ services:
       # `docker compose run` lives only in that one-off container's
       # writable layer: it is lost the moment the container exits, and
       # because FLEET_ENROLL_TOKEN is single-use, a later run cannot
-      # re-enroll to replace it (Codex review). Must match
-      # FLEET_IDENTITY_DIRECTORY above. On Linux, run
+      # re-enroll to replace it (Codex review). On Linux, run
       # `mkdir -p ~/.bagel/identity` once so the directory is owned by you.
+      # Identity lives on this volume; to relocate it, change the HOST side
+      # of this mapping -- do not set FLEET_IDENTITY_DIRECTORY inside the
+      # container (writes would land off-volume and be lost).
       - ${HOME}/.bagel/identity:/home/ubuntu/.bagel/identity
       # - <path-to-local-data>:/home/ubuntu/data
 
@@ -81,11 +82,10 @@ services:
       # unconditionally like FLEET_ENABLED itself so flipping FLEET_ENABLED
       # at runtime never also requires editing this file. Unset host vars
       # resolve to Settings' own defaults inside the container (empty
-      # string is falsy for the two optional str fields; the identity
-      # directory default below matches the volume mount below).
+      # string is falsy for the two optional str fields). FLEET_IDENTITY_DIRECTORY
+      # is deliberately NOT forwarded -- see the volume mount below.
       FLEET_ENROLL_TOKEN: ${FLEET_ENROLL_TOKEN:-}
       FLEET_ENROLL_URL: ${FLEET_ENROLL_URL:-}
-      FLEET_IDENTITY_DIRECTORY: ${FLEET_IDENTITY_DIRECTORY:-/home/ubuntu/.bagel/identity}
       FLEET_DEV_INSECURE: ${FLEET_DEV_INSECURE:-false}
       MCP_SERVER_PORT: ${MCP_SERVER_PORT}
       # Containers must listen on all container interfaces for Docker port
@@ -115,9 +115,11 @@ services:
       # `docker compose run` lives only in that one-off container's
       # writable layer: it is lost the moment the container exits, and
       # because FLEET_ENROLL_TOKEN is single-use, a later run cannot
-      # re-enroll to replace it (Codex review). Must match
-      # FLEET_IDENTITY_DIRECTORY above. On Linux, run
+      # re-enroll to replace it (Codex review). On Linux, run
       # `mkdir -p ~/.bagel/identity` once so the directory is owned by you.
+      # Identity lives on this volume; to relocate it, change the HOST side
+      # of this mapping -- do not set FLEET_IDENTITY_DIRECTORY inside the
+      # container (writes would land off-volume and be lost).
       - ${HOME}/.bagel/identity:/home/ubuntu/.bagel/identity
       # - <path-to-local-data>:/home/ubuntu/data
 
@@ -142,11 +144,10 @@ services:
       # unconditionally like FLEET_ENABLED itself so flipping FLEET_ENABLED
       # at runtime never also requires editing this file. Unset host vars
       # resolve to Settings' own defaults inside the container (empty
-      # string is falsy for the two optional str fields; the identity
-      # directory default below matches the volume mount below).
+      # string is falsy for the two optional str fields). FLEET_IDENTITY_DIRECTORY
+      # is deliberately NOT forwarded -- see the volume mount below.
       FLEET_ENROLL_TOKEN: ${FLEET_ENROLL_TOKEN:-}
       FLEET_ENROLL_URL: ${FLEET_ENROLL_URL:-}
-      FLEET_IDENTITY_DIRECTORY: ${FLEET_IDENTITY_DIRECTORY:-/home/ubuntu/.bagel/identity}
       FLEET_DEV_INSECURE: ${FLEET_DEV_INSECURE:-false}
       MCP_SERVER_PORT: ${MCP_SERVER_PORT}
       # Containers must listen on all container interfaces for Docker port
@@ -176,9 +177,11 @@ services:
       # `docker compose run` lives only in that one-off container's
       # writable layer: it is lost the moment the container exits, and
       # because FLEET_ENROLL_TOKEN is single-use, a later run cannot
-      # re-enroll to replace it (Codex review). Must match
-      # FLEET_IDENTITY_DIRECTORY above. On Linux, run
+      # re-enroll to replace it (Codex review). On Linux, run
       # `mkdir -p ~/.bagel/identity` once so the directory is owned by you.
+      # Identity lives on this volume; to relocate it, change the HOST side
+      # of this mapping -- do not set FLEET_IDENTITY_DIRECTORY inside the
+      # container (writes would land off-volume and be lost).
       - ${HOME}/.bagel/identity:/home/ubuntu/.bagel/identity
       # - <path-to-local-data>:/home/ubuntu/data
 
@@ -203,11 +206,10 @@ services:
       # unconditionally like FLEET_ENABLED itself so flipping FLEET_ENABLED
       # at runtime never also requires editing this file. Unset host vars
       # resolve to Settings' own defaults inside the container (empty
-      # string is falsy for the two optional str fields; the identity
-      # directory default below matches the volume mount below).
+      # string is falsy for the two optional str fields). FLEET_IDENTITY_DIRECTORY
+      # is deliberately NOT forwarded -- see the volume mount below.
       FLEET_ENROLL_TOKEN: ${FLEET_ENROLL_TOKEN:-}
       FLEET_ENROLL_URL: ${FLEET_ENROLL_URL:-}
-      FLEET_IDENTITY_DIRECTORY: ${FLEET_IDENTITY_DIRECTORY:-/home/ubuntu/.bagel/identity}
       FLEET_DEV_INSECURE: ${FLEET_DEV_INSECURE:-false}
       MCP_SERVER_PORT: ${MCP_SERVER_PORT}
       # Containers must listen on all container interfaces for Docker port
@@ -237,9 +239,11 @@ services:
       # `docker compose run` lives only in that one-off container's
       # writable layer: it is lost the moment the container exits, and
       # because FLEET_ENROLL_TOKEN is single-use, a later run cannot
-      # re-enroll to replace it (Codex review). Must match
-      # FLEET_IDENTITY_DIRECTORY above. On Linux, run
+      # re-enroll to replace it (Codex review). On Linux, run
       # `mkdir -p ~/.bagel/identity` once so the directory is owned by you.
+      # Identity lives on this volume; to relocate it, change the HOST side
+      # of this mapping -- do not set FLEET_IDENTITY_DIRECTORY inside the
+      # container (writes would land off-volume and be lost).
       - ${HOME}/.bagel/identity:/home/ubuntu/.bagel/identity
       # - <path-to-local-data>:/home/ubuntu/data
 
@@ -263,11 +267,10 @@ services:
       # unconditionally like FLEET_ENABLED itself so flipping FLEET_ENABLED
       # at runtime never also requires editing this file. Unset host vars
       # resolve to Settings' own defaults inside the container (empty
-      # string is falsy for the two optional str fields; the identity
-      # directory default below matches the volume mount below).
+      # string is falsy for the two optional str fields). FLEET_IDENTITY_DIRECTORY
+      # is deliberately NOT forwarded -- see the volume mount below.
       FLEET_ENROLL_TOKEN: ${FLEET_ENROLL_TOKEN:-}
       FLEET_ENROLL_URL: ${FLEET_ENROLL_URL:-}
-      FLEET_IDENTITY_DIRECTORY: ${FLEET_IDENTITY_DIRECTORY:-/home/ubuntu/.bagel/identity}
       FLEET_DEV_INSECURE: ${FLEET_DEV_INSECURE:-false}
       MCP_SERVER_PORT: ${MCP_SERVER_PORT}
       # Containers must listen on all container interfaces for Docker port
@@ -295,9 +298,11 @@ services:
       # `docker compose run` lives only in that one-off container's
       # writable layer: it is lost the moment the container exits, and
       # because FLEET_ENROLL_TOKEN is single-use, a later run cannot
-      # re-enroll to replace it (Codex review). Must match
-      # FLEET_IDENTITY_DIRECTORY above. On Linux, run
+      # re-enroll to replace it (Codex review). On Linux, run
       # `mkdir -p ~/.bagel/identity` once so the directory is owned by you.
+      # Identity lives on this volume; to relocate it, change the HOST side
+      # of this mapping -- do not set FLEET_IDENTITY_DIRECTORY inside the
+      # container (writes would land off-volume and be lost).
       - ${HOME}/.bagel/identity:/home/ubuntu/.bagel/identity
       # - <path-to-local-data>:/home/ubuntu/data
 
@@ -321,11 +326,10 @@ services:
       # unconditionally like FLEET_ENABLED itself so flipping FLEET_ENABLED
       # at runtime never also requires editing this file. Unset host vars
       # resolve to Settings' own defaults inside the container (empty
-      # string is falsy for the two optional str fields; the identity
-      # directory default below matches the volume mount below).
+      # string is falsy for the two optional str fields). FLEET_IDENTITY_DIRECTORY
+      # is deliberately NOT forwarded -- see the volume mount below.
       FLEET_ENROLL_TOKEN: ${FLEET_ENROLL_TOKEN:-}
       FLEET_ENROLL_URL: ${FLEET_ENROLL_URL:-}
-      FLEET_IDENTITY_DIRECTORY: ${FLEET_IDENTITY_DIRECTORY:-/home/ubuntu/.bagel/identity}
       FLEET_DEV_INSECURE: ${FLEET_DEV_INSECURE:-false}
       MCP_SERVER_PORT: ${MCP_SERVER_PORT}
       # Containers must listen on all container interfaces for Docker port
@@ -353,9 +357,11 @@ services:
       # `docker compose run` lives only in that one-off container's
       # writable layer: it is lost the moment the container exits, and
       # because FLEET_ENROLL_TOKEN is single-use, a later run cannot
-      # re-enroll to replace it (Codex review). Must match
-      # FLEET_IDENTITY_DIRECTORY above. On Linux, run
+      # re-enroll to replace it (Codex review). On Linux, run
       # `mkdir -p ~/.bagel/identity` once so the directory is owned by you.
+      # Identity lives on this volume; to relocate it, change the HOST side
+      # of this mapping -- do not set FLEET_IDENTITY_DIRECTORY inside the
+      # container (writes would land off-volume and be lost).
       - ${HOME}/.bagel/identity:/home/ubuntu/.bagel/identity
       # - <path-to-local-data>:/home/ubuntu/data
 
@@ -378,11 +384,10 @@ services:
       # unconditionally like FLEET_ENABLED itself so flipping FLEET_ENABLED
       # at runtime never also requires editing this file. Unset host vars
       # resolve to Settings' own defaults inside the container (empty
-      # string is falsy for the two optional str fields; the identity
-      # directory default below matches the volume mount below).
+      # string is falsy for the two optional str fields). FLEET_IDENTITY_DIRECTORY
+      # is deliberately NOT forwarded -- see the volume mount below.
       FLEET_ENROLL_TOKEN: ${FLEET_ENROLL_TOKEN:-}
       FLEET_ENROLL_URL: ${FLEET_ENROLL_URL:-}
-      FLEET_IDENTITY_DIRECTORY: ${FLEET_IDENTITY_DIRECTORY:-/home/ubuntu/.bagel/identity}
       FLEET_DEV_INSECURE: ${FLEET_DEV_INSECURE:-false}
       MCP_SERVER_PORT: ${MCP_SERVER_PORT}
       # Containers must listen on all container interfaces for Docker port
@@ -410,9 +415,11 @@ services:
       # `docker compose run` lives only in that one-off container's
       # writable layer: it is lost the moment the container exits, and
       # because FLEET_ENROLL_TOKEN is single-use, a later run cannot
-      # re-enroll to replace it (Codex review). Must match
-      # FLEET_IDENTITY_DIRECTORY above. On Linux, run
+      # re-enroll to replace it (Codex review). On Linux, run
       # `mkdir -p ~/.bagel/identity` once so the directory is owned by you.
+      # Identity lives on this volume; to relocate it, change the HOST side
+      # of this mapping -- do not set FLEET_IDENTITY_DIRECTORY inside the
+      # container (writes would land off-volume and be lost).
       - ${HOME}/.bagel/identity:/home/ubuntu/.bagel/identity
       # - <path-to-local-data>:/home/ubuntu/data
 
@@ -435,11 +442,10 @@ services:
       # unconditionally like FLEET_ENABLED itself so flipping FLEET_ENABLED
       # at runtime never also requires editing this file. Unset host vars
       # resolve to Settings' own defaults inside the container (empty
-      # string is falsy for the two optional str fields; the identity
-      # directory default below matches the volume mount below).
+      # string is falsy for the two optional str fields). FLEET_IDENTITY_DIRECTORY
+      # is deliberately NOT forwarded -- see the volume mount below.
       FLEET_ENROLL_TOKEN: ${FLEET_ENROLL_TOKEN:-}
       FLEET_ENROLL_URL: ${FLEET_ENROLL_URL:-}
-      FLEET_IDENTITY_DIRECTORY: ${FLEET_IDENTITY_DIRECTORY:-/home/ubuntu/.bagel/identity}
       FLEET_DEV_INSECURE: ${FLEET_DEV_INSECURE:-false}
       MCP_SERVER_PORT: ${MCP_SERVER_PORT}
       # Containers must listen on all container interfaces for Docker port
@@ -467,9 +473,11 @@ services:
       # `docker compose run` lives only in that one-off container's
       # writable layer: it is lost the moment the container exits, and
       # because FLEET_ENROLL_TOKEN is single-use, a later run cannot
-      # re-enroll to replace it (Codex review). Must match
-      # FLEET_IDENTITY_DIRECTORY above. On Linux, run
+      # re-enroll to replace it (Codex review). On Linux, run
       # `mkdir -p ~/.bagel/identity` once so the directory is owned by you.
+      # Identity lives on this volume; to relocate it, change the HOST side
+      # of this mapping -- do not set FLEET_IDENTITY_DIRECTORY inside the
+      # container (writes would land off-volume and be lost).
       - ${HOME}/.bagel/identity:/home/ubuntu/.bagel/identity
       # - <path-to-local-data>:/home/ubuntu/data
 
@@ -492,11 +500,10 @@ services:
       # unconditionally like FLEET_ENABLED itself so flipping FLEET_ENABLED
       # at runtime never also requires editing this file. Unset host vars
       # resolve to Settings' own defaults inside the container (empty
-      # string is falsy for the two optional str fields; the identity
-      # directory default below matches the volume mount below).
+      # string is falsy for the two optional str fields). FLEET_IDENTITY_DIRECTORY
+      # is deliberately NOT forwarded -- see the volume mount below.
       FLEET_ENROLL_TOKEN: ${FLEET_ENROLL_TOKEN:-}
       FLEET_ENROLL_URL: ${FLEET_ENROLL_URL:-}
-      FLEET_IDENTITY_DIRECTORY: ${FLEET_IDENTITY_DIRECTORY:-/home/ubuntu/.bagel/identity}
       FLEET_DEV_INSECURE: ${FLEET_DEV_INSECURE:-false}
       MCP_SERVER_PORT: ${MCP_SERVER_PORT}
       # Containers must listen on all container interfaces for Docker port
@@ -524,9 +531,11 @@ services:
       # `docker compose run` lives only in that one-off container's
       # writable layer: it is lost the moment the container exits, and
       # because FLEET_ENROLL_TOKEN is single-use, a later run cannot
-      # re-enroll to replace it (Codex review). Must match
-      # FLEET_IDENTITY_DIRECTORY above. On Linux, run
+      # re-enroll to replace it (Codex review). On Linux, run
       # `mkdir -p ~/.bagel/identity` once so the directory is owned by you.
+      # Identity lives on this volume; to relocate it, change the HOST side
+      # of this mapping -- do not set FLEET_IDENTITY_DIRECTORY inside the
+      # container (writes would land off-volume and be lost).
       - ${HOME}/.bagel/identity:/home/ubuntu/.bagel/identity
       # - <path-to-local-data>:/home/ubuntu/data
 
@@ -549,11 +558,10 @@ services:
       # unconditionally like FLEET_ENABLED itself so flipping FLEET_ENABLED
       # at runtime never also requires editing this file. Unset host vars
       # resolve to Settings' own defaults inside the container (empty
-      # string is falsy for the two optional str fields; the identity
-      # directory default below matches the volume mount below).
+      # string is falsy for the two optional str fields). FLEET_IDENTITY_DIRECTORY
+      # is deliberately NOT forwarded -- see the volume mount below.
       FLEET_ENROLL_TOKEN: ${FLEET_ENROLL_TOKEN:-}
       FLEET_ENROLL_URL: ${FLEET_ENROLL_URL:-}
-      FLEET_IDENTITY_DIRECTORY: ${FLEET_IDENTITY_DIRECTORY:-/home/ubuntu/.bagel/identity}
       FLEET_DEV_INSECURE: ${FLEET_DEV_INSECURE:-false}
       MCP_SERVER_PORT: ${MCP_SERVER_PORT}
       # Containers must listen on all container interfaces for Docker port
@@ -581,9 +589,11 @@ services:
       # `docker compose run` lives only in that one-off container's
       # writable layer: it is lost the moment the container exits, and
       # because FLEET_ENROLL_TOKEN is single-use, a later run cannot
-      # re-enroll to replace it (Codex review). Must match
-      # FLEET_IDENTITY_DIRECTORY above. On Linux, run
+      # re-enroll to replace it (Codex review). On Linux, run
       # `mkdir -p ~/.bagel/identity` once so the directory is owned by you.
+      # Identity lives on this volume; to relocate it, change the HOST side
+      # of this mapping -- do not set FLEET_IDENTITY_DIRECTORY inside the
+      # container (writes would land off-volume and be lost).
       - ${HOME}/.bagel/identity:/home/ubuntu/.bagel/identity
       # - <path-to-local-data>:/home/ubuntu/data
 
@@ -607,11 +617,10 @@ services:
       # unconditionally like FLEET_ENABLED itself so flipping FLEET_ENABLED
       # at runtime never also requires editing this file. Unset host vars
       # resolve to Settings' own defaults inside the container (empty
-      # string is falsy for the two optional str fields; the identity
-      # directory default below matches the volume mount below).
+      # string is falsy for the two optional str fields). FLEET_IDENTITY_DIRECTORY
+      # is deliberately NOT forwarded -- see the volume mount below.
       FLEET_ENROLL_TOKEN: ${FLEET_ENROLL_TOKEN:-}
       FLEET_ENROLL_URL: ${FLEET_ENROLL_URL:-}
-      FLEET_IDENTITY_DIRECTORY: ${FLEET_IDENTITY_DIRECTORY:-/home/ubuntu/.bagel/identity}
       FLEET_DEV_INSECURE: ${FLEET_DEV_INSECURE:-false}
       MCP_SERVER_PORT: ${MCP_SERVER_PORT}
       # Containers must listen on all container interfaces for Docker port
@@ -641,9 +650,11 @@ services:
       # `docker compose run` lives only in that one-off container's
       # writable layer: it is lost the moment the container exits, and
       # because FLEET_ENROLL_TOKEN is single-use, a later run cannot
-      # re-enroll to replace it (Codex review). Must match
-      # FLEET_IDENTITY_DIRECTORY above. On Linux, run
+      # re-enroll to replace it (Codex review). On Linux, run
       # `mkdir -p ~/.bagel/identity` once so the directory is owned by you.
+      # Identity lives on this volume; to relocate it, change the HOST side
+      # of this mapping -- do not set FLEET_IDENTITY_DIRECTORY inside the
+      # container (writes would land off-volume and be lost).
       - ${HOME}/.bagel/identity:/home/ubuntu/.bagel/identity
       # - <path-to-local-data>:/home/ubuntu/data
 

--- a/doc/fleet_protocol_v1.md
+++ b/doc/fleet_protocol_v1.md
@@ -315,7 +315,14 @@ streaming paused or stopped. It also refuses outright, before publishing
 anything, if the robot's live fleet session is already connected (detected
 via a bounded subscribe-probe for a retained `online: true` heartbeat) --
 retention and a distinct client id alone don't stop this run's fixture
-schema from reaching a connected live subscriber as a schema update.
+schema from reaching a connected live subscriber as a schema update. That
+same check keeps running for the rest of the run, not just at the start: it
+watches for any live activity on the robot's session topics (heartbeat AND
+schema, not heartbeat alone -- a resuming service's heartbeat can be stuck
+behind a lock while its router still reconnects and republishes the schema)
+and aborts the instant any of it appears, since a service could resume
+partway through a multi-batch run just as easily as it could already be
+connected at the start.
 
 All of the selftest's own publishes -- schema, heartbeat, and its final
 close() beat -- are deliberately NOT retained (unlike a real robot's own

--- a/doc/fleet_protocol_v1.md
+++ b/doc/fleet_protocol_v1.md
@@ -311,7 +311,11 @@ expected failure prints to stderr and exits 1). It requires both spool lanes
 (`channels`, `events`) to be fully drained (no pending unacked entries)
 before it will start -- it allocates and acks real seqs on those lanes, so
 pending backlog would otherwise be silently advanced past; run it with fleet
-streaming paused or stopped.
+streaming paused or stopped. It also refuses outright, before publishing
+anything, if the robot's live fleet session is already connected (detected
+via a bounded subscribe-probe for a retained `online: true` heartbeat) --
+retention and a distinct client id alone don't stop this run's fixture
+schema from reaching a connected live subscriber as a schema update.
 
 All of the selftest's own publishes -- schema, heartbeat, and its final
 close() beat -- are deliberately NOT retained (unlike a real robot's own

--- a/doc/fleet_protocol_v1.md
+++ b/doc/fleet_protocol_v1.md
@@ -173,6 +173,11 @@ The on-robot event *emitter* ships in a future release; this shape is
 contractual now, and the conformance selftest (§10) already publishes one
 event (without `artifact`).
 
+Likewise, the `stream_live_topics`/`stop_live_streams` tools already accept
+and persist event *rules* (the predicate that would decide when to emit):
+on-robot evaluation ships in a later release; configuration is
+forward-compatible.
+
 ## 8. `heartbeat` payload
 
 Published retained every **30 s** (first beat immediately at session start):

--- a/doc/fleet_protocol_v1.md
+++ b/doc/fleet_protocol_v1.md
@@ -305,13 +305,20 @@ uv run python -m src.sink.publish.selftest [--broker mqtt(s)://...] \
 ```
 
 It publishes, in order, using the enrolled identity (or `--broker` on a dev
-rig): one retained schema, N channel batches (default 10, default 0.5 s
-apart), one heartbeat, one event -- then prints a one-line JSON summary and
-exits 0 (any expected failure prints to stderr and exits 1). It requires both
-spool lanes (`channels`, `events`) to be fully drained (no pending unacked
-entries) before it will start -- it allocates and acks real seqs on those
-lanes, so pending backlog would otherwise be silently advanced past; run it
-with fleet streaming paused or stopped.
+rig): one schema, N channel batches (default 10, default 0.5 s apart), one
+heartbeat, one event -- then prints a one-line JSON summary and exits 0 (any
+expected failure prints to stderr and exits 1). It requires both spool lanes
+(`channels`, `events`) to be fully drained (no pending unacked entries)
+before it will start -- it allocates and acks real seqs on those lanes, so
+pending backlog would otherwise be silently advanced past; run it with fleet
+streaming paused or stopped.
+
+All of the selftest's own publishes -- schema, heartbeat, and its final
+close() beat -- are deliberately NOT retained (unlike a real robot's own
+schema/heartbeat) and it arms no last-will either, so a run leaves no
+retained residue on the robot's shared topics for a late subscriber to find;
+retention isn't load-bearing for conformance since a validator subscribes
+before or during the run.
 
 The fixture is fixed and deterministic. The schema is exactly these four
 channels:

--- a/doc/runbooks/fleet_streaming.md
+++ b/doc/runbooks/fleet_streaming.md
@@ -138,6 +138,13 @@ nothing touched -- since it would otherwise ack its way past that backlog and
 silently drop it; let the service drain the backlog, or discard it first via
 `pause_fleet_streaming(discard=True)`.
 
+And it refuses outright, before publishing anything, if the robot's live
+fleet session is currently **connected** (not merely paused) -- pausing or
+stopping the service first is required here, not just recommended, since
+this run's fixture schema would otherwise reach that connected live
+subscriber as a schema update, remapping live channel batches to the
+fixture's `selftest.*` channels until the live service's next reconnect.
+
 ## Dev rigs
 
 `FLEET_DEV_INSECURE=1` permits a plaintext `mqtt://` broker **only** when its

--- a/doc/runbooks/fleet_streaming.md
+++ b/doc/runbooks/fleet_streaming.md
@@ -117,7 +117,11 @@ uv run python -m src.sink.publish.selftest --broker mqtt://localhost:1883  # dev
 
 It publishes a fixed four-channel schema, ten deterministic batches, a
 heartbeat and an event (exact expected values are in the contract doc's
-Conformance section), prints a one-line JSON summary, and exits 0.
+Conformance section), prints a one-line JSON summary, and exits 0. It keeps
+publishing AS the enrolled robot on that robot's real topics, but none of its
+own messages are retained and it arms no last-will, so it leaves no residue
+behind once it's done -- a real robot's own retained schema/heartbeat, and
+the live service's own last-will, are left completely untouched.
 
 Run it with fleet streaming **paused or stopped**: it shares the robot's real
 spool lanes and holds the spool lock for its entire run, so a concurrently

--- a/doc/runbooks/fleet_streaming.md
+++ b/doc/runbooks/fleet_streaming.md
@@ -144,6 +144,14 @@ stopping the service first is required here, not just recommended, since
 this run's fixture schema would otherwise reach that connected live
 subscriber as a schema update, remapping live channel batches to the
 fixture's `selftest.*` channels until the live service's next reconnect.
+That check isn't just a start-of-run gate: it keeps watching for the rest
+of the run, and aborts (same typed error, connection torn down silently,
+no close beat) the instant it sees any live activity on the robot's
+session topics -- not the heartbeat alone. A service resuming partway
+through a run can have its heartbeat thread stuck behind the selftest's
+own spool lock while its router still reconnects and republishes the
+schema regardless, so both topics are watched, and a signal on either one
+is enough on its own to abort.
 
 ## Dev rigs
 

--- a/doc/runbooks/fleet_streaming.md
+++ b/doc/runbooks/fleet_streaming.md
@@ -120,9 +120,13 @@ heartbeat and an event (exact expected values are in the contract doc's
 Conformance section), prints a one-line JSON summary, and exits 0.
 
 Run it with fleet streaming **paused or stopped**: it shares the robot's real
-spool lanes, and a concurrently running streaming service makes one side fail
-a sequence check. That failure is clean and harmless -- a typed error, exit
-code 1, nothing corrupted -- but the run doesn't count; pause and rerun.
+spool lanes and holds the spool lock for its entire run, so a concurrently
+running service's ingestion blocks until the selftest finishes -- sequence
+integrity is preserved either way, but on a high-rate robot the paused
+ingestion can surface as counted queue drops (`queue.dropped` in the next
+heartbeat). Pausing first avoids both the wait and the drops. If another
+writer already holds the lock, the selftest refuses with a typed error
+rather than waiting indefinitely.
 
 The selftest also refuses outright if either spool lane already has pending
 unacked backlog (e.g. a paused service's queued-but-unsent data) -- exit 1,

--- a/doc/runbooks/fleet_streaming.md
+++ b/doc/runbooks/fleet_streaming.md
@@ -83,6 +83,12 @@ reconnects briefly to republish the schema, then re-pauses -- it never
 silently comes back online. Rules applied this way are persisted to the
 startup manifest's `streams:` section, so they survive container restarts.
 
+Event rules are accepted, validated, merged, and persisted the same way
+channel rules are, and `stream_live_topics`/`stop_live_streams` report them
+back as `events_configured` -- but on-robot evaluation ships in a later
+release; configuration is forward-compatible, not yet active
+(`events_active` is always `False`).
+
 `pause_fleet_streaming` / `resume_fleet_streaming` take the connection
 offline and back without touching identity or rules -- a paused robot leaves
 a retained `reason: "paused"` heartbeat on the broker, so fleet-side

--- a/server.py
+++ b/server.py
@@ -1235,11 +1235,12 @@ def stream_live_topics(
             (always ``False``: event rules are stored and forwarded but not
             evaluated until the event runtime ships -- configuring one now
             is forward-compatible, not a no-op). If the streaming change
-            itself succeeded but writing it back to the manifest failed
-            (e.g. an unparsable manifest file), this does not raise:
-            ``persisted`` is ``False`` and a ``persist_error`` message is
-            included, so the truthful state is reported -- the robot IS
-            running the new rules; only the on-disk manifest didn't get them.
+            itself succeeded but writing it back to the manifest failed (an
+            unparsable manifest file, a read-only manifest directory, a full
+            disk, etc), this does not raise: ``persisted`` is ``False`` and a
+            ``persist_error`` message is included, so the truthful state is
+            reported -- the robot IS running the new rules; only the on-disk
+            manifest didn't get them.
 
     Raises:
         StreamConfigError: An invalid rule, or no viable broker/covering

--- a/server.py
+++ b/server.py
@@ -1230,8 +1230,16 @@ def stream_live_topics(
     Returns:
         dict[str, Any]: ``service`` ("running" or "paused" -- "paused" when
             the service this replaced was paused), the resolved
-            ``channels``, the ``events`` names, and whether the change was
-            ``persisted`` to the manifest.
+            ``channels``, the ``events_configured`` names, whether the
+            change was ``persisted`` to the manifest, and ``events_active``
+            (always ``False``: event rules are stored and forwarded but not
+            evaluated until the event runtime ships -- configuring one now
+            is forward-compatible, not a no-op). If the streaming change
+            itself succeeded but writing it back to the manifest failed
+            (e.g. an unparsable manifest file), this does not raise:
+            ``persisted`` is ``False`` and a ``persist_error`` message is
+            included, so the truthful state is reported -- the robot IS
+            running the new rules; only the on-disk manifest didn't get them.
 
     Raises:
         StreamConfigError: An invalid rule, or no viable broker/covering
@@ -1285,9 +1293,14 @@ def stop_live_streams(
     Returns:
         dict[str, Any]: ``service`` ("running", "paused", or "stopped" --
             "paused" when a restart happened and the service it replaced was
-            paused), the remaining ``channels``, the remaining ``events``
-            names, whether anything ``changed``, and whether that change was
-            ``persisted``.
+            paused), the remaining ``channels``, the remaining
+            ``events_configured`` names, whether anything ``changed``,
+            whether that change was ``persisted``, and ``events_active``
+            (always ``False``: event rules are stored and forwarded but not
+            evaluated until the event runtime ships). If something changed
+            and the restart succeeded but writing it back to the manifest
+            failed, this does not raise: ``persisted`` is ``False`` and a
+            ``persist_error`` message is included.
 
     Raises:
         FleetNotEnrolledError | StreamConfigError: Only reachable when

--- a/src/sink/publish/control.py
+++ b/src/sink/publish/control.py
@@ -714,10 +714,15 @@ def _read_manifest_doc() -> dict:
     """Read the startup manifest into a dict; `{}` when unset, unwritten, or empty.
 
     Raises:
-        StreamConfigError: the file exists but fails to parse as YAML, or
-            parses to something other than a mapping -- so a corrupt
-            manifest is never silently treated as empty and then clobbered
-            by a subsequent `_persist_streams` write.
+        StreamConfigError: the file exists but fails to parse as YAML,
+            fails to even decode as UTF-8 (`Path.read_text()` raises
+            `UnicodeDecodeError` on invalid bytes -- before `yaml.safe_load`
+            ever runs, so this must be caught alongside `yaml.YAMLError`,
+            not just it; Codex round 3 follow-up, PR #214 P2, comment
+            3927023413's sibling finding), or parses to something other
+            than a mapping -- so a corrupt manifest is never silently
+            treated as empty and then clobbered by a subsequent
+            `_persist_streams` write.
 
     """
     path = _manifest_path()
@@ -725,7 +730,7 @@ def _read_manifest_doc() -> dict:
         return {}
     try:
         doc = yaml.safe_load(path.read_text())
-    except yaml.YAMLError as exc:
+    except (yaml.YAMLError, UnicodeDecodeError) as exc:
         raise StreamConfigError("manifest", f"unparsable manifest at {path}: {exc}") from exc
     if doc is None:
         return {}

--- a/src/sink/publish/control.py
+++ b/src/sink/publish/control.py
@@ -65,6 +65,63 @@ from src.sink.publish.spool import Spool
 # slow mutating call.
 _control_lock = threading.Lock()
 
+# Honest-reporting ruling (Codex round 3, P1a): event rules are accepted,
+# validated, merged, restarted against, and persisted to the manifest just
+# like channel rules -- but the on-robot runtime that would actually
+# evaluate an event predicate and fire an event ships in a later release
+# (step 8 lands before launch). Rejecting event rules now would break
+# manifest workflows that already declare them; instead `stream_topics`/
+# `stop_streams` report them honestly via `events_configured`/
+# `events_active` (see each function's Returns) and log this once whenever
+# a call leaves any event rule configured.
+EVENTS_NOT_ACTIVE_MSG = (
+    "event rules are stored and forwarded but not evaluated until the event runtime ships"
+)
+
+
+def _warn_if_events_configured(events: list) -> None:
+    if events:
+        logging.getLogger(__name__).warning(EVENTS_NOT_ACTIVE_MSG)
+
+
+def _fleet_installed() -> bool:
+    """Whether the optional `fleet` dependency group (paho-mqtt) is importable.
+
+    Uses `find_spec`, not an actual import: `fleet_status()` must answer
+    without ever eagerly importing paho (unlike `require_fleet()`, which
+    does import it, for the operations that actually need it running).
+
+    `find_spec` on a dotted name ("paho.mqtt") first resolves the PARENT
+    package ("paho") to read its `__path__`. If `paho` is present on the
+    path only as a half-installed namespace package -- no `__init__.py`, or
+    otherwise broken -- that parent-resolution step can itself raise
+    `ModuleNotFoundError` or `ValueError` instead of `find_spec` cleanly
+    returning `None` (Codex round 3, P2). `fleet_status()`'s whole contract
+    is "never raises", so either is treated as "not installed" here rather
+    than propagating.
+    """
+    try:
+        return importlib.util.find_spec("paho.mqtt") is not None
+    except (ModuleNotFoundError, ValueError):
+        return False
+
+
+def _service_status(service: FleetService | None) -> dict | None:
+    """`service.status()`, guarded: `fleet_status()` must never raise (Codex round 3, P2).
+
+    `status()` reads live spool stats (`Spool.stats()` rescans a lane's
+    active segment on first access), so a corrupt segment on disk can raise
+    `SpoolCorruptError` straight out of a call that is supposed to be a
+    read-only diagnostic. Surface the failure IN the report instead of
+    letting it blow up the report itself.
+    """
+    if service is None:
+        return None
+    try:
+        return service.status()
+    except Exception as exc:  # fleet_status() must never raise, by design (Codex round 3)
+        return {"error": f"{type(exc).__name__}: {exc}"}
+
 
 def fleet_status() -> dict:
     """Report this robot's fleet-streaming state -- the local source of truth (spec §7).
@@ -83,7 +140,10 @@ def fleet_status() -> dict:
                        "renew_url"} | None,  # never key material, never paths
           "service": "running" | "paused" | "stopped",
           "channels": list[dict],  # resolved channel descriptors, [] if no service
-          "status": dict | None,   # FleetService.status()'s §4 counters block, verbatim
+          "status": dict | None,   # FleetService.status()'s §4 counters block, verbatim,
+                                    # {"error": "<class>: <msg>"} if status() itself raised
+                                    # (e.g. a corrupt spool segment -- Codex round 3, P2),
+                                    # None if no service is running
         }
         ```
 
@@ -118,12 +178,12 @@ def fleet_status() -> dict:
 
     return {
         "enabled": bool(settings.FLEET_ENABLED),
-        "installed": importlib.util.find_spec("paho.mqtt") is not None,
+        "installed": _fleet_installed(),
         "enrolled": loaded is not None,
         "identity": identity_summary,
         "service": service_state,
         "channels": service.channels if service is not None else [],
-        "status": service.status() if service is not None else None,
+        "status": _service_status(service),
     }
 
 
@@ -266,11 +326,28 @@ def stream_topics(channels: list[dict] | None, events: list[dict] | None) -> dic
     configured.
 
     Returns:
-        `{"service": "running" | "paused", "channels": list[dict], "events":
-        list[str], "persisted": bool}`. `"paused"` when the service this
-        replaced was paused: `_restart_service` preserves paused-ness across
-        the rule-change restart (I1 ruling) -- a brief reconnect blip to
-        republish the schema, then straight back to paused.
+        `{"service": "running" | "paused", "channels": list[dict],
+        "events_configured": list[str], "events_active": False, "persisted":
+        bool}`, plus `"persist_error": str` ONLY when persisting after an
+        otherwise-successful restart failed (see below). `"paused"` when the
+        service this replaced was paused: `_restart_service` preserves
+        paused-ness across the rule-change restart (I1 ruling) -- a brief
+        reconnect blip to republish the schema, then straight back to
+        paused. `events_configured` lists every event rule name now stored
+        and forwarded; `events_active` is always `False` -- event rules are
+        accepted, merged, and persisted, but nothing on-robot evaluates them
+        yet (honest-reporting ruling, Codex round 3: the event runtime ships
+        in a later release). A WARNING is logged once whenever
+        `events_configured` is non-empty.
+
+        Live-vs-persisted atomicity (Codex round 3, P2): the restart above
+        has ALREADY happened by the time persistence is attempted, so a
+        persist failure here (e.g. an unparsable manifest) does NOT raise --
+        raising would misreport a live change that genuinely succeeded as a
+        total failure. Instead `persisted` is `False` and `persist_error`
+        carries the manifest problem, so the caller sees the true state:
+        the robot IS running the new rules; the manifest just doesn't
+        reflect it yet.
 
     Raises:
         FleetDisabledError | FleetNotInstalledError: via `require_fleet()`.
@@ -309,14 +386,20 @@ def stream_topics(channels: list[dict] | None, events: list[dict] | None) -> dic
         )
 
         _restart_service(merged)
-        persisted = _persist_streams(merged.to_manifest())
+        persisted, persist_error = _persist_or_report(merged.to_manifest())
         service = startup.fleet_service()
-        return {
+        event_names = [rule.name for rule in merged.events]
+        _warn_if_events_configured(event_names)
+        result = {
             "service": "paused" if service.paused else "running",
             "channels": service.channels,
-            "events": [rule.name for rule in merged.events],
+            "events_configured": event_names,
+            "events_active": False,
             "persisted": persisted,
         }
+        if persist_error is not None:
+            result["persist_error"] = persist_error
+        return result
 
 
 def stop_streams(channels: list[str] | None, events: list[str] | None) -> dict:
@@ -343,11 +426,25 @@ def stop_streams(channels: list[str] | None, events: list[str] | None) -> dict:
 
     Returns:
         `{"service": "running" | "paused" | "stopped", "channels":
-        list[dict], "events": list[str], "changed": bool, "persisted":
-        bool}`. `"paused"` when a restart happened and the service it
+        list[dict], "events_configured": list[str], "events_active": False,
+        "changed": bool, "persisted": bool}`, plus `"persist_error": str`
+        ONLY when persisting after an actual (`changed`) restart failed (see
+        below). `"paused"` when a restart happened and the service it
         replaced was paused: `_restart_service` preserves paused-ness across
         the restart (I1 ruling) -- a brief reconnect blip to republish the
-        schema, then straight back to paused.
+        schema, then straight back to paused. `events_configured` lists the
+        event rule names still stored and forwarded after this call;
+        `events_active` is always `False` -- nothing on-robot evaluates them
+        yet (honest-reporting ruling, Codex round 3: the event runtime ships
+        in a later release). A WARNING is logged once whenever
+        `events_configured` is non-empty.
+
+        Live-vs-persisted atomicity (Codex round 3, P2): same ruling as
+        `stream_topics`'s -- when `changed` is True, the restart has ALREADY
+        happened by the time persistence is attempted, so a persist failure
+        (e.g. an unparsable manifest) does NOT raise; `persisted` is `False`
+        and `persist_error` carries the manifest problem instead, so a
+        genuinely successful live change is never misreported as a failure.
 
     Raises:
         FleetDisabledError | FleetNotInstalledError: via `require_fleet()`.
@@ -384,20 +481,30 @@ def stop_streams(channels: list[str] | None, events: list[str] | None) -> dict:
         # A pure no-op must not touch the manifest at all (not even a rewrite
         # with identical content) -- a manifest with no `streams:` section
         # stays byte-identical, and `persisted` truthfully reports `False`.
-        persisted = _persist_streams(remaining.to_manifest()) if changed else False
+        persist_error = None
+        if changed:
+            persisted, persist_error = _persist_or_report(remaining.to_manifest())
+        else:
+            persisted = False
         if service is None:
             service_state = "stopped"
         elif service.paused:
             service_state = "paused"
         else:
             service_state = "running"
-        return {
+        remaining_event_names = [rule.name for rule in remaining.events]
+        _warn_if_events_configured(remaining_event_names)
+        result = {
             "service": service_state,
             "channels": service.channels if service is not None else [],
-            "events": [rule.name for rule in remaining.events],
+            "events_configured": remaining_event_names,
+            "events_active": False,
             "changed": changed,
             "persisted": persisted,
         }
+        if persist_error is not None:
+            result["persist_error"] = persist_error
+        return result
 
 
 def _merge_by_key(current: list, new: list, *, key: Callable[[object], object]) -> list:
@@ -633,3 +740,29 @@ def _persist_streams(streams_manifest: dict | None) -> bool:
     finally:
         tmp.unlink(missing_ok=True)
     return True
+
+
+def _persist_or_report(streams_manifest: dict | None) -> tuple[bool, str | None]:
+    """`_persist_streams`, guarded so persist failure never masks an already-successful live change.
+
+    By the time `stream_topics`/`stop_streams` call this, `_restart_service`
+    has ALREADY succeeded -- the robot is really running the new rules. If
+    the on-disk manifest happens to be unparsable, `_persist_streams` raises
+    `StreamConfigError` (correctly refusing to clobber a human-maintained
+    file it can't safely read first); letting that propagate here would
+    surface as a raised exception from `stream_topics`/`stop_streams`, which
+    reads to a caller as "nothing happened" when actually the live change
+    DID happen and only the manifest write failed. So: catch it here, and
+    let the caller report `persisted=False` plus the error message alongside
+    its otherwise-successful result, instead of raising post-restart.
+
+    Returns:
+        `(persisted, persist_error)`: `persist_error` is `None` on success
+        (including the "no manifest configured" `False` case, which is not
+        an error).
+
+    """
+    try:
+        return _persist_streams(streams_manifest), None
+    except StreamConfigError as exc:
+        return False, str(exc)

--- a/src/sink/publish/control.py
+++ b/src/sink/publish/control.py
@@ -429,25 +429,37 @@ def stop_streams(channels: list[str] | None, events: list[str] | None) -> dict:
         `{"service": "running" | "paused" | "stopped", "channels":
         list[dict], "events_configured": list[str], "events_active": False,
         "changed": bool, "persisted": bool}`, plus `"persist_error": str`
-        ONLY when persisting after an actual (`changed`) restart failed (see
-        below). `"paused"` when a restart happened and the service it
-        replaced was paused: `_restart_service` preserves paused-ness across
-        the restart (I1 ruling) -- a brief reconnect blip to republish the
-        schema, then straight back to paused. `events_configured` lists the
-        event rule names still stored and forwarded after this call;
-        `events_active` is always `False` -- nothing on-robot evaluates them
-        yet (honest-reporting ruling, Codex round 3: the event runtime ships
-        in a later release). A WARNING is logged once whenever
-        `events_configured` is non-empty.
+        ONLY when persisting after an actual, RESTARTED (`changed` AND a
+        live service) change failed (see below). `"paused"` when a restart
+        happened and the service it replaced was paused: `_restart_service`
+        preserves paused-ness across the restart (I1 ruling) -- a brief
+        reconnect blip to republish the schema, then straight back to
+        paused. `events_configured` lists the event rule names still stored
+        and forwarded after this call; `events_active` is always `False` --
+        nothing on-robot evaluates them yet (honest-reporting ruling, Codex
+        round 3: the event runtime ships in a later release). A WARNING is
+        logged once whenever `events_configured` is non-empty.
 
         Live-vs-persisted atomicity (Codex round 3, P2; widened P2 follow-up
-        on PR #214 to also cover `OSError`): same ruling as `stream_topics`'s
-        -- when `changed` is True, the restart has ALREADY happened by the
-        time persistence is attempted, so a persist failure (an unparsable
+        on PR #214 to also cover `OSError`) -- ONLY for the restarted case:
+        when `changed` is True AND a live service was running, the restart
+        has ALREADY happened (and, per `_restart_service`'s own
+        failure-outcome contract, already SUCCEEDED) by the time
+        persistence is attempted, so a persist failure there (an unparsable
         manifest, or an `OSError` from a read-only manifest directory, a
         full disk, etc) does NOT raise; `persisted` is `False` and
         `persist_error` carries the problem instead, so a genuinely
         successful live change is never misreported as a failure.
+
+        Persist-ONLY failure-outcome contract (Codex round 3 follow-up, PR
+        #214 P2 on comment 3924387659): when `changed` is True but NO live
+        service was running, this call's ENTIRE effect is the manifest
+        write -- there is no successful restart for a swallowed persist
+        failure to protect. A persist failure there PROPAGATES typed
+        (`StreamConfigError` or `OSError`) instead of being folded into
+        `persist_error`: the call did nothing, so it says so, rather than
+        reporting a misleadingly benign-looking `persisted: False` for what
+        is actually a total failure.
 
     Raises:
         FleetDisabledError | FleetNotInstalledError: via `require_fleet()`.
@@ -456,6 +468,10 @@ def stop_streams(channels: list[str] | None, events: list[str] | None) -> dict:
             something changed and a service is running; per its failure-
             outcome contract, such a failure leaves the OLD service running
             untouched (see `_restart_service`'s docstring).
+        StreamConfigError | OSError: from `_persist_streams` itself, ONLY
+            when `changed` is True and NO live service was running (the
+            persist-only path above) -- an unparsable manifest, or a
+            read-only manifest directory / full disk / other write failure.
 
     """
     require_fleet()
@@ -485,8 +501,23 @@ def stop_streams(channels: list[str] | None, events: list[str] | None) -> dict:
         # with identical content) -- a manifest with no `streams:` section
         # stays byte-identical, and `persisted` truthfully reports `False`.
         persist_error = None
-        if changed:
+        if changed and service is not None:
+            # A restart already happened here (and, per `_restart_service`'s
+            # own failure-outcome contract, already SUCCEEDED -- a failing
+            # restart would have raised before this line was ever reached).
+            # `_persist_or_report`'s swallow-and-report ruling exists
+            # precisely to avoid masking that success (Codex round 3, P2,
+            # widened in the PR #214 follow-up).
             persisted, persist_error = _persist_or_report(remaining.to_manifest())
+        elif changed:
+            # No live service, so nothing was restarted -- the manifest
+            # write IS this call's entire effect (Codex round 3 follow-up,
+            # PR #214 P2 on comment 3924387659). There is no successful
+            # restart here for a swallowed failure to protect, so a persist
+            # failure propagates typed instead: the call did nothing, and
+            # says so, rather than reporting a misleadingly benign-looking
+            # `persisted: False` for what is actually a total failure.
+            persisted = _persist_streams(remaining.to_manifest())
         else:
             persisted = False
         if service is None:

--- a/src/sink/publish/control.py
+++ b/src/sink/publish/control.py
@@ -340,14 +340,15 @@ def stream_topics(channels: list[dict] | None, events: list[dict] | None) -> dic
         in a later release). A WARNING is logged once whenever
         `events_configured` is non-empty.
 
-        Live-vs-persisted atomicity (Codex round 3, P2): the restart above
-        has ALREADY happened by the time persistence is attempted, so a
-        persist failure here (e.g. an unparsable manifest) does NOT raise --
-        raising would misreport a live change that genuinely succeeded as a
-        total failure. Instead `persisted` is `False` and `persist_error`
-        carries the manifest problem, so the caller sees the true state:
-        the robot IS running the new rules; the manifest just doesn't
-        reflect it yet.
+        Live-vs-persisted atomicity (Codex round 3, P2; widened P2 follow-up
+        on PR #214 to also cover `OSError`): the restart above has ALREADY
+        happened by the time persistence is attempted, so a persist failure
+        here (an unparsable manifest, or an `OSError` from a read-only
+        manifest directory, a full disk, etc) does NOT raise -- raising
+        would misreport a live change that genuinely succeeded as a total
+        failure. Instead `persisted` is `False` and `persist_error` carries
+        the problem, so the caller sees the true state: the robot IS running
+        the new rules; the manifest just doesn't reflect it yet.
 
     Raises:
         FleetDisabledError | FleetNotInstalledError: via `require_fleet()`.
@@ -439,12 +440,14 @@ def stop_streams(channels: list[str] | None, events: list[str] | None) -> dict:
         in a later release). A WARNING is logged once whenever
         `events_configured` is non-empty.
 
-        Live-vs-persisted atomicity (Codex round 3, P2): same ruling as
-        `stream_topics`'s -- when `changed` is True, the restart has ALREADY
-        happened by the time persistence is attempted, so a persist failure
-        (e.g. an unparsable manifest) does NOT raise; `persisted` is `False`
-        and `persist_error` carries the manifest problem instead, so a
-        genuinely successful live change is never misreported as a failure.
+        Live-vs-persisted atomicity (Codex round 3, P2; widened P2 follow-up
+        on PR #214 to also cover `OSError`): same ruling as `stream_topics`'s
+        -- when `changed` is True, the restart has ALREADY happened by the
+        time persistence is attempted, so a persist failure (an unparsable
+        manifest, or an `OSError` from a read-only manifest directory, a
+        full disk, etc) does NOT raise; `persisted` is `False` and
+        `persist_error` carries the problem instead, so a genuinely
+        successful live change is never misreported as a failure.
 
     Raises:
         FleetDisabledError | FleetNotInstalledError: via `require_fleet()`.
@@ -747,14 +750,21 @@ def _persist_or_report(streams_manifest: dict | None) -> tuple[bool, str | None]
 
     By the time `stream_topics`/`stop_streams` call this, `_restart_service`
     has ALREADY succeeded -- the robot is really running the new rules. If
-    the on-disk manifest happens to be unparsable, `_persist_streams` raises
-    `StreamConfigError` (correctly refusing to clobber a human-maintained
-    file it can't safely read first); letting that propagate here would
-    surface as a raised exception from `stream_topics`/`stop_streams`, which
-    reads to a caller as "nothing happened" when actually the live change
-    DID happen and only the manifest write failed. So: catch it here, and
-    let the caller report `persisted=False` plus the error message alongside
-    its otherwise-successful result, instead of raising post-restart.
+    persisting that to disk fails, letting the exception propagate here
+    would surface as a raised exception from `stream_topics`/`stop_streams`,
+    which reads to a caller as "nothing happened" when actually the live
+    change DID happen and only the manifest write failed. So: catch it here,
+    and let the caller report `persisted=False` plus the error message
+    alongside its otherwise-successful result, instead of raising
+    post-restart.
+
+    Two failure modes are caught (Codex round 3, PR #214 P2 follow-up):
+    `StreamConfigError` (`_read_manifest_doc` refusing to clobber an
+    unparsable manifest it can't safely read first) and `OSError` (a
+    read-only manifest directory, a full disk, or any other failure from
+    `_persist_streams`'s `mkdir`/`mkstemp`/`fchmod`/write/`os.replace`
+    calls) -- both are equally "the live change succeeded, only the disk
+    write failed", so both get the same non-raising treatment.
 
     Returns:
         `(persisted, persist_error)`: `persist_error` is `None` on success
@@ -764,5 +774,5 @@ def _persist_or_report(streams_manifest: dict | None) -> tuple[bool, str | None]
     """
     try:
         return _persist_streams(streams_manifest), None
-    except StreamConfigError as exc:
+    except (StreamConfigError, OSError) as exc:
         return False, str(exc)

--- a/src/sink/publish/heartbeat.py
+++ b/src/sink/publish/heartbeat.py
@@ -218,8 +218,20 @@ class HeartbeatThread(threading.Thread):
             logging.getLogger(__name__).debug("heartbeat publish failed", exc_info=True)
             if self._spool is not None:
                 try:
-                    seq = self._spool.next_seq("heartbeat")
-                    self._spool.append("heartbeat", seq, payload)
+                    # `append_next`, not a separate `next_seq()` + `append()`
+                    # pair (Codex round 3 P1 follow-up, comment 3924082774):
+                    # that shape left a gap a concurrent writer (e.g. a
+                    # selftest run) could land in, allocating a seq that
+                    # collided with what append() then tried to use. This
+                    # `except Exception` already caught that `ValueError`
+                    # (so it was never a thread-killer here, unlike the
+                    # router's unguarded batch-flush path -- see
+                    # `router.py`), but it still silently dropped this
+                    # beat's heartbeat from the never-drop lane on a
+                    # spurious collision. The heartbeat payload itself
+                    # carries no embedded `seq` field (spec §8 -- unlike
+                    # channels/events), so the `build` callable is trivial.
+                    self._spool.append_next("heartbeat", lambda _seq: payload)
                 except Exception as exc:
                     self._spool_failures += 1
                     logging.getLogger(__name__).warning(

--- a/src/sink/publish/identity.py
+++ b/src/sink/publish/identity.py
@@ -508,17 +508,24 @@ def delete_identity(directory: pathlib.Path) -> list[str]:
     belt-and-braces, applied here to reads-become-deletes) before anything is
     unlinked:
 
-    1. If ``directory / "identity.yaml"`` doesn't exist, this is a no-op
-       returning ``[]`` -- nothing enrolled, nothing to do, so a repeat
-       ``unenroll`` call never raises.
-    2. ``load_identity(directory)`` is tried. If it parses, the deletion set
-       starts as ``{key_path, cert_path, ca_path}``: each must resolve
-       INSIDE ``directory`` or this raises ``ValueError`` immediately --
-       BEFORE any unlink -- so a hand-edited ``key_file: ../../victim``
-       pointer can never delete outside the directory. If it doesn't parse
-       (``FleetNotEnrolledError`` -- a corrupt identity.yaml), this step is
-       skipped entirely: a corrupt identity must still be removable via the
-       pattern sweep below, not permanently stuck.
+    1. If ``directory / "identity.yaml"`` doesn't exist, steps 2 and 4's
+       pointer-set/whole-file work are skipped, but the pattern sweep
+       (step 3) still runs unconditionally (Codex round 3, P2) -- it's
+       contained and non-recursive, so it's always safe, and it's the only
+       way to clean up an enroll that crashed between writing key material
+       and writing ``identity.yaml`` itself: without this, those orphaned
+       key/cert files would never be swept, since nothing else ever points
+       at them. Idempotent either way: a directory with nothing left in it
+       returns ``[]`` on the next call.
+    2. ``load_identity(directory)`` is tried (only when ``identity.yaml``
+       exists). If it parses, the deletion set starts as ``{key_path,
+       cert_path, ca_path}``: each must resolve INSIDE ``directory`` or this
+       raises ``ValueError`` immediately -- BEFORE any unlink -- so a
+       hand-edited ``key_file: ../../victim`` pointer can never delete
+       outside the directory. If it doesn't parse (``FleetNotEnrolledError``
+       -- a corrupt identity.yaml), this step is skipped entirely: a corrupt
+       identity must still be removable via the pattern sweep below, not
+       permanently stuck.
     3. This module's own naming patterns (see ``_DELETE_GLOB_PATTERNS``) are
        globbed inside ``directory`` (non-recursive) to additionally sweep up
        renewal orphans identity.yaml no longer points at. The same
@@ -531,10 +538,11 @@ def delete_identity(directory: pathlib.Path) -> list[str]:
        opportunistic best-effort sweep over whatever happens to match a
        filename pattern, so one bad entry must not block cleanup of
        everything else.
-    4. The union of steps 2+3, plus ``identity.yaml`` itself, is unlinked
-       (``missing_ok=True``); then ``directory.rmdir()`` is attempted,
-       best-effort (``OSError`` -- e.g. "not empty", because a skipped
-       symlink or an unrelated file is still in there -- is swallowed).
+    4. The union of steps 2+3, plus ``identity.yaml`` itself (only when it
+       exists), is unlinked (``missing_ok=True``); then ``directory.rmdir()``
+       is attempted, best-effort (``OSError`` -- e.g. "not empty", because a
+       skipped symlink or an unrelated file is still in there, or the
+       directory never existed at all -- is swallowed).
 
     Never uses ``shutil.rmtree``: only paths derived from steps 2 and 3
     above are ever touched.
@@ -542,9 +550,10 @@ def delete_identity(directory: pathlib.Path) -> list[str]:
     Returns:
         Sorted basenames of every file actually targeted for deletion (the
         pointer set that passed containment, the pattern-set matches that
-        passed containment, and ``identity.yaml``) -- not necessarily the
-        basenames actually removed, since ``missing_ok=True`` tolerates a
-        concurrent removal, but in the ordinary case these coincide.
+        passed containment, and ``identity.yaml`` when it exists) -- not
+        necessarily the basenames actually removed, since ``missing_ok=True``
+        tolerates a concurrent removal, but in the ordinary case these
+        coincide.
 
     Raises:
         ValueError: a pointer field in a parsable identity.yaml resolves
@@ -553,20 +562,21 @@ def delete_identity(directory: pathlib.Path) -> list[str]:
     """
     directory = pathlib.Path(directory).resolve()
     identity_path = directory / "identity.yaml"
-    if not identity_path.is_file():
-        return []
+    identity_yaml_exists = identity_path.is_file()
 
     to_delete: dict[str, pathlib.Path] = {}
-    to_delete.update(_delete_identity_pointer_set(directory))
+    if identity_yaml_exists:
+        to_delete.update(_delete_identity_pointer_set(directory))
     to_delete.update(_delete_identity_pattern_set(directory))
-    to_delete["identity.yaml"] = identity_path
+    if identity_yaml_exists:
+        to_delete["identity.yaml"] = identity_path
 
     for path in to_delete.values():
         path.unlink(missing_ok=True)
     try:
         directory.rmdir()
     except OSError:
-        pass  # not empty (a skipped entry or unrelated file remains) -- fine, best-effort
+        pass  # not empty (a skipped entry or unrelated file remains), or never existed -- fine
 
     return sorted(to_delete)
 

--- a/src/sink/publish/mqtt.py
+++ b/src/sink/publish/mqtt.py
@@ -29,6 +29,86 @@ def _dump(payload: dict) -> str:
     return json.dumps(payload, separators=(",", ":"))
 
 
+_TRUNCATED_PAYLOAD_MAX_BYTES = 200
+
+
+def _parse_heartbeat_payload(raw: bytes) -> dict:
+    """Parse a heartbeat-topic payload; fail CLOSED on anything but a JSON object.
+
+    Codex round 3 follow-up (PR #214, P2, comment 3927023413's sibling
+    finding): `wait_for_retained_heartbeat` used to treat an unparsable
+    payload (garbage bytes, or valid JSON that isn't an object -- e.g. a
+    bare array) the same as "nothing retained" and let the selftest
+    proceed. That is backwards: SOMETHING is retained on the robot's own
+    heartbeat topic and this process cannot tell what it means, so the safe
+    default is to refuse, not to guess "safe". Shared by
+    `wait_for_retained_heartbeat` (the bounded START-only probe) and
+    `MqttPublisher.watch_live_session`'s ongoing callback (Codex round 3
+    follow-up, PR #214 P1, comment 3927287968's own follow-up) so both
+    apply the identical fail-closed rule.
+
+    Raises:
+        PublishError: `raw` isn't valid UTF-8 JSON, or parses to something
+            other than a JSON object. The message names the truncated raw
+            payload (capped at 200 bytes) for diagnosis, without risking an
+            unbounded error message for a pathological payload.
+
+    """
+    truncated = raw[:_TRUNCATED_PAYLOAD_MAX_BYTES]
+    try:
+        parsed = json.loads(raw.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise PublishError(f"heartbeat topic: unparsable retained payload: {truncated!r}") from exc
+    if not isinstance(parsed, dict):
+        raise PublishError(f"heartbeat topic: retained payload is not a JSON object: {truncated!r}")
+    return parsed
+
+
+class LiveSessionWatch:
+    """Handle from `MqttPublisher.watch_live_session()`: an ONGOING probe.
+
+    Codex round 3 follow-up (PR #214, P1, comment 3927287968's own
+    follow-up): `wait_for_retained_heartbeat` only ever looks at the
+    heartbeat topic's state at ONE moment (subscribe, wait a bounded
+    window, unsubscribe) -- exactly the state at the START of a
+    `run_selftest` call. A live `FleetService` that RESUMES partway through
+    a (multi-second, `interval_s`-spaced) selftest run reopens the same
+    schema-pollution window the original START-only check was meant to
+    close: nothing about a START check tells `run_selftest` that a session
+    connected a moment ago.
+
+    `watch_live_session()` instead keeps the heartbeat subscription open
+    for as long as the caller wants (until `.stop()`), so `.detected`
+    (a `threading.Event`) can be set by ANY message arriving on the topic
+    for the life of the watch, not just the one seen at subscribe time --
+    covering exactly the "live session appears mid-run" case. `run_selftest`
+    polls `.detected.is_set()` between batches and before the
+    heartbeat/event publishes, aborting the instant it's set.
+
+    `.stop()` unsubscribes and restores the client's prior `on_message`
+    handler; idempotent (a second call is a no-op), mirroring `close()`'s
+    own idempotency contract.
+    """
+
+    def __init__(self, *, client: object, topic: str, previous_on_message: object) -> None:
+        """Store the subscribed client/topic and the handler to restore on `.stop()`."""
+        self.detected = threading.Event()
+        self._client = client
+        self._topic = topic
+        self._previous_on_message = previous_on_message
+        self._stopped = False
+
+    def stop(self) -> None:
+        """Unsubscribe and restore the client's prior `on_message` handler; idempotent."""
+        if self._stopped:
+            return
+        self._stopped = True
+        try:
+            self._client.unsubscribe(self._topic)
+        finally:
+            self._client.on_message = self._previous_on_message
+
+
 def _finalize(client: object) -> None:
     """Best-effort teardown for a garbage-collected publisher's client."""
     if client is None:
@@ -340,12 +420,18 @@ class MqttPublisher(Publisher):
         Returns:
             The retained heartbeat's parsed JSON payload, or `None` if
             nothing retained arrived within `timeout_s` (a fresh
-            robot/broker with nothing retained yet) or the retained
-            payload failed to parse (treated the same as "unknown" --
-            never raises here; the caller decides what "unknown" means).
+            robot/broker with nothing retained yet).
 
         Raises:
-            PublishError: not connected.
+            PublishError: not connected, or a retained payload DID arrive
+                but failed to parse as a JSON object -- garbage bytes or
+                valid-but-non-object JSON (e.g. a bare array) on the
+                robot's own heartbeat topic (Codex round 3 follow-up, PR
+                #214 P2, comment 3927023413's sibling finding: fail CLOSED
+                here rather than silently treating "couldn't tell" the same
+                as "definitely safe, proceed" -- see
+                `_parse_heartbeat_payload`). The message names the
+                truncated raw payload.
 
         """
         if self._client is None:
@@ -358,20 +444,83 @@ class MqttPublisher(Publisher):
             if done.is_set() or not message.retain:  # type: ignore[attr-defined]
                 return
             try:
-                result["payload"] = json.loads(message.payload.decode("utf-8"))  # type: ignore[attr-defined]
-            except (json.JSONDecodeError, UnicodeDecodeError):
-                result["payload"] = None
+                result["payload"] = _parse_heartbeat_payload(message.payload)  # type: ignore[attr-defined]
+            except PublishError as exc:
+                result["error"] = exc
             done.set()
 
         previous_on_message = self._client.on_message
         self._client.on_message = _on_retained_message
-        self._client.subscribe(topic, qos=1)
+        self._client.subscribe(topic, options=_paho().SubscribeOptions(qos=1, noLocal=True))
         try:
             done.wait(timeout=timeout_s)
         finally:
             self._client.unsubscribe(topic)
             self._client.on_message = previous_on_message
+        if "error" in result:
+            raise result["error"]  # type: ignore[misc]
         return result.get("payload")  # type: ignore[return-value]
+
+    def watch_live_session(self) -> LiveSessionWatch:
+        """Subscribe to this robot's heartbeat topic and keep watching it.
+
+        Codex round 3 follow-up (PR #214, P1, comment 3927287968's own
+        follow-up): unlike `wait_for_retained_heartbeat` (a bounded
+        one-shot probe that unsubscribes as soon as it returns), the
+        returned `LiveSessionWatch` stays subscribed until its own
+        `.stop()` is called, so `run_selftest` can keep polling
+        `.detected` for the ENTIRE run -- catching a live service that
+        RESUMES mid-run, not just one that was already connected at the
+        moment this was called. See `LiveSessionWatch`'s own docstring for
+        the full reasoning.
+
+        Every message on the topic is parsed with the same fail-closed
+        `_parse_heartbeat_payload` `wait_for_retained_heartbeat` uses: an
+        unparsable payload sets `.detected` too (can't tell what it means,
+        so don't guess "safe"), not just a payload with `online: true`.
+
+        Intended to be called right after `wait_for_retained_heartbeat` has
+        already cleared the START state (see `selftest._check_no_live_session`)
+        -- this method does not itself wait for or return the current
+        retained state; it only arms the ongoing watch going forward.
+
+        Subscribes with MQTT5's `noLocal` option set (critical, found only
+        by the live-broker e2e suite -- `FakeFleetPaho`'s unit-test double
+        doesn't simulate broker echo, so this was invisible to the mocked
+        tests): without it, a broker delivers a client's OWN publishes back
+        to itself on any topic it's subscribed to. `run_selftest` publishes
+        its OWN `online: true` heartbeat over THIS SAME publisher partway
+        through the run, on the exact topic this watch subscribes to --
+        with `noLocal=False` (the default), that publish loops straight
+        back through this watch's own `on_message` callback and gets
+        mistaken for a genuinely different, live session appearing mid-run,
+        aborting every single run. `noLocal=True` tells the broker to never
+        deliver this client's own publishes back to it, so only an actual
+        OTHER session's beat can ever set `.detected`.
+
+        Raises:
+            PublishError: not connected.
+
+        """
+        if self._client is None:
+            raise PublishError("publisher is not connected")
+        topic = wire_topic(self._tenant, self._robot, "heartbeat")
+        watch = LiveSessionWatch(
+            client=self._client, topic=topic, previous_on_message=self._client.on_message
+        )
+
+        def _on_message(_client: object, _userdata: object, message: object) -> None:
+            try:
+                payload = _parse_heartbeat_payload(message.payload)  # type: ignore[attr-defined]
+            except PublishError:
+                watch.detected.set()
+                return
+            if payload.get("online") is True:
+                watch.detected.set()
+
+        self._client.on_message = _on_message
+        self._client.subscribe(topic, options=_paho().SubscribeOptions(qos=1, noLocal=True))
+        return watch
 
     def disconnect_without_publishing(self) -> None:
         """Tear down the connection WITHOUT publishing a clean-stop heartbeat.

--- a/src/sink/publish/mqtt.py
+++ b/src/sink/publish/mqtt.py
@@ -6,6 +6,7 @@ package's no-eager-import invariant; require_fleet() remains the gate.
 
 import json
 import logging
+import threading
 import time
 import weakref
 from urllib.parse import urlparse
@@ -73,7 +74,7 @@ class MqttPublisher(Publisher):
             client_id_suffix: Appended to the deterministic
                 `bagel/{tenant}/{robot}` client id (see `connect()`).
                 Defaults to `""` (the live service's id, unchanged). The
-                selftest CLI passes `"-selftest"` here (Codex round 3
+                selftest CLI passes `"/selftest"` here (Codex round 3
                 follow-up, PR #214 P2 on comment 3925391258): the live
                 service's `MqttPublisher` and the selftest's both derive the
                 SAME client id from the same `(tenant, robot)` pair, and
@@ -90,7 +91,15 @@ class MqttPublisher(Publisher):
                 semantics the id's own determinism exists for (see
                 `connect()`'s comment) -- it just puts the selftest in its
                 own, separate client-id namespace instead of the live
-                service's.
+                service's. `"/"`, not `"-"` (Codex round 3 follow-up, PR
+                #214 P2 on comment 3927231074): a hyphen suffix
+                reintroduces exactly the hyphen-injectivity ambiguity the
+                `"/"` delimiter between tenant/robot was already fixed for
+                (see `connect()`'s comment) -- robot `"r7"` suffixed
+                `"-selftest"` would collide with a robot actually NAMED
+                `"r7-selftest"`. `"/"` is outside both id charsets (robot
+                ids match `^[a-z0-9][a-z0-9_-]{0,62}$`), so it's provably
+                collision-free the same way.
             retain_messages: When `False`, forces `retain=False` on every
                 publish (schema, heartbeat, and `close()`'s clean-stop
                 beat) and skips arming a last-will entirely (see
@@ -304,6 +313,97 @@ class MqttPublisher(Publisher):
             raise PublishError(f"{topic}: not acknowledged within {timeout_s}s: {exc}") from exc
         if info.rc != 0 or not info.is_published():
             raise PublishError(f"{topic}: publish failed (rc={info.rc})")
+
+    def wait_for_retained_heartbeat(self, timeout_s: float = 1.5) -> dict | None:
+        """Subscribe to this robot's own heartbeat topic; return a RETAINED payload, if any.
+
+        A selftest-only probe (Codex round 3 follow-up, PR #214 P1, comment
+        3927287968), NOT part of the `Publisher` ABC -- it's a `MqttPublisher`-
+        specific capability, called via `getattr(publisher,
+        "wait_for_retained_heartbeat", None)` from `selftest.run_selftest`
+        (see its `_check_no_live_session`), so any `Publisher` implementation
+        that doesn't offer it (including most test doubles) simply skips the
+        check rather than needing to grow the ABC or stub out a method it has
+        no use for. Design choice: keeping this as a small, direct-paho,
+        selftest-scoped helper on `MqttPublisher` was cleaner than adding a
+        new abstract method every `Publisher` implementation would have to
+        carry, most of which (the live service's own usage) never need it.
+
+        Subscribes at QoS 1, waits up to `timeout_s` for the FIRST message
+        with its `retain` flag set (a broker delivers any existing retained
+        message on that topic immediately upon subscribing -- before any
+        live traffic), then unsubscribes and restores the client's prior
+        `on_message` handler either way. A non-retained message (live
+        traffic arriving in the same window) is ignored; it does not
+        satisfy or extend the wait.
+
+        Returns:
+            The retained heartbeat's parsed JSON payload, or `None` if
+            nothing retained arrived within `timeout_s` (a fresh
+            robot/broker with nothing retained yet) or the retained
+            payload failed to parse (treated the same as "unknown" --
+            never raises here; the caller decides what "unknown" means).
+
+        Raises:
+            PublishError: not connected.
+
+        """
+        if self._client is None:
+            raise PublishError("publisher is not connected")
+        topic = wire_topic(self._tenant, self._robot, "heartbeat")
+        result: dict[str, object] = {}
+        done = threading.Event()
+
+        def _on_retained_message(_client: object, _userdata: object, message: object) -> None:
+            if done.is_set() or not message.retain:  # type: ignore[attr-defined]
+                return
+            try:
+                result["payload"] = json.loads(message.payload.decode("utf-8"))  # type: ignore[attr-defined]
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                result["payload"] = None
+            done.set()
+
+        previous_on_message = self._client.on_message
+        self._client.on_message = _on_retained_message
+        self._client.subscribe(topic, qos=1)
+        try:
+            done.wait(timeout=timeout_s)
+        finally:
+            self._client.unsubscribe(topic)
+            self._client.on_message = previous_on_message
+        return result.get("payload")  # type: ignore[return-value]
+
+    def disconnect_without_publishing(self) -> None:
+        """Tear down the connection WITHOUT publishing a clean-stop heartbeat.
+
+        A selftest-only cleanup helper (Codex round 3 follow-up, PR #214
+        P1, comment 3927287968), used when `run_selftest`'s live-session
+        refusal (`wait_for_retained_heartbeat` found a connected live
+        session) needs to release THIS session's deterministic client id
+        before raising -- otherwise it lingers until this `MqttPublisher`
+        is eventually garbage-collected, which is neither prompt nor
+        reliable enough to guarantee a follow-up run can immediately
+        reclaim the same client id cleanly.
+
+        Deliberately NOT `close()`: a live session was just detected as
+        connected, and even `close()`'s non-retained clean-stop beat (with
+        `retain_messages=False`) would still deliver a misleading momentary
+        `online: false` to whoever is watching THAT live session's own
+        heartbeat topic -- exactly the class of problem this whole
+        precondition exists to prevent. This tears the connection down
+        silently: no publish of any kind.
+
+        Idempotent and safe when never connected, same as `close()`.
+        """
+        client, self._client = self._client, None
+        if client is None:
+            return
+        self._closing = True
+        try:
+            client.loop_stop()
+            client.disconnect()
+        finally:
+            self._closing = False
 
     def close(self, reason: str = "stopped") -> None:
         """Publish a clean-stop heartbeat (best-effort) then stop and disconnect.

--- a/src/sink/publish/mqtt.py
+++ b/src/sink/publish/mqtt.py
@@ -55,6 +55,7 @@ class MqttPublisher(Publisher):
         password: str | None = None,
         keepalive_s: int = 30,
         client_id_suffix: str = "",
+        retain_messages: bool = True,
     ) -> None:
         """Parse `broker_url` and stash connection options; does not connect.
 
@@ -90,6 +91,30 @@ class MqttPublisher(Publisher):
                 `connect()`'s comment) -- it just puts the selftest in its
                 own, separate client-id namespace instead of the live
                 service's.
+            retain_messages: When `False`, forces `retain=False` on every
+                publish (schema, heartbeat, and `close()`'s clean-stop
+                beat) and skips arming a last-will entirely (see
+                `connect()`). Defaults to `True` (the live service's
+                behavior, unchanged -- retained schema/heartbeat/LWT are
+                load-bearing there: a
+                late subscriber must be able to decode live batches and
+                see current liveness without waiting for the next publish).
+                The selftest CLI passes `False` (Codex round 3 follow-up,
+                PR #214 P1 on comment 3927023413): it keeps publishing AS
+                the robot (client-id suffix aside, cert-CN ACLs make an
+                isolated identity a non-starter -- see `client_id_suffix`
+                above), so its retained publishes would otherwise linger
+                on the SAME shared robot topics with nothing to overwrite
+                them once the run ends -- its fixture schema staying
+                retained until the live service's next reconnect (a late
+                subscriber decodes live batches against the WRONG schema
+                in the meantime), and its `close()` beat leaving a
+                retained `online: false` (the robot looks dead until the
+                next live beat). Retention is not load-bearing for
+                conformance -- the validator subscribes before/during the
+                run, and the wire contract's §10 sequence is about
+                ordering and shape, not retention -- so going fully
+                non-retained costs the selftest nothing.
 
         Raises:
             ValueError: If `broker_url`'s scheme is not `mqtt` or `mqtts`, or it has
@@ -107,6 +132,7 @@ class MqttPublisher(Publisher):
         self._tenant = tenant
         self._robot = robot
         self._client_id_suffix = client_id_suffix
+        self._retain_messages = retain_messages
         self._tls = {"ca_certs": tls_ca_certs, "certfile": tls_certfile, "keyfile": tls_keyfile}
         self._username = username
         self._password = password
@@ -188,12 +214,24 @@ class MqttPublisher(Publisher):
             client_id=f"bagel/{self._tenant}/{self._robot}{self._client_id_suffix}",
             protocol=paho.MQTTv5,
         )
-        client.will_set(
-            wire_topic(self._tenant, self._robot, "heartbeat"),
-            _dump(LWT_PAYLOAD),
-            qos=1,
-            retain=True,
-        )
+        # No LWT at all when `retain_messages` is False (Codex round 3
+        # follow-up, PR #214 P1 on comment 3927023413): `will_set` exists to
+        # tell subscribers the ROBOT went offline unexpectedly, RETAINED so
+        # a late subscriber still sees it -- neither half of that applies to
+        # an ephemeral, non-retained session like the selftest's. It isn't
+        # "the robot" going offline, just a diagnostic run ending, and
+        # arming even a non-retained will would still momentarily publish a
+        # confusing "offline" blip on the SHARED robot heartbeat topic to
+        # anyone watching live if this session ever dropped uncleanly.
+        # Simplest and safest: skip arming a will at all for this mode,
+        # rather than merely un-retaining it.
+        if self._retain_messages:
+            client.will_set(
+                wire_topic(self._tenant, self._robot, "heartbeat"),
+                _dump(LWT_PAYLOAD),
+                qos=1,
+                retain=True,
+            )
         if self._use_tls:
             client.tls_set(**self._tls)
         if self._username is not None:
@@ -247,11 +285,19 @@ class MqttPublisher(Publisher):
     def publish(
         self, kind: str, payload: dict, *, retain: bool = False, timeout_s: float = 10.0
     ) -> None:
-        """Publish `payload` as JSON at QoS 1 on the wire topic for `kind`."""
+        """Publish `payload` as JSON at QoS 1 on the wire topic for `kind`.
+
+        `retain` is forced to `False` when `self._retain_messages` is
+        `False` regardless of what the caller (e.g. `Publisher.
+        publish_schema`/`publish_heartbeat`, which always call with
+        `retain=True`) requested -- see `__init__`'s `retain_messages`
+        docstring for why the selftest needs this.
+        """
         if self._client is None:
             raise PublishError("publisher is not connected")
         topic = wire_topic(self._tenant, self._robot, kind)
-        info = self._client.publish(topic, _dump(payload), qos=1, retain=retain)
+        effective_retain = retain and self._retain_messages
+        info = self._client.publish(topic, _dump(payload), qos=1, retain=effective_retain)
         try:
             info.wait_for_publish(timeout=timeout_s)
         except Exception as exc:
@@ -269,7 +315,13 @@ class MqttPublisher(Publisher):
                 field (spec §3). `FleetService.stop()` uses the default
                 `"stopped"`; `FleetService.pause()` passes `"paused"` so a
                 paused robot's last retained heartbeat reads distinctly from
-                a genuinely stopped one.
+                a genuinely stopped one. Retained only when
+                `self._retain_messages` is `True` (the live service default)
+                -- the selftest's clean-stop beat must not leave a retained
+                `online: false` corpse on the shared robot's heartbeat
+                topic (Codex round 3 follow-up, PR #214 P1 on comment
+                3927023413), or the robot would look dead until its live
+                service's next beat.
 
         """
         client, self._client = self._client, None
@@ -284,7 +336,7 @@ class MqttPublisher(Publisher):
                         wire_topic(self._tenant, self._robot, "heartbeat"),
                         _dump(stopped),
                         qos=1,
-                        retain=True,
+                        retain=self._retain_messages,
                     )
                     info.wait_for_publish(timeout=5.0)
                 except Exception:

--- a/src/sink/publish/mqtt.py
+++ b/src/sink/publish/mqtt.py
@@ -54,6 +54,7 @@ class MqttPublisher(Publisher):
         username: str | None = None,
         password: str | None = None,
         keepalive_s: int = 30,
+        client_id_suffix: str = "",
     ) -> None:
         """Parse `broker_url` and stash connection options; does not connect.
 
@@ -68,6 +69,27 @@ class MqttPublisher(Publisher):
             username: Broker username, if auth is required.
             password: Broker password, if auth is required.
             keepalive_s: MQTT keepalive interval in seconds.
+            client_id_suffix: Appended to the deterministic
+                `bagel/{tenant}/{robot}` client id (see `connect()`).
+                Defaults to `""` (the live service's id, unchanged). The
+                selftest CLI passes `"-selftest"` here (Codex round 3
+                follow-up, PR #214 P2 on comment 3925391258): the live
+                service's `MqttPublisher` and the selftest's both derive the
+                SAME client id from the same `(tenant, robot)` pair, and
+                MQTT brokers kick the existing session when a NEW connection
+                claims an already-connected client id -- so running the
+                selftest against an enrolled robot's `mqtts://` broker,
+                while that robot's real streaming service is also
+                connected, would silently DISPLACE (disconnect) the live
+                session. Cloud confirmed ACLs key on the cert CN, not the
+                client id, so appending a suffix here is free -- it doesn't
+                touch authorization. Still fully deterministic (no
+                randomness): the same `(tenant, robot, suffix)` always
+                produces the same id, preserving the reconnect-displacement
+                semantics the id's own determinism exists for (see
+                `connect()`'s comment) -- it just puts the selftest in its
+                own, separate client-id namespace instead of the live
+                service's.
 
         Raises:
             ValueError: If `broker_url`'s scheme is not `mqtt` or `mqtts`, or it has
@@ -84,6 +106,7 @@ class MqttPublisher(Publisher):
         self._use_tls = parsed.scheme == "mqtts" or any((tls_ca_certs, tls_certfile, tls_keyfile))
         self._tenant = tenant
         self._robot = robot
+        self._client_id_suffix = client_id_suffix
         self._tls = {"ca_certs": tls_ca_certs, "certfile": tls_certfile, "keyfile": tls_keyfile}
         self._username = username
         self._password = password
@@ -156,9 +179,13 @@ class MqttPublisher(Publisher):
             # unlike the old "bagel-{tenant}-{robot}" hyphen join, where
             # ("acme-west", "r7") and ("acme", "west-r7") both produced
             # "bagel-acme-west-r7" (Codex review). Mirrors the cert CN's
-            # delimiter. Must stay deterministic per (tenant, robot):
-            # reconnect displacement semantics depend on it.
-            client_id=f"bagel/{self._tenant}/{self._robot}",
+            # delimiter. Must stay deterministic per (tenant, robot,
+            # client_id_suffix): reconnect displacement semantics depend on
+            # it. `client_id_suffix` defaults to "" (unchanged live-service
+            # id); the selftest CLI passes "-selftest" so it never displaces
+            # the live service's own session on the same broker (see
+            # `__init__`'s docstring).
+            client_id=f"bagel/{self._tenant}/{self._robot}{self._client_id_suffix}",
             protocol=paho.MQTTv5,
         )
         client.will_set(

--- a/src/sink/publish/mqtt.py
+++ b/src/sink/publish/mqtt.py
@@ -41,11 +41,16 @@ def _parse_heartbeat_payload(raw: bytes) -> dict:
     bare array) the same as "nothing retained" and let the selftest
     proceed. That is backwards: SOMETHING is retained on the robot's own
     heartbeat topic and this process cannot tell what it means, so the safe
-    default is to refuse, not to guess "safe". Shared by
-    `wait_for_retained_heartbeat` (the bounded START-only probe) and
-    `MqttPublisher.watch_live_session`'s ongoing callback (Codex round 3
-    follow-up, PR #214 P1, comment 3927287968's own follow-up) so both
-    apply the identical fail-closed rule.
+    default is to refuse, not to guess "safe".
+
+    Used ONLY by `wait_for_retained_heartbeat` (the bounded, one-shot,
+    START-only probe against the retained heartbeat state) -- NOT by
+    `MqttPublisher.watch_live_session`'s ongoing mid-run watch (Codex
+    round 3 follow-up, PR #214 P1, comment 3928569268): that watch is
+    content-agnostic by design (ANY message on either watched topic is,
+    by construction via `noLocal`/`retainHandling=2`, already proof of a
+    genuinely different live session -- see its own docstring), so it has
+    nothing left to parse.
 
     Raises:
         PublishError: `raw` isn't valid UTF-8 JSON, or parses to something
@@ -77,34 +82,57 @@ class LiveSessionWatch:
     close: nothing about a START check tells `run_selftest` that a session
     connected a moment ago.
 
-    `watch_live_session()` instead keeps the heartbeat subscription open
-    for as long as the caller wants (until `.stop()`), so `.detected`
-    (a `threading.Event`) can be set by ANY message arriving on the topic
-    for the life of the watch, not just the one seen at subscribe time --
-    covering exactly the "live session appears mid-run" case. `run_selftest`
-    polls `.detected.is_set()` between batches and before the
-    heartbeat/event publishes, aborting the instant it's set.
+    `watch_live_session()` instead keeps BOTH the heartbeat AND schema
+    topic subscriptions open for as long as the caller wants (until
+    `.stop()`), so `.detected` (a `threading.Event`) can be set by ANY
+    message arriving on EITHER topic for the life of the watch, not just
+    the one seen at subscribe time -- covering exactly the "live session
+    appears mid-run" case. `run_selftest` polls `.detected.is_set()`
+    between batches and before the heartbeat/event publishes, aborting the
+    instant it's set.
 
-    `.stop()` unsubscribes and restores the client's prior `on_message`
-    handler; idempotent (a second call is a no-op), mirroring `close()`'s
-    own idempotency contract.
+    Codex round 3 follow-up (PR #214, P1, comment 3928569268): watching
+    ONLY the heartbeat topic missed a real failure chain -- a resuming
+    `FleetService`'s heartbeat thread can block indefinitely in
+    `spool.stats()` on the exclusive lock this selftest run holds, so it
+    may never emit the `online: true` beat the original watch depended on,
+    while its ROUTER (a separate, lock-free pending/reconnect path)
+    reconnects and republishes the live schema regardless. Watching BOTH
+    topics -- and, per that same comment, watching for the pollution ACT
+    ITSELF rather than parsing message content (see
+    `MqttPublisher.watch_live_session`'s own docstring for the
+    `noLocal`/`retainHandling` reasoning that makes "any delivery = abort"
+    safe) -- closes that gap independent of whatever lock a resuming
+    service happens to be stuck behind.
+
+    `.stop()` unsubscribes both topics and restores the client's prior
+    `on_message` handler; idempotent (a second call is a no-op), mirroring
+    `close()`'s own idempotency contract.
     """
 
-    def __init__(self, *, client: object, topic: str, previous_on_message: object) -> None:
-        """Store the subscribed client/topic and the handler to restore on `.stop()`."""
+    def __init__(
+        self, *, client: object, topics: tuple[str, ...], previous_on_message: object
+    ) -> None:
+        """Store the subscribed client/topics and the handler to restore on `.stop()`."""
         self.detected = threading.Event()
         self._client = client
-        self._topic = topic
+        self._topics = topics
         self._previous_on_message = previous_on_message
         self._stopped = False
 
     def stop(self) -> None:
-        """Unsubscribe and restore the client's prior `on_message` handler; idempotent."""
+        """Unsubscribe both topics and restore the client's prior `on_message` handler.
+
+        Idempotent. Best-effort across both topics: an `unsubscribe`
+        failure on the first topic does not skip the second, and the
+        `on_message` handler is always restored in a `finally`.
+        """
         if self._stopped:
             return
         self._stopped = True
         try:
-            self._client.unsubscribe(self._topic)
+            for topic in self._topics:
+                self._client.unsubscribe(topic)
         finally:
             self._client.on_message = self._previous_on_message
 
@@ -462,41 +490,65 @@ class MqttPublisher(Publisher):
         return result.get("payload")  # type: ignore[return-value]
 
     def watch_live_session(self) -> LiveSessionWatch:
-        """Subscribe to this robot's heartbeat topic and keep watching it.
+        """Subscribe to this robot's heartbeat AND schema topics; keep watching both.
 
         Codex round 3 follow-up (PR #214, P1, comment 3927287968's own
-        follow-up): unlike `wait_for_retained_heartbeat` (a bounded
-        one-shot probe that unsubscribes as soon as it returns), the
-        returned `LiveSessionWatch` stays subscribed until its own
-        `.stop()` is called, so `run_selftest` can keep polling
-        `.detected` for the ENTIRE run -- catching a live service that
-        RESUMES mid-run, not just one that was already connected at the
-        moment this was called. See `LiveSessionWatch`'s own docstring for
-        the full reasoning.
+        follow-up; widened by comment 3928569268): unlike
+        `wait_for_retained_heartbeat` (a bounded one-shot probe that
+        unsubscribes as soon as it returns), the returned `LiveSessionWatch`
+        stays subscribed until its own `.stop()` is called, so `run_selftest`
+        can keep polling `.detected` for the ENTIRE run -- catching a live
+        service that RESUMES mid-run, not just one that was already
+        connected at the moment this was called. See `LiveSessionWatch`'s
+        own docstring for the full reasoning.
 
-        Every message on the topic is parsed with the same fail-closed
-        `_parse_heartbeat_payload` `wait_for_retained_heartbeat` uses: an
-        unparsable payload sets `.detected` too (can't tell what it means,
-        so don't guess "safe"), not just a payload with `online: true`.
+        Watches BOTH topics, not just heartbeat (comment 3928569268): a
+        resuming `FleetService`'s heartbeat thread can block indefinitely in
+        `spool.stats()` on the exclusive lock this selftest run holds, so it
+        may NEVER emit the `online: true` beat a heartbeat-only watch
+        depends on -- while its ROUTER (a separate, lock-free
+        pending/reconnect path) reconnects and republishes the live schema
+        regardless. Watching the schema topic too closes that gap
+        independent of whatever lock a resuming service happens to be stuck
+        behind: the schema publish itself IS the pollution.
+
+        No payload parsing any more, on EITHER topic (comment 3928569268):
+        this now watches for the pollution ACT ITSELF -- any message
+        arriving at all -- rather than trying to decide from its content
+        whether it's "dangerous". That simplification is only safe because
+        of the two subscribe options below; without them it would false-
+        abort constantly.
 
         Intended to be called right after `wait_for_retained_heartbeat` has
         already cleared the START state (see `selftest._check_no_live_session`)
         -- this method does not itself wait for or return the current
         retained state; it only arms the ongoing watch going forward.
 
-        Subscribes with MQTT5's `noLocal` option set (critical, found only
-        by the live-broker e2e suite -- `FakeFleetPaho`'s unit-test double
-        doesn't simulate broker echo, so this was invisible to the mocked
-        tests): without it, a broker delivers a client's OWN publishes back
-        to itself on any topic it's subscribed to. `run_selftest` publishes
-        its OWN `online: true` heartbeat over THIS SAME publisher partway
-        through the run, on the exact topic this watch subscribes to --
-        with `noLocal=False` (the default), that publish loops straight
-        back through this watch's own `on_message` callback and gets
-        mistaken for a genuinely different, live session appearing mid-run,
-        aborting every single run. `noLocal=True` tells the broker to never
-        deliver this client's own publishes back to it, so only an actual
-        OTHER session's beat can ever set `.detected`.
+        Subscribes both topics with TWO MQTT5 `SubscribeOptions`:
+
+        - `noLocal=True` (critical, found only by the live-broker e2e suite
+          -- `FakeFleetPaho`'s unit-test double doesn't simulate broker
+          echo, so this was invisible to the mocked tests): without it, a
+          broker delivers a client's OWN publishes back to itself on a
+          topic it's subscribed to. `run_selftest` publishes its OWN schema
+          and heartbeat over THIS SAME publisher during the run, on these
+          exact topics -- with `noLocal=False` (the default), those
+          publishes loop straight back through this watch's own
+          `on_message` callback and get mistaken for a genuinely different,
+          live session, aborting every single run. `noLocal=True` tells the
+          broker to never deliver this client's own publishes back to it,
+          so only an actual OTHER session's message can ever set
+          `.detected`.
+        - `retainHandling=2` (`RETAIN_DO_NOT_SEND`, comment 3928569268):
+          a retained schema ALWAYS exists on a robot's schema topic once
+          anything has ever run there (the live service's own pre-pause
+          schema, if nothing else) -- the MQTT5 default (`retainHandling=0`,
+          `RETAIN_SEND_ON_SUBSCRIBE`) would replay it the instant this
+          subscribes, and since content is no longer parsed, that replay
+          alone would false-abort every single run. `retainHandling=2`
+          suppresses that replay entirely: only a message actually
+          PUBLISHED after this subscribes can ever arrive, which is exactly
+          what "a NEW publish from another session" means.
 
         Raises:
             PublishError: not connected.
@@ -504,22 +556,27 @@ class MqttPublisher(Publisher):
         """
         if self._client is None:
             raise PublishError("publisher is not connected")
-        topic = wire_topic(self._tenant, self._robot, "heartbeat")
+        heartbeat_topic = wire_topic(self._tenant, self._robot, "heartbeat")
+        schema_topic = wire_topic(self._tenant, self._robot, "schema")
         watch = LiveSessionWatch(
-            client=self._client, topic=topic, previous_on_message=self._client.on_message
+            client=self._client,
+            topics=(heartbeat_topic, schema_topic),
+            previous_on_message=self._client.on_message,
         )
 
-        def _on_message(_client: object, _userdata: object, message: object) -> None:
-            try:
-                payload = _parse_heartbeat_payload(message.payload)  # type: ignore[attr-defined]
-            except PublishError:
-                watch.detected.set()
-                return
-            if payload.get("online") is True:
-                watch.detected.set()
+        def _on_message(_client: object, _userdata: object, _message: object) -> None:
+            # Content-agnostic by design (comment 3928569268): `noLocal`
+            # already rules out this session's own publishes, and
+            # `retainHandling=2` already rules out the pre-existing
+            # retained schema -- so ANY delivery that reaches here is, by
+            # construction, a NEW publish from a genuinely different
+            # session. There is nothing left to parse or decide.
+            watch.detected.set()
 
         self._client.on_message = _on_message
-        self._client.subscribe(topic, options=_paho().SubscribeOptions(qos=1, noLocal=True))
+        options = _paho().SubscribeOptions(qos=1, noLocal=True, retainHandling=2)
+        self._client.subscribe(heartbeat_topic, options=options)
+        self._client.subscribe(schema_topic, options=options)
         return watch
 
     def disconnect_without_publishing(self) -> None:

--- a/src/sink/publish/router.py
+++ b/src/sink/publish/router.py
@@ -238,6 +238,21 @@ class StreamRouter(threading.Thread):
         and exit the loop so `alive`/`last_error` surface it to
         `FleetService.status()`.
 
+        This catch-all is exactly why `_tick`'s spool writes MUST go
+        through `Spool.append_next()`, never a separate `next_seq()` +
+        `append()` pair (Codex round 3 P1, comment 3924082774):
+        investigation for that fix confirmed the old two-call pattern's
+        `ValueError` (raised when a concurrent writer -- e.g. a selftest
+        run's `spool.exclusive()` -- interleaved between the two calls and
+        advanced the lane first) was completely unguarded here. It
+        propagated straight out of `_tick()` into this `except`, which
+        treated it as the fatal "bug in Spool" case and KILLED the thread --
+        `alive` false, streaming dead until the service is restarted, from
+        what was actually a harmless, expected race between two legitimate
+        writers. `append_next()` closes the race structurally (allocate and
+        write in one lock acquisition), so this failure mode is now
+        unreachable, not merely less likely.
+
         On a clean exit (the stop signal, not a fatal `_tick` error), this
         calls `_final_flush()` as the very last thing before returning --
         see its docstring for why samples the tap already accepted (via
@@ -270,6 +285,10 @@ class StreamRouter(threading.Thread):
         `pause(discard=True)` is unaffected: it flushes here same as any
         other stop, then FleetService acks past the newly-spooled batch's
         seq, same as it always could for anything already in the spool.
+
+        Uses `Spool.append_next()` (Codex round 3 P1 follow-up), not a
+        `next_seq()` + `append()` pair -- see `run()`'s docstring for why
+        the two-call shape is unsafe here.
         """
         while True:
             samples = self._queue.drain(max_items=500, timeout_s=0.0)
@@ -279,9 +298,7 @@ class StreamRouter(threading.Thread):
                 self._core.offer(topic, t, msg)
         now = time.time()
         while (batch := self._core.flush(now)) is not None:
-            seq = self._spool.next_seq("channels")
-            batch["seq"] = seq
-            self._spool.append("channels", seq, batch)
+            self._spool.append_next("channels", lambda seq, batch=batch: {**batch, "seq": seq})
 
     def _tick(self, now: float) -> None:
         """One iteration: drain+offer+maybe-flush-to-spool, then publish.
@@ -293,9 +310,10 @@ class StreamRouter(threading.Thread):
         `core.flush(now)` caps its own output at `max_samples` (Codex
         review), so a should_flush-triggered flush loops here until it
         returns `None` -- every chunk gets its own seq and its own spool
-        append, so a wide manifest's oversized batch is fully drained and
-        durably spooled within this one tick rather than trickling out over
-        several.
+        append (via `Spool.append_next()`, atomically -- see `run()`'s
+        docstring), so a wide manifest's oversized batch is fully drained
+        and durably spooled within this one tick rather than trickling out
+        over several.
         """
         timeout_s = min(0.2, self._core.flush_interval_s)
         samples = self._queue.drain(max_items=500, timeout_s=timeout_s)
@@ -303,9 +321,9 @@ class StreamRouter(threading.Thread):
             self._core.offer(topic, t, msg)
         if self._core.should_flush(now, self._core.pending_count):
             while (batch := self._core.flush(now)) is not None:
-                seq = self._spool.next_seq("channels")
-                batch["seq"] = seq
-                self._spool.append("channels", seq, batch)
+                self._spool.append_next(
+                    "channels", lambda seq, batch=batch: {**batch, "seq": seq}
+                )
         self._pump(now)
 
     def _pump(self, now: float) -> None:

--- a/src/sink/publish/selftest.py
+++ b/src/sink/publish/selftest.py
@@ -43,10 +43,11 @@ from src.sink.publish.heartbeat import build_heartbeat, disk_free
 from src.sink.publish.identity import Identity, load_identity
 from src.sink.publish.mqtt import MqttPublisher
 from src.sink.publish.publisher import Publisher, PublishError
-from src.sink.publish.spool import Spool
+from src.sink.publish.spool import Spool, SpoolLockedError
 
 DEFAULT_BATCHES = 10
 DEFAULT_INTERVAL_S = 0.5
+DEFAULT_LOCK_TIMEOUT_S = 5.0
 
 
 class SelftestPreconditionError(ValueError):
@@ -135,13 +136,14 @@ def _check_no_pending_backlog(spool: Spool) -> None:
             )
 
 
-def run_selftest(
+def run_selftest(  # noqa: PLR0913
     publisher: Publisher,
     spool: Spool,
     *,
     batches: int = DEFAULT_BATCHES,
     interval_s: float = 0.0,
     now: Callable[[], float] = time.time,
+    lock_timeout_s: float = DEFAULT_LOCK_TIMEOUT_S,
 ) -> dict:
     """Publish the conformance fixture end to end: schema, batches, heartbeat, event.
 
@@ -158,6 +160,19 @@ def run_selftest(
     otherwise this run's own first ack would advance the watermark past
     that pre-existing backlog and silently drop it.
 
+    The entire run -- the backlog check and every `next_seq`/`append`/`ack`
+    call that follows -- holds `spool.exclusive()` (Codex round 3, P1b): a
+    concurrently running `FleetService`/`StreamRouter` writing this same real
+    spool waits for the selftest to finish instead of racing it for seqs
+    (previously, `next_seq` then `append` released the lock in between,
+    letting a concurrent writer interleave and see the seq monotonicity
+    check fail with `ValueError` -- clean, but nondeterministic). If a
+    different writer already holds the lock for longer than `lock_timeout_s`,
+    this refuses to start at all rather than hanging. Pausing the real
+    service before running the selftest (see the runbook) remains good
+    practice -- it avoids the brief wait -- but is no longer required for
+    correctness.
+
     Args:
         publisher: A connected-or-connectable `Publisher` (typically
             `MqttPublisher`).
@@ -166,91 +181,102 @@ def run_selftest(
         interval_s: Delay between batches (0 in tests; the CLI defaults this
             to 0.5s so a subscriber can observe batches arriving over time).
         now: Clock, injectable for deterministic tests.
+        lock_timeout_s: Seconds to wait for `spool.exclusive()` before
+            refusing to start (typed `SelftestPreconditionError`).
 
     Returns:
         `{"channels": 4, "batches", "samples", "heartbeat": 1, "events": 1,
         "channels_seq": [first, last], "events_seq": <seq>}`.
 
     Raises:
-        SelftestPreconditionError: a spool lane has pending unacked backlog
-            -- checked first, before any connect/append side effect.
+        SelftestPreconditionError: a spool lane has pending unacked backlog,
+            or another writer already holds the spool's lock -- both checked
+            before any connect/append side effect.
         Whatever `publisher`/`spool` raise thereafter (typically
         `PublishError` or a spool `ValueError`/`SpoolError`) -- always
-        re-raised after the cleanup above.
+        re-raised after the cleanup below.
 
     """
-    _check_no_pending_backlog(spool)
-
-    last_channels_seq: int | None = None
-    last_events_seq: int | None = None
-    channels_seqs: list[int] = []
-    total_samples = 0
-    t0 = now()
-
     try:
-        publisher.connect()
-        publisher.publish_schema({"v": 1, "channels": SELFTEST_CHANNELS})
+        lock = spool.exclusive(timeout=lock_timeout_s)
+    except SpoolLockedError as exc:
+        raise SelftestPreconditionError(
+            f"selftest refused: another writer holds the spool ({exc})"
+        ) from exc
 
-        for i in range(batches):
-            t = now()
-            batch = _build_batch(i, t)
-            seq = spool.next_seq("channels")
-            batch["seq"] = seq
-            spool.append("channels", seq, batch)
-            last_channels_seq = seq
-            publisher.publish_channels(batch)
-            spool.ack("channels", seq)
-            channels_seqs.append(seq)
-            total_samples += len(batch["samples"])
-            if interval_s:
-                time.sleep(interval_s)
+    with lock:
+        _check_no_pending_backlog(spool)
 
-        heartbeat_payload = build_heartbeat(
-            started_at=t0,
-            subscriptions=["selftest"],
-            channels_active=len(SELFTEST_CHANNELS),
-            queue_depth=0,
-            queue_dropped=0,
-            spool_stats=spool.stats(),
-            disk_free_bytes=disk_free(settings.CACHE_DIRECTORY),
-            reconnects=0,
-            now=now(),
-        )
-        publisher.publish_heartbeat(heartbeat_payload)
+        last_channels_seq: int | None = None
+        last_events_seq: int | None = None
+        channels_seqs: list[int] = []
+        total_samples = 0
+        t0 = now()
 
-        events_seq = spool.next_seq("events")
-        event_payload = {
-            "v": 1,
-            "seq": events_seq,
-            "event_id": f"selftest-{uuid.uuid4()}",
-            "name": "selftest",
-            "t_start": t0,
-            "t_end": now(),
-            "source_topic": "selftest",
-            "summary": {"kind": "selftest", "batches": batches},
+        try:
+            publisher.connect()
+            publisher.publish_schema({"v": 1, "channels": SELFTEST_CHANNELS})
+
+            for i in range(batches):
+                t = now()
+                batch = _build_batch(i, t)
+                seq = spool.next_seq("channels")
+                batch["seq"] = seq
+                spool.append("channels", seq, batch)
+                last_channels_seq = seq
+                publisher.publish_channels(batch)
+                spool.ack("channels", seq)
+                channels_seqs.append(seq)
+                total_samples += len(batch["samples"])
+                if interval_s:
+                    time.sleep(interval_s)
+
+            heartbeat_payload = build_heartbeat(
+                started_at=t0,
+                subscriptions=["selftest"],
+                channels_active=len(SELFTEST_CHANNELS),
+                queue_depth=0,
+                queue_dropped=0,
+                spool_stats=spool.stats(),
+                disk_free_bytes=disk_free(settings.CACHE_DIRECTORY),
+                reconnects=0,
+                now=now(),
+            )
+            publisher.publish_heartbeat(heartbeat_payload)
+
+            events_seq = spool.next_seq("events")
+            event_payload = {
+                "v": 1,
+                "seq": events_seq,
+                "event_id": f"selftest-{uuid.uuid4()}",
+                "name": "selftest",
+                "t_start": t0,
+                "t_end": now(),
+                "source_topic": "selftest",
+                "summary": {"kind": "selftest", "batches": batches},
+            }
+            spool.append("events", events_seq, event_payload)
+            last_events_seq = events_seq
+            publisher.publish_event(event_payload)
+            spool.ack("events", events_seq)
+
+            publisher.close()
+        except Exception:
+            if last_channels_seq is not None:
+                spool.ack("channels", last_channels_seq)
+            if last_events_seq is not None:
+                spool.ack("events", last_events_seq)
+            raise
+
+        return {
+            "channels": len(SELFTEST_CHANNELS),
+            "batches": batches,
+            "samples": total_samples,
+            "heartbeat": 1,
+            "events": 1,
+            "channels_seq": [channels_seqs[0], channels_seqs[-1]] if channels_seqs else [],
+            "events_seq": events_seq,
         }
-        spool.append("events", events_seq, event_payload)
-        last_events_seq = events_seq
-        publisher.publish_event(event_payload)
-        spool.ack("events", events_seq)
-
-        publisher.close()
-    except Exception:
-        if last_channels_seq is not None:
-            spool.ack("channels", last_channels_seq)
-        if last_events_seq is not None:
-            spool.ack("events", last_events_seq)
-        raise
-
-    return {
-        "channels": len(SELFTEST_CHANNELS),
-        "batches": batches,
-        "samples": total_samples,
-        "heartbeat": 1,
-        "events": 1,
-        "channels_seq": [channels_seqs[0], channels_seqs[-1]] if channels_seqs else [],
-        "events_seq": events_seq,
-    }
 
 
 def _build_arg_parser() -> argparse.ArgumentParser:
@@ -310,9 +336,9 @@ def main(argv: list[str] | None = None) -> int:
     Returns 0 and prints the `run_selftest` summary as one line of JSON on
     success. On any expected failure state (fleet disabled/not installed,
     unenrolled with no `--broker` override, bad broker config, a publish
-    failure, a spool lane with pending backlog, or a concurrently running
-    service's spool `ValueError`), prints the typed error's message to
-    stderr (no traceback) and returns 1.
+    failure, a spool lane with pending backlog, or another writer already
+    holding the spool's lock), prints the typed error's message to stderr
+    (no traceback) and returns 1.
     """
     args = _build_arg_parser().parse_args(argv)
     try:

--- a/src/sink/publish/selftest.py
+++ b/src/sink/publish/selftest.py
@@ -219,6 +219,68 @@ def _check_no_live_session(
         )
 
 
+def _open_live_session_watch(publisher: Publisher) -> object | None:
+    """Arm the ONGOING live-session watch for the rest of the run, if offered.
+
+    Codex round 3 follow-up (PR #214 P1, comment 3927287968's own
+    follow-up): `_check_no_live_session` only ever proves the heartbeat
+    topic's state at the moment it's called -- right after `connect()`,
+    before the schema publish. A live `FleetService` that RESUMES any time
+    AFTER that check (mid-run, between batches, or even between the last
+    batch and the heartbeat/event publishes) reopens the exact schema-
+    pollution window `_check_no_live_session` exists to close, since
+    nothing about a one-shot START check tells `run_selftest` about a
+    session that connects a moment later.
+
+    `publisher.watch_live_session()` (see `MqttPublisher`'s implementation),
+    called here right after `_check_no_live_session` has cleared the START
+    state, keeps the heartbeat subscription open for the remainder of the
+    run -- `run_selftest` polls the returned watch's `.detected` Event
+    between batches and before the heartbeat/event publishes via
+    `_abort_if_live_session_detected`. Same optional-capability pattern as
+    `_check_no_live_session`'s own probe (`getattr(...,  None)`): a
+    `Publisher` that doesn't offer this (most test doubles, and any future
+    non-MQTT implementation) simply isn't watched, matching this module's
+    existing behavior before this round.
+    """
+    open_watch = getattr(publisher, "watch_live_session", None)
+    if open_watch is None:
+        return None
+    return open_watch()
+
+
+def _abort_if_live_session_detected(watch: object | None, publisher: Publisher) -> None:
+    """Raise the same typed refusal as `_check_no_live_session` if `watch` fired.
+
+    Called between every channel batch and immediately before the
+    heartbeat and event publishes (see `run_selftest`) -- checking the
+    SAME `watch.detected` Event a live beat's paho callback sets the
+    instant it arrives (Codex round 3 follow-up, PR #214 P1, comment
+    3927287968's own follow-up), so a live service resuming at any point
+    during the run is caught before this run's next publish, not just at
+    the very start.
+
+    Mirrors `_check_no_live_session`'s own refusal exactly: the connection
+    is torn down silently via `disconnect_without_publishing` (never
+    `close()`, which would publish a clean-stop beat and could itself
+    mislead whoever is watching the live session's own heartbeat topic) --
+    the same typed `SelftestPreconditionError`, the same "exit 1" contract
+    via `main()`'s `_EXPECTED_ERRORS`. `watch.stop()` is deliberately NOT
+    called here: `disconnect_without_publishing` already tears down the
+    whole underlying connection the watch's subscription lives on, so
+    there is nothing left for `.stop()` to usefully unwind.
+    """
+    if watch is None or not watch.detected.is_set():  # type: ignore[attr-defined]
+        return
+    disconnect_silently = getattr(publisher, "disconnect_without_publishing", None)
+    if disconnect_silently is not None:
+        disconnect_silently()
+    raise SelftestPreconditionError(
+        "selftest refused: a live fleet session connected for this robot "
+        "partway through this run; pause or stop the fleet service first"
+    )
+
+
 def run_selftest(  # noqa: PLR0913
     publisher: Publisher,
     spool: Spool,
@@ -256,6 +318,16 @@ def run_selftest(  # noqa: PLR0913
     schema update, remapping live channel batches to the fixture's
     `selftest.*` channels until the live service's next reconnect.
 
+    That START-only check is not the end of it: right after it passes, an
+    ONGOING watch is armed too (Codex round 3 follow-up, PR #214 P1,
+    comment 3927287968's own follow-up -- see `_open_live_session_watch`)
+    and re-checked between every channel batch and immediately before the
+    heartbeat and event publishes (`_abort_if_live_session_detected`). A
+    live `FleetService` that RESUMES at any point DURING the run -- not
+    just one that was already connected at the start -- reopens the exact
+    same schema-pollution window; the ongoing watch is what closes it for
+    the run's full duration, not just its first instant.
+
     The entire run -- the backlog check and every `append_next`/`ack` call
     that follows -- holds `spool.exclusive()` (Codex round 3, P1b): a
     concurrently running `FleetService`/`StreamRouter` writing this same
@@ -286,9 +358,11 @@ def run_selftest(  # noqa: PLR0913
     Raises:
         SelftestPreconditionError: a spool lane has pending unacked backlog
             or another writer already holds the spool's lock (both checked
-            before any connect/append side effect), or the robot's live
-            fleet session is already connected (checked right after
-            connecting, before any publish).
+            before any connect/append side effect), the robot's live fleet
+            session is already connected (checked right after connecting,
+            before any publish), or a live session connects PARTWAY through
+            the run (checked between batches and before the heartbeat/event
+            publishes -- see `_abort_if_live_session_detected`).
         Whatever `publisher`/`spool` raise thereafter (typically
         `PublishError` or a spool `ValueError`/`SpoolError`) -- always
         re-raised after the cleanup below.
@@ -313,9 +387,11 @@ def run_selftest(  # noqa: PLR0913
         try:
             publisher.connect()
             _check_no_live_session(publisher)
+            watch = _open_live_session_watch(publisher)
             publisher.publish_schema({"v": 1, "channels": SELFTEST_CHANNELS})
 
             for i in range(batches):
+                _abort_if_live_session_detected(watch, publisher)
                 t = now()
                 batch = _build_batch(i, t)
                 seq = spool.append_next("channels", lambda seq, batch=batch: _stamp_seq(batch, seq))
@@ -327,6 +403,7 @@ def run_selftest(  # noqa: PLR0913
                 if interval_s:
                     time.sleep(interval_s)
 
+            _abort_if_live_session_detected(watch, publisher)
             heartbeat_payload = build_heartbeat(
                 started_at=t0,
                 subscriptions=["selftest"],
@@ -356,11 +433,14 @@ def run_selftest(  # noqa: PLR0913
                 }
                 return event_payload
 
+            _abort_if_live_session_detected(watch, publisher)
             events_seq = spool.append_next("events", _build_event_payload)
             last_events_seq = events_seq
             publisher.publish_event(event_payload)
             spool.ack("events", events_seq)
 
+            if watch is not None:
+                watch.stop()  # type: ignore[attr-defined]
             publisher.close()
         except Exception:
             if last_channels_seq is not None:

--- a/src/sink/publish/selftest.py
+++ b/src/sink/publish/selftest.py
@@ -153,6 +153,72 @@ def _check_no_pending_backlog(spool: Spool) -> None:
             )
 
 
+DEFAULT_LIVE_SESSION_PROBE_TIMEOUT_S = 1.5
+
+
+def _check_no_live_session(
+    publisher: Publisher, *, timeout_s: float = DEFAULT_LIVE_SESSION_PROBE_TIMEOUT_S
+) -> None:
+    """Refuse to run while the robot's live fleet session is connected.
+
+    Codex round 3 P1, comment 3927287968.
+
+    Investigation for the earlier rounds this round follows up on
+    (`client_id_suffix`, `retain_messages=False`) established that neither
+    fix protects a CONNECTED live subscriber: the selftest's fixture schema
+    still reaches a live ingestor as a schema update the instant it's
+    published, remapping live channel batches to the fixture's four
+    `selftest.*` channels until the live service's next reconnect --
+    non-retention only protects a LATE subscriber, and a distinct client id
+    only stops the broker from displacing the live session, not from
+    delivering this session's publishes to it. The only structural fix is
+    to never publish at all while a live session exists.
+
+    Detection uses the wire itself, since nothing else (spool state,
+    process state) tells this process whether some OTHER process/robot
+    already holds a live session on this broker: subscribes to the robot's
+    own heartbeat topic (`Publisher.wait_for_retained_heartbeat`, if the
+    publisher offers it -- see `MqttPublisher`'s implementation) and waits a
+    short bounded window for a RETAINED message. A live service keeps its
+    heartbeat retained with `online: true` for as long as it's connected; a
+    paused/stopped service (or an unclean disconnect's last-will) retains
+    `online: false`; a fresh robot/broker has nothing retained at all.
+    Refuses ONLY on the first case.
+
+    Called AFTER `publisher.connect()` (the probe needs a live connection to
+    subscribe) but BEFORE any publish (see `run_selftest`'s call site) --
+    a refusal here leaves nothing published. Combined with
+    `retain_messages=False` and no last-will (round 8's fix), even the
+    aborted connection attempt leaves no RETAINED residue on the broker.
+    The connection itself is torn down silently (`Publisher.
+    disconnect_without_publishing`, if offered -- see `MqttPublisher`'s
+    implementation) before raising, releasing this session's deterministic
+    client id promptly rather than leaving it to eventually be
+    garbage-collected -- deliberately NOT `publisher.close()`, which would
+    publish a non-retained clean-stop beat that could itself deliver a
+    misleading momentary `online: false` to whoever is watching the live
+    session's own heartbeat topic.
+
+    If `publisher` doesn't offer `wait_for_retained_heartbeat` (most test
+    doubles, and any future non-MQTT `Publisher` implementation), this is a
+    no-op: the check simply can't be performed, and `run_selftest` proceeds
+    as it always did before this round -- see `wait_for_retained_heartbeat`'s
+    own docstring for why this isn't grown into the `Publisher` ABC instead.
+    """
+    probe = getattr(publisher, "wait_for_retained_heartbeat", None)
+    if probe is None:
+        return
+    beat = probe(timeout_s=timeout_s)
+    if beat is not None and beat.get("online") is True:
+        disconnect_silently = getattr(publisher, "disconnect_without_publishing", None)
+        if disconnect_silently is not None:
+            disconnect_silently()
+        raise SelftestPreconditionError(
+            "selftest refused: a live fleet session is connected for this "
+            "robot; pause or stop the fleet service first"
+        )
+
+
 def run_selftest(  # noqa: PLR0913
     publisher: Publisher,
     spool: Spool,
@@ -182,6 +248,14 @@ def run_selftest(  # noqa: PLR0913
     otherwise this run's own first ack would advance the watermark past
     that pre-existing backlog and silently drop it.
 
+    Immediately after connecting, but before any publish: refuses to
+    proceed if the robot's live fleet session is already connected (Codex
+    round 3 P1, comment 3927287968 -- see `_check_no_live_session`). Even
+    non-retained and even under a distinct client id, this run's fixture
+    schema would otherwise still reach a connected live subscriber as a
+    schema update, remapping live channel batches to the fixture's
+    `selftest.*` channels until the live service's next reconnect.
+
     The entire run -- the backlog check and every `append_next`/`ack` call
     that follows -- holds `spool.exclusive()` (Codex round 3, P1b): a
     concurrently running `FleetService`/`StreamRouter` writing this same
@@ -210,9 +284,11 @@ def run_selftest(  # noqa: PLR0913
         "channels_seq": [first, last], "events_seq": <seq>}`.
 
     Raises:
-        SelftestPreconditionError: a spool lane has pending unacked backlog,
-            or another writer already holds the spool's lock -- both checked
-            before any connect/append side effect.
+        SelftestPreconditionError: a spool lane has pending unacked backlog
+            or another writer already holds the spool's lock (both checked
+            before any connect/append side effect), or the robot's live
+            fleet session is already connected (checked right after
+            connecting, before any publish).
         Whatever `publisher`/`spool` raise thereafter (typically
         `PublishError` or a spool `ValueError`/`SpoolError`) -- always
         re-raised after the cleanup below.
@@ -236,6 +312,7 @@ def run_selftest(  # noqa: PLR0913
 
         try:
             publisher.connect()
+            _check_no_live_session(publisher)
             publisher.publish_schema({"v": 1, "channels": SELFTEST_CHANNELS})
 
             for i in range(batches):
@@ -360,9 +437,10 @@ def main(argv: list[str] | None = None) -> int:
     Returns 0 and prints the `run_selftest` summary as one line of JSON on
     success. On any expected failure state (fleet disabled/not installed,
     unenrolled with no `--broker` override, bad broker config, a publish
-    failure, a spool lane with pending backlog, or another writer already
-    holding the spool's lock), prints the typed error's message to stderr
-    (no traceback) and returns 1.
+    failure, a spool lane with pending backlog, another writer already
+    holding the spool's lock, or the robot's live fleet session already
+    being connected), prints the typed error's message to stderr (no
+    traceback) and returns 1.
     """
     args = _build_arg_parser().parse_args(argv)
     try:
@@ -370,17 +448,24 @@ def main(argv: list[str] | None = None) -> int:
         directory = pathlib.Path(settings.FLEET_IDENTITY_DIRECTORY)
         identity = _load_identity_or_none(directory)
         kwargs = resolve_publisher_kwargs(StreamsConfig(broker=args.broker), identity)
-        # "-selftest" (Codex round 3 follow-up, PR #214 P2 on comment
-        # 3925391258): without this, the selftest's MqttPublisher would
+        # "/selftest" (Codex round 3 follow-up, PR #214 P2 on comment
+        # 3925391258; delimiter fixed to "/" in a later follow-up, comment
+        # 3927231074): without this, the selftest's MqttPublisher would
         # derive the SAME deterministic client id as the live service's own
         # (same tenant/robot), and the broker kicks the existing session
         # when a new connection claims an already-connected client id --
         # running the selftest against an enrolled robot's broker while
         # that robot's real streaming service is connected would silently
         # DISPLACE the live session. Cloud confirmed ACLs key on the cert
-        # CN, not the client id, so this is free. See
-        # `MqttPublisher.__init__`'s docstring for the full reasoning.
-        kwargs["client_id_suffix"] = "-selftest"
+        # CN, not the client id, so this is free. "/" (not "-") because a
+        # hyphen reintroduces exactly the hyphen-injectivity ambiguity the
+        # tenant/robot delimiter itself was already fixed for: robot "r7"
+        # suffixed "-selftest" would collide with a robot actually NAMED
+        # "r7-selftest". "/" is outside both id charsets (robot ids match
+        # ^[a-z0-9][a-z0-9_-]{0,62}$), so it's provably collision-free the
+        # same way. See `MqttPublisher.__init__`'s docstring for the full
+        # reasoning.
+        kwargs["client_id_suffix"] = "/selftest"
         # retain_messages=False (Codex round 3 follow-up, PR #214 P1 on
         # comment 3927023413): the selftest keeps publishing AS the robot
         # (client-id suffix aside, cert-CN ACLs make an isolated identity a

--- a/src/sink/publish/selftest.py
+++ b/src/sink/publish/selftest.py
@@ -370,6 +370,17 @@ def main(argv: list[str] | None = None) -> int:
         directory = pathlib.Path(settings.FLEET_IDENTITY_DIRECTORY)
         identity = _load_identity_or_none(directory)
         kwargs = resolve_publisher_kwargs(StreamsConfig(broker=args.broker), identity)
+        # "-selftest" (Codex round 3 follow-up, PR #214 P2 on comment
+        # 3925391258): without this, the selftest's MqttPublisher would
+        # derive the SAME deterministic client id as the live service's own
+        # (same tenant/robot), and the broker kicks the existing session
+        # when a new connection claims an already-connected client id --
+        # running the selftest against an enrolled robot's broker while
+        # that robot's real streaming service is connected would silently
+        # DISPLACE the live session. Cloud confirmed ACLs key on the cert
+        # CN, not the client id, so this is free. See
+        # `MqttPublisher.__init__`'s docstring for the full reasoning.
+        kwargs["client_id_suffix"] = "-selftest"
         publisher = MqttPublisher(**kwargs)
         spool = Spool.for_robot(identity.robot if identity is not None else "dev/robot")
         result = run_selftest(publisher, spool, batches=args.batches, interval_s=args.interval_s)

--- a/src/sink/publish/selftest.py
+++ b/src/sink/publish/selftest.py
@@ -234,9 +234,15 @@ def _open_live_session_watch(publisher: Publisher) -> object | None:
 
     `publisher.watch_live_session()` (see `MqttPublisher`'s implementation),
     called here right after `_check_no_live_session` has cleared the START
-    state, keeps the heartbeat subscription open for the remainder of the
-    run -- `run_selftest` polls the returned watch's `.detected` Event
-    between batches and before the heartbeat/event publishes via
+    state, keeps BOTH the heartbeat AND schema subscriptions open for the
+    remainder of the run -- not heartbeat alone (Codex round 3 follow-up,
+    PR #214 P1, comment 3928569268): a resuming `FleetService`'s heartbeat
+    thread can block indefinitely on the exclusive lock this run holds
+    (inside `spool.stats()`), so it may never emit a beat, while its
+    lock-free router still reconnects and republishes the schema regardless
+    -- watching only the heartbeat topic would miss exactly that case.
+    `run_selftest` polls the returned watch's `.detected` Event between
+    batches and before the heartbeat/event publishes via
     `_abort_if_live_session_detected`. Same optional-capability pattern as
     `_check_no_live_session`'s own probe (`getattr(...,  None)`): a
     `Publisher` that doesn't offer this (most test doubles, and any future
@@ -254,11 +260,11 @@ def _abort_if_live_session_detected(watch: object | None, publisher: Publisher) 
 
     Called between every channel batch and immediately before the
     heartbeat and event publishes (see `run_selftest`) -- checking the
-    SAME `watch.detected` Event a live beat's paho callback sets the
-    instant it arrives (Codex round 3 follow-up, PR #214 P1, comment
-    3927287968's own follow-up), so a live service resuming at any point
-    during the run is caught before this run's next publish, not just at
-    the very start.
+    SAME `watch.detected` Event a live message's paho callback sets the
+    instant ANY message arrives on either watched topic (Codex round 3
+    follow-up, PR #214 P1, comments 3927287968 and 3928569268), so a live
+    service resuming at any point during the run is caught before this
+    run's next publish, not just at the very start.
 
     Mirrors `_check_no_live_session`'s own refusal exactly: the connection
     is torn down silently via `disconnect_without_publishing` (never
@@ -326,7 +332,14 @@ def run_selftest(  # noqa: PLR0913
     live `FleetService` that RESUMES at any point DURING the run -- not
     just one that was already connected at the start -- reopens the exact
     same schema-pollution window; the ongoing watch is what closes it for
-    the run's full duration, not just its first instant.
+    the run's full duration, not just its first instant. It watches for
+    any live activity on the robot's session topics (heartbeat AND
+    schema, content-agnostic), not the heartbeat's `online: true` content
+    alone (Codex round 3 follow-up, PR #214 P1, comment 3928569268): a
+    resuming service's heartbeat thread can block on the exclusive lock
+    this run holds while its router still reconnects and republishes the
+    schema regardless, so the watch cannot depend on that lock -- or on
+    the heartbeat topic alone -- to see the pollution.
 
     The entire run -- the backlog check and every `append_next`/`ack` call
     that follows -- holds `spool.exclusive()` (Codex round 3, P1b): a

--- a/src/sink/publish/selftest.py
+++ b/src/sink/publish/selftest.py
@@ -381,6 +381,19 @@ def main(argv: list[str] | None = None) -> int:
         # CN, not the client id, so this is free. See
         # `MqttPublisher.__init__`'s docstring for the full reasoning.
         kwargs["client_id_suffix"] = "-selftest"
+        # retain_messages=False (Codex round 3 follow-up, PR #214 P1 on
+        # comment 3927023413): the selftest keeps publishing AS the robot
+        # (client-id suffix aside, cert-CN ACLs make an isolated identity a
+        # non-starter), so its retained publishes would otherwise linger on
+        # the SAME shared robot topics with nothing to overwrite them once
+        # the run ends -- its fixture schema staying retained until the
+        # live service's next reconnect (a late subscriber decodes live
+        # batches against the WRONG schema meanwhile), and its close() beat
+        # leaving a retained online:false (the robot looks dead until the
+        # next live beat). Retention isn't load-bearing for conformance --
+        # the validator subscribes before/during the run. See
+        # `MqttPublisher.__init__`'s docstring for the full reasoning.
+        kwargs["retain_messages"] = False
         publisher = MqttPublisher(**kwargs)
         spool = Spool.for_robot(identity.robot if identity is not None else "dev/robot")
         result = run_selftest(publisher, spool, batches=args.batches, interval_s=args.interval_s)

--- a/src/sink/publish/selftest.py
+++ b/src/sink/publish/selftest.py
@@ -10,10 +10,13 @@ dev-insecure/mTLS rules a real robot would hit, not a shortcut around them.
 
 Run this with fleet streaming paused or stopped on the target robot/dev rig:
 a concurrently running `FleetService`/`StreamRouter` writes to the same real
-spool lanes this selftest uses (`Spool.for_robot`), and the spool's
-single-writer invariant means a concurrent writer fails the seq monotonicity
-check (`Spool.append`'s `ValueError`) cleanly rather than corrupting
-anything.
+spool lanes this selftest uses (`Spool.for_robot`). This is no longer
+required for correctness (Codex round 3): the whole run holds
+`spool.exclusive()` (P1b) so a concurrent writer simply waits its turn
+instead of racing for seqs, and every allocate-then-write call goes through
+`Spool.append_next()` (P1 follow-up, comment 3924082774) so allocation and
+write can never be interleaved by a DIFFERENT writer even without the lock.
+Pausing first remains good practice -- it avoids the wait -- see the runbook.
 
 Invocation is `uv run python -m src.sink.publish.selftest` -- there is no
 console-script entry point. This repo ships as a Docker image, not a PyPI
@@ -114,6 +117,20 @@ def _build_batch(i: int, t: float) -> dict:
     }
 
 
+def _stamp_seq(payload: dict, seq: int) -> dict:
+    """Stamp `payload["seq"] = seq` in place and return it.
+
+    A small `Spool.append_next()` `build` helper for the common case: the
+    wire payload dict already exists (e.g. `_build_batch`'s output) and just
+    needs the atomically-allocated seq written into its own embedded `seq`
+    field before it's spooled -- MUTATING in place (not returning a copy)
+    matters here, since the caller keeps its own reference to the same dict
+    to publish afterward, and both must see the identical stamped seq.
+    """
+    payload["seq"] = seq
+    return payload
+
+
 def _check_no_pending_backlog(spool: Spool) -> None:
     """Refuse to run against a spool lane with pending unacked entries (C1 ruling).
 
@@ -147,11 +164,16 @@ def run_selftest(  # noqa: PLR0913
 ) -> dict:
     """Publish the conformance fixture end to end: schema, batches, heartbeat, event.
 
-    Uses the robot's REAL spool lanes (`spool.next_seq`/`append`/`ack`), in
-    the exact append -> publish -> ack order `StreamRouter._pump` uses --
+    Uses the robot's REAL spool lanes (`spool.append_next`/`ack`), in the
+    exact append -> publish -> ack order `StreamRouter._pump` uses --
     durable before sent, acked only after the broker has QoS-1 acknowledged
-    it. On any exception once appending has begun, every lane this run wrote
-    to is acked past the last seq it appended (advance-to semantics, per
+    it. Every channel batch and the event use `Spool.append_next()`, never a
+    separate `next_seq()` + `append()` pair (Codex round 3 P1, comment
+    3924082774 -- see `Spool.append_next`'s and `next_seq`'s docstrings for
+    why that two-call shape is unsafe: it left a gap between allocation and
+    write that a concurrent writer's `exclusive()`-held run could land in).
+    On any exception once appending has begun, every lane this run wrote to
+    is acked past the last seq it appended (advance-to semantics, per
     `Spool.ack`) before the exception is re-raised, so nothing this run
     spooled lingers for the real fleet service to replay later.
 
@@ -160,18 +182,17 @@ def run_selftest(  # noqa: PLR0913
     otherwise this run's own first ack would advance the watermark past
     that pre-existing backlog and silently drop it.
 
-    The entire run -- the backlog check and every `next_seq`/`append`/`ack`
-    call that follows -- holds `spool.exclusive()` (Codex round 3, P1b): a
-    concurrently running `FleetService`/`StreamRouter` writing this same real
-    spool waits for the selftest to finish instead of racing it for seqs
-    (previously, `next_seq` then `append` released the lock in between,
-    letting a concurrent writer interleave and see the seq monotonicity
-    check fail with `ValueError` -- clean, but nondeterministic). If a
-    different writer already holds the lock for longer than `lock_timeout_s`,
-    this refuses to start at all rather than hanging. Pausing the real
-    service before running the selftest (see the runbook) remains good
-    practice -- it avoids the brief wait -- but is no longer required for
-    correctness.
+    The entire run -- the backlog check and every `append_next`/`ack` call
+    that follows -- holds `spool.exclusive()` (Codex round 3, P1b): a
+    concurrently running `FleetService`/`StreamRouter` writing this same
+    real spool waits for the selftest to finish instead of racing it for
+    seqs. If a different writer already holds the lock for longer than
+    `lock_timeout_s`, this refuses to start at all rather than hanging.
+    Pausing the real service before running the selftest (see the runbook)
+    remains good practice -- it avoids the brief wait -- but is no longer
+    required for correctness, on either count (`exclusive()` for
+    cross-instance serialization, `append_next()` for atomic allocation
+    within whichever instance is currently writing).
 
     Args:
         publisher: A connected-or-connectable `Publisher` (typically
@@ -220,9 +241,7 @@ def run_selftest(  # noqa: PLR0913
             for i in range(batches):
                 t = now()
                 batch = _build_batch(i, t)
-                seq = spool.next_seq("channels")
-                batch["seq"] = seq
-                spool.append("channels", seq, batch)
+                seq = spool.append_next("channels", lambda seq, batch=batch: _stamp_seq(batch, seq))
                 last_channels_seq = seq
                 publisher.publish_channels(batch)
                 spool.ack("channels", seq)
@@ -244,18 +263,23 @@ def run_selftest(  # noqa: PLR0913
             )
             publisher.publish_heartbeat(heartbeat_payload)
 
-            events_seq = spool.next_seq("events")
-            event_payload = {
-                "v": 1,
-                "seq": events_seq,
-                "event_id": f"selftest-{uuid.uuid4()}",
-                "name": "selftest",
-                "t_start": t0,
-                "t_end": now(),
-                "source_topic": "selftest",
-                "summary": {"kind": "selftest", "batches": batches},
-            }
-            spool.append("events", events_seq, event_payload)
+            event_payload: dict = {}
+
+            def _build_event_payload(seq: int) -> dict:
+                nonlocal event_payload
+                event_payload = {
+                    "v": 1,
+                    "seq": seq,
+                    "event_id": f"selftest-{uuid.uuid4()}",
+                    "name": "selftest",
+                    "t_start": t0,
+                    "t_end": now(),
+                    "source_topic": "selftest",
+                    "summary": {"kind": "selftest", "batches": batches},
+                }
+                return event_payload
+
+            events_seq = spool.append_next("events", _build_event_payload)
             last_events_seq = events_seq
             publisher.publish_event(event_payload)
             spool.ack("events", events_seq)

--- a/src/sink/publish/service.py
+++ b/src/sink/publish/service.py
@@ -204,14 +204,26 @@ class FleetService:
     def pause(self, discard: bool = False) -> None:
         """Go offline, keeping the resolved config so `resume()` needs no re-resolve.
 
-        Idempotent: a no-op if not started or already paused. `discard=True`
-        additionally acks the channels lane up to its last written seq,
-        dropping any still-unacked backlog (events/heartbeat are never-drop
-        lanes and are left untouched). Closes the publisher with
-        `reason="paused"` (spec §3), so the retained clean-stop heartbeat a
-        broker-side subscriber sees reads distinctly from a genuine `stop()`.
+        Idempotent on the pause transition itself: a no-op if not started,
+        and if already paused, the offline state is left exactly as it was
+        (threads already stopped, publisher already closed -- stopping them
+        again would be wrong, not merely redundant). `discard=True` is
+        honored independently of that transition, though (Codex round 3,
+        P2): an explicit discard request empties the channels lane's
+        still-unacked backlog (events/heartbeat are never-drop lanes and are
+        left untouched) even when the service was ALREADY paused -- e.g. two
+        `pause_streaming(discard=True)` calls in a row must both actually
+        discard, not have the second silently no-op just because the service
+        was already offline. Closes the publisher with `reason="paused"`
+        (spec §3) on the transition itself, so the retained clean-stop
+        heartbeat a broker-side subscriber sees reads distinctly from a
+        genuine `stop()`.
         """
-        if not self._started or self._paused:
+        if not self._started:
+            return
+        if self._paused:
+            if discard:
+                self._discard_channels_backlog()
             return
         self._clear_taps()
         if self._heartbeat is not None:
@@ -220,9 +232,13 @@ class FleetService:
             self._router.stop()
         self._publisher.close(reason="paused")
         if discard:
-            last_seq = self._spool.next_seq("channels") - 1
-            self._spool.ack("channels", last_seq)
+            self._discard_channels_backlog()
         self._paused = True
+
+    def _discard_channels_backlog(self) -> None:
+        """Ack the channels lane up to its last written seq, dropping any unacked backlog."""
+        last_seq = self._spool.next_seq("channels") - 1
+        self._spool.ack("channels", last_seq)
 
     def resume(self) -> None:
         """Restart threads (fresh queue/core/router/heartbeat) and reconnect.

--- a/src/sink/publish/spool.py
+++ b/src/sink/publish/spool.py
@@ -282,7 +282,7 @@ class Spool:
 
         Safe to call while holding `self._lock`: no other `Spool` instance
         can be mid-write to this segment concurrently, so the only reason
-        the tail could be untermianted/unparsable is a stale unclean-
+        the tail could be unterminated/unparsable is a stale unclean-
         shutdown remnant. Unlike the tail-content parsing below, THIS
         function does not repair that itself -- it only reports it (see
         `terminated` below); `_current_last_seq` is what reseals.
@@ -477,16 +477,24 @@ class Spool:
             reentrant counter) on exit.
 
         Raises:
+            ValueError: `timeout` is negative -- `filelock.FileLock.acquire`
+                treats a negative timeout as "wait forever" (Codex round 3
+                follow-up, PR #214 P2, comment 3927023413's sibling
+                finding), silently breaking this method's own documented
+                bounded-wait contract. Checked here, before `filelock` is
+                ever called, so this refusal never depends on `filelock`'s
+                own (undocumented) handling of negative values.
             SpoolLockedError: the lock is held elsewhere and was not
                 released within `timeout` seconds.
 
         """
+        if timeout < 0:
+            raise ValueError(f"exclusive(): timeout must be >= 0, got {timeout!r}")
         try:
             return self._lock.acquire(timeout=timeout)
         except filelock.Timeout as exc:
             raise SpoolLockedError(
-                f"spool at {self._root} is locked by another writer "
-                f"(timed out after {timeout}s)"
+                f"spool at {self._root} is locked by another writer (timed out after {timeout}s)"
             ) from exc
 
     def next_seq(self, lane: str) -> int:

--- a/src/sink/publish/spool.py
+++ b/src/sink/publish/spool.py
@@ -211,6 +211,88 @@ class Spool:
         floor = _first_seq_of(last_segment) - 1
         return max(last, floor, self._watermark(lane))
 
+    def _tail_last_seq(self, lane: str) -> int | None:
+        """Peek the highest seq already on disk in O(tail), not O(whole active segment).
+
+        Appends only ever land at the end of the active segment, so the
+        highest already-written seq for the lane is always in that
+        segment's LAST complete line -- there's no need to parse every
+        earlier line the way `_scan_last_seq` does (that full scan exists
+        for crash-tail recovery on a lane's first touch, not for a cheap
+        per-call disk check). Reads backward from the end in a small number
+        of bounded, growing chunks instead of the whole file.
+
+        Safe to call while holding `self._lock`: no other `Spool` instance
+        can be mid-write to this segment concurrently, so the only reason
+        the tail could be unparsable is a stale unclean-shutdown remnant --
+        already handled by `_scan_last_seq`'s truncate-on-first-touch path,
+        not something this cheap peek needs to repair itself.
+
+        Returns:
+            The last complete line's `seq`, or `None` if there is no active
+            segment, it's empty, or its tail doesn't parse (the caller falls
+            back to the watermark / full scan in that case).
+
+        """
+        segments = self._segments(lane, create=False)
+        if not segments:
+            return None
+        path = segments[-1]
+        size = path.stat().st_size
+        if size == 0:
+            return None
+        chunk = 8192
+        window = 0
+        data = b""
+        with open(path, "rb") as handle:
+            while True:
+                window = min(size, window + chunk)
+                handle.seek(size - window)
+                data = handle.read(window)
+                if data.rstrip(b"\n").count(b"\n") >= 1 or window >= size:
+                    break
+        last_line = data.rstrip(b"\n").rsplit(b"\n", 1)[-1]
+        if not last_line:
+            return None
+        try:
+            record = json.loads(last_line.decode("utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return None
+        seq = record.get("seq")
+        return seq if isinstance(seq, int) else None
+
+    def _current_last_seq(self, lane: str) -> int:
+        """Disk-authoritative last-written seq for `lane` -- cheap on the common path.
+
+        Codex round 3 follow-up (PR #214, P1): `next_seq()`/`append()`
+        previously trusted `self._last_seq[lane]` unconditionally once a
+        lane had been touched once in this process's lifetime, checking
+        monotonicity only against that in-process cache. `exclusive()`
+        (P1b) serializes concurrent DISK ACCESS, but does nothing to refresh
+        a DIFFERENT already-open `Spool` instance's stale cache -- a
+        long-lived instance (e.g. a `FleetService`) whose cache predates an
+        intervening writer on the same real spool (e.g. a selftest run)
+        would accept/allocate a seq that collides with what's already on
+        disk: a silent DUPLICATE write, not the clean `ValueError` the
+        single-writer invariant is supposed to guarantee.
+
+        First touch (lane not yet in `self._last_seq`) keeps the existing,
+        crash-tail-tolerant `_scan_last_seq` path unchanged -- unavoidable
+        and needed exactly once, to recover from (and truncate) a possible
+        unclean-shutdown remnant. Every later call instead re-derives the
+        floor from disk cheaply: the watermark plus `_tail_last_seq`'s
+        tail-only peek, maxed against the cache purely as a floor (never a
+        source of truth) so this can never regress below what THIS instance
+        itself already wrote.
+        """
+        if lane not in self._last_seq:
+            self._last_seq[lane] = self._scan_last_seq(lane)
+            return self._last_seq[lane]
+        tail = self._tail_last_seq(lane)
+        disk_floor = self._watermark(lane) if tail is None else tail
+        disk_floor = max(disk_floor, self._watermark(lane))
+        return max(disk_floor, self._last_seq[lane])
+
     def exclusive(self, timeout: float = 5.0) -> filelock.AcquireReturnProxy:
         """Hold this spool's lock across an extended, multi-call critical section.
 
@@ -260,6 +342,13 @@ class Spool:
     def next_seq(self, lane: str) -> int:
         """Get the next sequence number for a lane.
 
+        Disk-authoritative (Codex round 3 follow-up, PR #214 P1): re-derives
+        the floor from disk on every call after the lane's first touch --
+        see `_current_last_seq` -- so a concurrent writer (a different
+        `Spool` instance on the same root) that advanced the lane since this
+        instance last looked is reflected here too, not just in `append()`'s
+        rejection.
+
         Args:
             lane: Lane name.
 
@@ -272,9 +361,7 @@ class Spool:
 
         """
         with self._lock:
-            if lane not in self._last_seq:
-                self._last_seq[lane] = self._scan_last_seq(lane)
-            return self._last_seq[lane] + 1
+            return self._current_last_seq(lane) + 1
 
     # -- append ----------------------------------------------------------------
 
@@ -287,7 +374,12 @@ class Spool:
             payload: JSON-serializable record.
 
         Raises:
-            ValueError: If seq is not monotonic.
+            ValueError: If seq is not monotonic against the DISK-authoritative
+                last-written seq (Codex round 3 follow-up, PR #214 P1) --
+                checked fresh on every call after the lane's first touch, not
+                just against this instance's in-process cache, so a
+                concurrent writer's advance on the same real spool root is
+                always caught cleanly here rather than silently duplicated.
             SpoolFullError: If lane is never-capped and write fails.
             SpoolError: If lane is capped and write fails.
             SpoolCorruptError: The lane's active segment has mid-file corruption
@@ -295,12 +387,10 @@ class Spool:
 
         """
         with self._lock:
-            if lane not in self._last_seq:
-                self._last_seq[lane] = self._scan_last_seq(lane)
-            if seq <= self._last_seq[lane]:
-                raise ValueError(
-                    f"seq must be monotonic: got {seq}, last was {self._last_seq[lane]}"
-                )
+            current = self._current_last_seq(lane)
+            self._last_seq[lane] = current
+            if seq <= current:
+                raise ValueError(f"seq must be monotonic: got {seq}, last was {current}")
             line = json.dumps({"seq": seq, "payload": payload}) + "\n"
             # Drop-oldest semantics extend to drop-oversized (Codex review):
             # _evict() only ever unlinks while more than one segment exists,

--- a/src/sink/publish/spool.py
+++ b/src/sink/publish/spool.py
@@ -226,6 +226,49 @@ class Spool:
         floor = _first_seq_of(last_segment) - 1
         return max(last, floor, self._watermark(lane))
 
+    def _set_last_seq(self, lane: str, value: int) -> int:
+        """Assign `self._last_seq[lane]`, folded through `max()` against whatever's already cached.
+
+        The ONE place every assignment to `self._last_seq[lane]` in this
+        class must go through (Codex round 3 follow-up, PR #214 P2 on
+        comment 3925663134): the cache is a never-regress floor by
+        contract -- every reader of it (`_current_last_seq`'s own
+        `self._last_seq[lane]` reads, `append()`/`append_next()`'s
+        monotonicity checks) trusts that once this instance has recorded a
+        seq as consumed, it stays recorded, never reverts to something
+        lower.
+
+        That contract had exactly one violation: `_current_last_seq`'s
+        reseal branch (an unterminated or `None` tail) REPLACED the cache
+        with `_scan_last_seq(lane)`'s result outright, with no `max()`
+        against the value already there. A capped lane's oversized-drop
+        path (`_write_locked`) consumes a seq into the cache alone -- no
+        segment is ever written for a dropped record, so disk shows
+        NOTHING for that lane. If that lane's FIRST-ever record is
+        oversized, the lane has no directory at all yet; a later call on
+        the SAME (now warm-cached) instance -- `stats()`, `next_seq()`, or
+        another `append_next()` -- sees a `None` tail (no segments exist)
+        and took the reseal branch, which unconditionally replaced the
+        cache with `_scan_last_seq`'s result: `self._watermark(lane)`
+        (0, nothing acked) -- REGRESSING the cache from the already-
+        consumed seq back down to 0. The next oversized record then
+        reused that already-consumed seq instead of advancing past it.
+
+        Folding every assignment through `max()` here closes that one
+        confirmed regression and makes the invariant structural rather
+        than dependent on each call site reasoning correctly about
+        whether IT could ever regress -- audited every assignment site in
+        this class (see the round's own report for the full audit; in
+        short, several other sites were already safe by construction --
+        e.g. anything assigning a `seq` that a caller just validated as
+        strictly greater than the current authoritative floor -- but
+        routing them through here too costs nothing and removes the need
+        to keep re-proving that reasoning as the code evolves).
+        """
+        current = max(value, self._last_seq.get(lane, 0))
+        self._last_seq[lane] = current
+        return current
+
     def _tail_last_seq(self, lane: str) -> tuple[int | None, bool]:
         r"""Peek the highest seq already on disk in O(tail), not O(whole active segment).
 
@@ -387,16 +430,18 @@ class Spool:
         never regress, and it costs nothing extra to write.
         """
         if lane not in self._last_seq:
-            self._last_seq[lane] = self._scan_last_seq(lane)
-            return self._last_seq[lane]
+            return self._set_last_seq(lane, self._scan_last_seq(lane))
         tail, terminated = self._tail_last_seq(lane)
         if not terminated or tail is None:
-            self._last_seq[lane] = self._scan_last_seq(lane)
-            return self._last_seq[lane]
+            # The confirmed regression (Codex round 3 follow-up, PR #214
+            # P2, comment 3925663134): this branch used to REPLACE the
+            # cache outright with `_scan_last_seq`'s result, with no fold
+            # against what was already cached -- see `_set_last_seq`'s
+            # docstring for the exact oversized-drop-then-rescan scenario
+            # that regressed it.
+            return self._set_last_seq(lane, self._scan_last_seq(lane))
         disk_floor = max(tail, self._watermark(lane))
-        current = max(disk_floor, self._last_seq[lane])
-        self._last_seq[lane] = current
-        return current
+        return self._set_last_seq(lane, disk_floor)
 
     def exclusive(self, timeout: float = 5.0) -> filelock.AcquireReturnProxy:
         """Hold this spool's lock across an extended, multi-call critical section.
@@ -518,7 +563,7 @@ class Spool:
         """
         with self._lock:
             current = self._current_last_seq(lane)
-            self._last_seq[lane] = current
+            self._set_last_seq(lane, current)
             if seq <= current:
                 raise ValueError(f"seq must be monotonic: got {seq}, last was {current}")
             self._write_locked(lane, seq, payload)
@@ -564,7 +609,7 @@ class Spool:
         """
         with self._lock:
             current = self._current_last_seq(lane)
-            self._last_seq[lane] = current
+            self._set_last_seq(lane, current)
             seq = current + 1
             payload = build(seq)
             self._write_locked(lane, seq, payload)
@@ -600,7 +645,7 @@ class Spool:
                 len(line.encode("utf-8")),
                 SEGMENT_MAX_BYTES,
             )
-            self._last_seq[lane] = seq
+            self._set_last_seq(lane, seq)
             return
         segments = self._segments(lane)
         active = segments[-1] if segments else None
@@ -615,7 +660,7 @@ class Spool:
             if lane not in self._capped:
                 raise SpoolFullError(f"lane '{lane}': {exc}") from exc
             raise SpoolError(f"lane '{lane}': {exc}") from exc
-        self._last_seq[lane] = seq
+        self._set_last_seq(lane, seq)
         if rolled:
             self._evict(lane)
 

--- a/src/sink/publish/spool.py
+++ b/src/sink/publish/spool.py
@@ -693,6 +693,22 @@ class Spool:
     def stats(self) -> dict[str, LaneStats]:
         """Get per-lane statistics (bytes, pending, seqs, evicted count).
 
+        Disk-authoritative `last_seq` (Codex round 3 follow-up, PR #214 P2
+        on comment 3925391258): previously `self._last_seq.get(lane) or
+        self._scan_last_seq(lane)` trusted this instance's own cache
+        WHENEVER it was already warm (non-zero) -- unlike `acked`
+        (`_watermarks()`) and `pending` (`self.pending()`), both of which
+        already re-read fresh from disk on every call. A warm cache left
+        stale by another writer advancing the same real lane (e.g. a live
+        `FleetService` whose heartbeat calls `stats()` while a selftest run
+        on a separate instance appends past where this instance last
+        looked) meant a heartbeat's reported `last_seq` -- and by extension
+        an operator's read of how far behind that lane's backlog actually
+        is -- silently lagged reality. Routed through `_current_last_seq`
+        instead: the same disk-authoritative derivation `next_seq()`/
+        `append()` use, cheap on the common path and storing the fresher
+        value back through the cache as a never-regress floor.
+
         Returns:
             Dict mapping lane name to LaneStats.
 
@@ -709,7 +725,7 @@ class Spool:
             for lane in sorted(lanes):
                 segments = self._segments(lane, create=False)
                 acked = marks.get(lane, 0)
-                last = self._last_seq.get(lane) or self._scan_last_seq(lane)
+                last = self._current_last_seq(lane)
                 pending = sum(1 for _ in self.pending(lane))
                 out[lane] = LaneStats(
                     bytes=sum(p.stat().st_size for p in segments),

--- a/src/sink/publish/spool.py
+++ b/src/sink/publish/spool.py
@@ -348,23 +348,55 @@ class Spool:
         either call, not just `append()` -- and there's exactly one piece
         of code that knows how to interpret "is this segment's tail
         trustworthy", not two copies that could drift apart. When
-        `_tail_last_seq` reports `terminated=False`, this reseals via the
-        same crash-tail-tolerant `_scan_last_seq` first touch already uses
-        (it truncates the untrustworthy bytes -- correct: no trailing
-        newline means the record was never durably committed -- and
-        recomputes the floor from what's left, with the watermark still
+        `_tail_last_seq` reports `terminated=False` -- OR reports `seq is
+        None` while a segment file DOES exist (empty or unparsable; Codex
+        round 3 follow-up, PR #214 P1 on comment 3924387659 -- see below),
+        this reseals via the same crash-tail-tolerant `_scan_last_seq` first
+        touch already uses (it truncates any untrustworthy bytes -- correct:
+        no trailing newline means the record was never durably committed --
+        and recomputes the floor from what's left, with the watermark still
         guarding against ever regressing below an already-acked seq).
+
+        Why a `None` tail on an EXISTING segment must reseal too, not just
+        fall back to the watermark: a `None` tail means "no active-segment
+        record was found" (the segment is empty -- e.g. a roll that created
+        the file but crashed before writing its first record -- or its tail
+        line doesn't parse). The watermark alone is NOT a safe floor there:
+        the segment's own FILENAME encodes a floor (`_first_seq_of(segment)
+        - 1`, exactly what `_scan_last_seq` derives), and EARLIER segments
+        can hold live, still-unacked records with seqs above the watermark.
+        Falling back to the watermark alone would ignore both, letting a
+        warm cache allocate a seq that collides with data already on disk
+        (a floor REGRESSION, not merely a stale-but-safe undercount) -- so
+        this is folded into the very same reseal branch as an unterminated
+        tail, not treated as a separate "safe to just use the watermark"
+        case. Only the genuine "no segment file exists at all" case (a lane
+        truly never touched) has no filename to derive a floor from --
+        `_scan_last_seq` handles that identically anyway (`if not segments:
+        return self._watermark(lane)`), so resealing unconditionally
+        whenever `tail is None` is both correct and just as cheap in that
+        case (a directory glob, no file I/O).
+
+        The disk-derived floor on the normal (non-reseal) path is stored
+        back into `self._last_seq[lane]` too (Codex round 3 follow-up, PR
+        #214 P2 on comment 3924387659): previously it was computed fresh on
+        every call but discarded instead of cached, so the cache could
+        silently lag behind what this instance's OWN reads had already
+        established on disk. Storing it is always safe -- it's folded
+        through `max()` with the existing cache, so it can only advance,
+        never regress, and it costs nothing extra to write.
         """
         if lane not in self._last_seq:
             self._last_seq[lane] = self._scan_last_seq(lane)
             return self._last_seq[lane]
         tail, terminated = self._tail_last_seq(lane)
-        if not terminated:
+        if not terminated or tail is None:
             self._last_seq[lane] = self._scan_last_seq(lane)
             return self._last_seq[lane]
-        disk_floor = self._watermark(lane) if tail is None else tail
-        disk_floor = max(disk_floor, self._watermark(lane))
-        return max(disk_floor, self._last_seq[lane])
+        disk_floor = max(tail, self._watermark(lane))
+        current = max(disk_floor, self._last_seq[lane])
+        self._last_seq[lane] = current
+        return current
 
     def exclusive(self, timeout: float = 5.0) -> filelock.AcquireReturnProxy:
         """Hold this spool's lock across an extended, multi-call critical section.

--- a/src/sink/publish/spool.py
+++ b/src/sink/publish/spool.py
@@ -211,8 +211,8 @@ class Spool:
         floor = _first_seq_of(last_segment) - 1
         return max(last, floor, self._watermark(lane))
 
-    def _tail_last_seq(self, lane: str) -> int | None:
-        """Peek the highest seq already on disk in O(tail), not O(whole active segment).
+    def _tail_last_seq(self, lane: str) -> tuple[int | None, bool]:
+        r"""Peek the highest seq already on disk in O(tail), not O(whole active segment).
 
         Appends only ever land at the end of the active segment, so the
         highest already-written seq for the lane is always in that
@@ -224,9 +224,34 @@ class Spool:
 
         Safe to call while holding `self._lock`: no other `Spool` instance
         can be mid-write to this segment concurrently, so the only reason
-        the tail could be unparsable is a stale unclean-shutdown remnant --
-        already handled by `_scan_last_seq`'s truncate-on-first-touch path,
-        not something this cheap peek needs to repair itself.
+        the tail could be untermianted/unparsable is a stale unclean-
+        shutdown remnant. Unlike the tail-content parsing below, THIS
+        function does not repair that itself -- it only reports it (see
+        `terminated` below); `_current_last_seq` is what reseals.
+
+        Terminatedness is checked explicitly (Codex round 3 follow-up, PR
+        #214 P1 on comment 3923824688), not inferred from whether the tail
+        parses: a write is `line = json.dumps(...) + "\n"`, one `write()`
+        call, but a crash can still land the file's true end anywhere
+        inside or after that write. Two prior failure modes both left a
+        write, in "a" (append) mode, land directly onto an unterminated
+        tail with no separating newline -- corrupting the file into one
+        unparsable line, discovered only much later when `pending()` raises
+        `SpoolCorruptError`:
+          - The crash lands exactly after a COMPLETE JSON payload but
+            before its trailing `\n`. The old code parsed that tail as a
+            legitimately committed record (it parses fine without the
+            newline) and reported its seq as trustworthy.
+          - The crash lands mid-payload (a genuinely partial JSON tail).
+            The old code's `json.loads` failed as expected, but nothing
+            then TRUNCATED the partial bytes before the next `append()`
+            wrote onto them.
+        Checking the segment's LAST BYTE (`O(1)`, a single `seek(-1,
+        SEEK_END)` + one-byte read) sidesteps both: if it isn't `b"\n"`,
+        the tail is torn regardless of what it parses as, full stop --
+        `_current_last_seq` reseals (truncates) before anything else
+        happens, so this function doesn't even attempt to parse a tail it
+        already knows is untrustworthy.
 
         The window grows GEOMETRICALLY (doubling each retry: 8KiB, 16KiB,
         32KiB, ...), not by a fixed 8KiB step (Codex round 3 follow-up, PR
@@ -238,21 +263,28 @@ class Spool:
         size), since a geometric series sums to about 2x its last term.
 
         Returns:
-            The last complete line's `seq`, or `None` if there is no active
-            segment, it's empty, or its tail doesn't parse (the caller falls
-            back to the watermark / full scan in that case).
+            `(seq, terminated)`. `terminated` is `True` iff the active
+            segment is empty/absent, or its true last byte is `b"\n"` -- a
+            properly durable record boundary. `seq` is the last complete
+            line's `seq`, or `None` if there is no active segment, it's
+            empty, the tail isn't terminated (in which case `seq` is always
+            `None` -- see above, it's never even parsed), or it doesn't
+            parse (the caller falls back to the watermark / full scan).
 
         """
         segments = self._segments(lane, create=False)
         if not segments:
-            return None
+            return None, True
         path = segments[-1]
         size = path.stat().st_size
         if size == 0:
-            return None
+            return None, True
         window = min(size, 8192)
         data = b""
         with open(path, "rb") as handle:
+            handle.seek(-1, os.SEEK_END)
+            if handle.read(1) != b"\n":
+                return None, False
             while True:
                 handle.seek(size - window)
                 data = handle.read(window)
@@ -261,13 +293,13 @@ class Spool:
                 window = min(size, window * 2)
         last_line = data.rstrip(b"\n").rsplit(b"\n", 1)[-1]
         if not last_line:
-            return None
+            return None, True
         try:
             record = json.loads(last_line.decode("utf-8"))
         except (json.JSONDecodeError, UnicodeDecodeError):
-            return None
+            return None, True
         seq = record.get("seq")
-        return seq if isinstance(seq, int) else None
+        return (seq if isinstance(seq, int) else None), True
 
     def _current_last_seq(self, lane: str) -> int:
         """Disk-authoritative last-written seq for `lane` -- cheap on the common path.
@@ -292,11 +324,29 @@ class Spool:
         tail-only peek, maxed against the cache purely as a floor (never a
         source of truth) so this can never regress below what THIS instance
         itself already wrote.
+
+        Design choice (comment 3923824688): the O(1) unterminated-tail
+        check is folded INTO `_tail_last_seq` (returning a `(seq,
+        terminated)` pair) rather than duplicated as a separate check in
+        `append()`'s write path. This is the single place both `next_seq()`
+        and `append()` funnel through, so a warm cache gets resealed by
+        either call, not just `append()` -- and there's exactly one piece
+        of code that knows how to interpret "is this segment's tail
+        trustworthy", not two copies that could drift apart. When
+        `_tail_last_seq` reports `terminated=False`, this reseals via the
+        same crash-tail-tolerant `_scan_last_seq` first touch already uses
+        (it truncates the untrustworthy bytes -- correct: no trailing
+        newline means the record was never durably committed -- and
+        recomputes the floor from what's left, with the watermark still
+        guarding against ever regressing below an already-acked seq).
         """
         if lane not in self._last_seq:
             self._last_seq[lane] = self._scan_last_seq(lane)
             return self._last_seq[lane]
-        tail = self._tail_last_seq(lane)
+        tail, terminated = self._tail_last_seq(lane)
+        if not terminated:
+            self._last_seq[lane] = self._scan_last_seq(lane)
+            return self._last_seq[lane]
         disk_floor = self._watermark(lane) if tail is None else tail
         disk_floor = max(disk_floor, self._watermark(lane))
         return max(disk_floor, self._last_seq[lane])

--- a/src/sink/publish/spool.py
+++ b/src/sink/publish/spool.py
@@ -12,6 +12,21 @@ absorbs the replay. Concurrency: every mutator holds the spool's file
 lock (one lock per spool root, like the sink buffer's per-topic locks).
 `exclusive()` lets a caller hold that same lock across several mutating
 calls as one atomic unit (e.g. the selftest CLI, Codex round 3 P1b).
+
+Allocate-then-append MUST go through `append_next()`, never a separate
+`next_seq()` call followed by `append()` (Codex round 3 P1, comment
+3924082774): those are two separate lock acquisitions, so a competing
+writer's `exclusive()` (or its own `next_seq()`/`append()` pair) can run
+in the gap between them, and the disk-authoritative floor added earlier
+this round then makes the SECOND caller's `append()` raise `ValueError`
+against a seq it allocated against a now-stale floor -- exactly the
+router's `_tick`/`_final_flush` batch-spool path, which had that
+`ValueError` propagate uncaught out of `_tick()` and kill the whole
+`StreamRouter` thread (see `router.py`, and its own docstring update).
+`append_next()` derives the floor, allocates, and writes in ONE critical
+section, so no caller can ever be interleaved between allocation and
+write. `next_seq()` remains for genuine read-only introspection only
+(e.g. heartbeat prune-window math) -- see its docstring.
 """
 
 import dataclasses
@@ -20,7 +35,7 @@ import logging
 import os
 import pathlib
 import tempfile
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 
 import filelock
 
@@ -398,20 +413,38 @@ class Spool:
             ) from exc
 
     def next_seq(self, lane: str) -> int:
-        """Get the next sequence number for a lane.
+        """Peek the next sequence number for a lane -- READ-ONLY introspection.
+
+        NOT for allocate-then-append (Codex round 3 P1, comment 3924082774):
+        this returns a snapshot that is immediately stale the instant the
+        lock releases. A separate `next_seq()` call followed by a separate
+        `append()` call is TWO lock acquisitions with a gap between them in
+        which any other writer (another `Spool` instance's own
+        `next_seq()`/`append()` pair, or a `spool.exclusive()`-held run)
+        can advance the lane -- the disk-authoritative floor (this round)
+        then makes the second caller's `append()` raise `ValueError`
+        against a seq it allocated against a floor that's since moved. That
+        used to just mean a clean, if surprising, `ValueError`; it turned
+        out to also be exactly what could kill the live `StreamRouter`
+        thread (see `router.py` and its docstring) when the interleaving
+        landed on ITS `next_seq()`/`append()` pair. Every allocate-then-
+        write caller must use `append_next()` instead, which does both
+        under ONE lock acquisition. This method is for genuine read-only
+        uses that never write anything off the result -- e.g. heartbeat
+        prune-window math that only needs to know roughly where a lane is.
 
         Disk-authoritative (Codex round 3 follow-up, PR #214 P1): re-derives
         the floor from disk on every call after the lane's first touch --
         see `_current_last_seq` -- so a concurrent writer (a different
         `Spool` instance on the same root) that advanced the lane since this
-        instance last looked is reflected here too, not just in `append()`'s
-        rejection.
+        instance last looked is reflected here too.
 
         Args:
             lane: Lane name.
 
         Returns:
-            Next monotonic sequence number (1-based).
+            Next monotonic sequence number (1-based), valid only as a
+            snapshot at the moment this call returns.
 
         Raises:
             SpoolCorruptError: The lane's active segment has mid-file corruption
@@ -424,7 +457,14 @@ class Spool:
     # -- append ----------------------------------------------------------------
 
     def append(self, lane: str, seq: int, payload: dict) -> None:
-        """Append a record to a lane.
+        """Append a record to a lane at a CALLER-CHOSEN seq.
+
+        For a caller that already knows the exact seq it must use (e.g.
+        replaying/reconciling a specific record). For the far more common
+        "give me the next seq and write my payload there" pattern, use
+        `append_next()` instead -- it's the only way to do that atomically
+        (see its docstring and `next_seq()`'s for why a separate `next_seq()`
+        + `append()` pair is unsafe).
 
         Args:
             lane: Lane name.
@@ -449,45 +489,103 @@ class Spool:
             self._last_seq[lane] = current
             if seq <= current:
                 raise ValueError(f"seq must be monotonic: got {seq}, last was {current}")
-            line = json.dumps({"seq": seq, "payload": payload}) + "\n"
-            # Drop-oldest semantics extend to drop-oversized (Codex review):
-            # _evict() only ever unlinks while more than one segment exists,
-            # so a single record whose own serialized size alone exceeds
-            # SEGMENT_MAX_BYTES becomes its own sole/newest segment and can
-            # never be evicted -- unboundedly blowing past a capped lane's
-            # byte cap. Refuse to write it instead: consume the seq (so the
-            # caller's sequencing stays monotonic and no retry re-attempts
-            # the same doomed record) and count it as evicted. EXCEPTION:
-            # never drop on never-drop lanes (spec §4) -- their payloads are
-            # tiny, so this is in practice unreachable, but the never-drop
-            # ruling still applies if it somehow were.
-            if lane not in NEVER_CAPPED_LANES and len(line.encode("utf-8")) > SEGMENT_MAX_BYTES:
-                self._evicted[lane] = self._evicted.get(lane, 0) + 1
-                logging.getLogger(__name__).warning(
-                    "lane '%s': dropping oversized record seq=%d (%d bytes > SEGMENT_MAX_BYTES=%d)",
-                    lane,
-                    seq,
-                    len(line.encode("utf-8")),
-                    SEGMENT_MAX_BYTES,
-                )
-                self._last_seq[lane] = seq
-                return
-            segments = self._segments(lane)
-            active = segments[-1] if segments else None
-            rolled = False
-            if active is None or active.stat().st_size + len(line) > SEGMENT_MAX_BYTES:
-                active = self._lane_dir(lane) / _segment_name(seq)
-                rolled = True
-            try:
-                with open(active, "a", encoding="utf-8") as handle:
-                    handle.write(line)
-            except OSError as exc:
-                if lane not in self._capped:
-                    raise SpoolFullError(f"lane '{lane}': {exc}") from exc
-                raise SpoolError(f"lane '{lane}': {exc}") from exc
+            self._write_locked(lane, seq, payload)
+
+    def append_next(self, lane: str, build: Callable[[int], dict]) -> int:
+        """Atomically allocate the next seq AND append it -- ONE critical section.
+
+        The structural fix for the allocate-then-append race (Codex round 3
+        P1, comment 3924082774): deriving the floor, assigning `seq =
+        floor + 1`, and writing all happen under a SINGLE acquisition of
+        `self._lock`. No other writer -- another `Spool` instance's own
+        call, or a `spool.exclusive()`-held run -- can observe this lane's
+        state, allocate a colliding seq, or write in between; by
+        construction, there is no gap left for one to land in. This is now
+        the required path for every allocate-then-write caller (the live
+        router's batch-spool path, the selftest's channel/event appends) --
+        `next_seq()` followed by a separate `append()` call is exactly the
+        two-lock-acquisition pattern that made this race possible, and
+        remains unsafe for anything that writes off the result.
+
+        Args:
+            lane: Lane name.
+            build: Called with the allocated seq, INSIDE the lock, to
+                produce the JSON-serializable payload -- e.g.
+                ``lambda seq: {**batch, "seq": seq}`` or a small function
+                that stamps `payload["seq"] = seq` on an already-built dict
+                and returns it. This is the one point where the wire
+                payload's own embedded `seq` field (distinct from the
+                spool's own outer JSONL wrapper, which always carries `seq`
+                regardless) gets set, so it's guaranteed to match the
+                atomically-allocated value -- never a value observed,
+                computed, or raced against before the lock was held.
+
+        Returns:
+            The allocated seq.
+
+        Raises:
+            SpoolFullError: If lane is never-capped and write fails.
+            SpoolError: If lane is capped and write fails.
+            SpoolCorruptError: The lane's active segment has mid-file corruption
+                (only on the first call for this lane in this process's lifetime).
+
+        """
+        with self._lock:
+            current = self._current_last_seq(lane)
+            self._last_seq[lane] = current
+            seq = current + 1
+            payload = build(seq)
+            self._write_locked(lane, seq, payload)
+            return seq
+
+    def _write_locked(self, lane: str, seq: int, payload: dict) -> None:
+        """Write one record to `lane` at `seq` -- caller must already hold `self._lock`.
+
+        Shared by `append()` (caller-chosen seq, already floor-checked) and
+        `append_next()` (seq just allocated in the same critical section):
+        both have already established that `seq` is the correct next value
+        for this lane by the time this runs; this only does the actual
+        line-write, oversized-drop, segment-roll, and eviction bookkeeping.
+        """
+        line = json.dumps({"seq": seq, "payload": payload}) + "\n"
+        # Drop-oldest semantics extend to drop-oversized (Codex review):
+        # _evict() only ever unlinks while more than one segment exists,
+        # so a single record whose own serialized size alone exceeds
+        # SEGMENT_MAX_BYTES becomes its own sole/newest segment and can
+        # never be evicted -- unboundedly blowing past a capped lane's
+        # byte cap. Refuse to write it instead: consume the seq (so the
+        # caller's sequencing stays monotonic and no retry re-attempts
+        # the same doomed record) and count it as evicted. EXCEPTION:
+        # never drop on never-drop lanes (spec §4) -- their payloads are
+        # tiny, so this is in practice unreachable, but the never-drop
+        # ruling still applies if it somehow were.
+        if lane not in NEVER_CAPPED_LANES and len(line.encode("utf-8")) > SEGMENT_MAX_BYTES:
+            self._evicted[lane] = self._evicted.get(lane, 0) + 1
+            logging.getLogger(__name__).warning(
+                "lane '%s': dropping oversized record seq=%d (%d bytes > SEGMENT_MAX_BYTES=%d)",
+                lane,
+                seq,
+                len(line.encode("utf-8")),
+                SEGMENT_MAX_BYTES,
+            )
             self._last_seq[lane] = seq
-            if rolled:
-                self._evict(lane)
+            return
+        segments = self._segments(lane)
+        active = segments[-1] if segments else None
+        rolled = False
+        if active is None or active.stat().st_size + len(line) > SEGMENT_MAX_BYTES:
+            active = self._lane_dir(lane) / _segment_name(seq)
+            rolled = True
+        try:
+            with open(active, "a", encoding="utf-8") as handle:
+                handle.write(line)
+        except OSError as exc:
+            if lane not in self._capped:
+                raise SpoolFullError(f"lane '{lane}': {exc}") from exc
+            raise SpoolError(f"lane '{lane}': {exc}") from exc
+        self._last_seq[lane] = seq
+        if rolled:
+            self._evict(lane)
 
     # -- ack & watermark --------------------------------------------------------
 

--- a/src/sink/publish/spool.py
+++ b/src/sink/publish/spool.py
@@ -228,6 +228,15 @@ class Spool:
         already handled by `_scan_last_seq`'s truncate-on-first-touch path,
         not something this cheap peek needs to repair itself.
 
+        The window grows GEOMETRICALLY (doubling each retry: 8KiB, 16KiB,
+        32KiB, ...), not by a fixed 8KiB step (Codex round 3 follow-up, PR
+        #214 P1): a fixed step re-reads the whole (growing) window every
+        iteration, so a final record bigger than one chunk -- worst case a
+        segment-max single-line record, ~4MB -- would cost ~512 iterations
+        each re-reading up to 4MB: quadratic total bytes read. Doubling
+        bounds total bytes read to O(the eventual window size), i.e. O(tail
+        size), since a geometric series sums to about 2x its last term.
+
         Returns:
             The last complete line's `seq`, or `None` if there is no active
             segment, it's empty, or its tail doesn't parse (the caller falls
@@ -241,16 +250,15 @@ class Spool:
         size = path.stat().st_size
         if size == 0:
             return None
-        chunk = 8192
-        window = 0
+        window = min(size, 8192)
         data = b""
         with open(path, "rb") as handle:
             while True:
-                window = min(size, window + chunk)
                 handle.seek(size - window)
                 data = handle.read(window)
                 if data.rstrip(b"\n").count(b"\n") >= 1 or window >= size:
                     break
+                window = min(size, window * 2)
         last_line = data.rstrip(b"\n").rsplit(b"\n", 1)[-1]
         if not last_line:
             return None

--- a/src/sink/publish/spool.py
+++ b/src/sink/publish/spool.py
@@ -10,6 +10,8 @@ segment appends are plain writes (no fsync), so a crash may lose the
 active segment's tail — QoS-1 at-least-once plus cloud-side seq dedupe
 absorbs the replay. Concurrency: every mutator holds the spool's file
 lock (one lock per spool root, like the sink buffer's per-topic locks).
+`exclusive()` lets a caller hold that same lock across several mutating
+calls as one atomic unit (e.g. the selftest CLI, Codex round 3 P1b).
 """
 
 import dataclasses
@@ -36,6 +38,18 @@ class SpoolFullError(SpoolError):
 
 class SpoolCorruptError(SpoolError):
     """Raised when a segment has mid-file JSON corruption (not a crash-torn final line)."""
+
+
+class SpoolLockedError(SpoolError):
+    """Raised when `Spool.exclusive()` cannot acquire the spool's lock within its timeout.
+
+    Means a DIFFERENT `Spool` instance (almost always a different process --
+    e.g. a live `FleetService`) is currently mid-operation on this same
+    spool root. Never raised by the ordinary per-call mutators
+    (`next_seq`/`append`/`ack`/`stats`) themselves -- those block
+    indefinitely on the lock, matching the single-writer invariant's
+    existing behavior. Only `exclusive()`'s bounded wait can time out.
+    """
 
 
 @dataclasses.dataclass
@@ -196,6 +210,52 @@ class Spool:
         last = records[-1]["seq"] if records else 0
         floor = _first_seq_of(last_segment) - 1
         return max(last, floor, self._watermark(lane))
+
+    def exclusive(self, timeout: float = 5.0) -> filelock.AcquireReturnProxy:
+        """Hold this spool's lock across an extended, multi-call critical section.
+
+        For callers that need more than one mutating call (`next_seq`/
+        `append`/`ack`/`stats`) to run as a single atomic unit against this
+        spool root -- e.g. the selftest CLI, which must not interleave with a
+        concurrently running `FleetService` writing the same real spool
+        (Codex round 3, P1b). Use it as a context manager:
+
+            with spool.exclusive(timeout=5.0):
+                spool.next_seq(...)
+                spool.append(...)
+                spool.ack(...)
+
+        Reentrant with those calls: `filelock.FileLock` (used here and by
+        every mutator below) is thread-local reentrant, and this method
+        acquires the SAME `FileLock` instance every mutator already uses --
+        so calls made inside the `with` block just increment/decrement its
+        counter instead of blocking on a lock this thread already holds.
+        Only safe from the thread that entered the context; a lock held by a
+        DIFFERENT `Spool` instance (in practice, almost always a different
+        process) is a real OS-level file lock and is waited on normally.
+
+        Args:
+            timeout: Seconds to wait for a lock held elsewhere before giving
+                up. Short and bounded on purpose: this is a refusal, not an
+                indefinite wait -- unlike the per-call mutators, which block
+                without a timeout.
+
+        Returns:
+            A context manager that releases the lock (or decrements its
+            reentrant counter) on exit.
+
+        Raises:
+            SpoolLockedError: the lock is held elsewhere and was not
+                released within `timeout` seconds.
+
+        """
+        try:
+            return self._lock.acquire(timeout=timeout)
+        except filelock.Timeout as exc:
+            raise SpoolLockedError(
+                f"spool at {self._root} is locked by another writer "
+                f"(timed out after {timeout}s)"
+            ) from exc
 
     def next_seq(self, lane: str) -> int:
         """Get the next sequence number for a lane.

--- a/test/sink/publish/conftest.py
+++ b/test/sink/publish/conftest.py
@@ -12,6 +12,7 @@ import these from here.
 """
 
 import pathlib
+import threading
 import time
 
 import pyarrow as pa
@@ -73,6 +74,23 @@ class FakeSinkNoPrivateBuffers:
         return self._writers_by_topic[topic]
 
 
+class FakeLiveSessionWatch:
+    """In-memory double for `mqtt.LiveSessionWatch` (Codex round 3 follow-up,
+    PR #214 P1, comment 3927287968's own follow-up): `.detected` is set
+    directly by `FakePublisher`'s `publish()` (see `live_session_beat_after_batch`)
+    to simulate a live beat arriving mid-run, without needing a real paho
+    callback thread. `stop_calls` counts `.stop()` calls, mirroring the real
+    `LiveSessionWatch.stop()`'s idempotency contract.
+    """
+
+    def __init__(self) -> None:
+        self.detected = threading.Event()
+        self.stop_calls = 0
+
+    def stop(self) -> None:
+        self.stop_calls += 1
+
+
 class FakePublisher(Publisher):
     """In-memory Publisher double: records every kind of publish; can fail on demand.
 
@@ -103,6 +121,16 @@ class FakePublisher(Publisher):
     calls to the matching silent-teardown helper `_check_no_live_session`
     uses on refusal (comment 3927287968) -- distinct from `close_calls`,
     since that path must NEVER publish a clean-stop beat.
+
+    `live_session_beat_after_batch` (Codex round 3 follow-up, PR #214 P1,
+    comment 3927287968's own follow-up) simulates a live service RESUMING
+    mid-run: when set, the Nth (1-indexed) successful `publish_channels`
+    call sets the open `FakeLiveSessionWatch`'s `.detected` Event, exactly
+    as a real `LiveSessionWatch`'s paho callback would upon receiving a
+    later `online: true` beat. `watch_live_session()` -- the ongoing-watch
+    capability `run_selftest` polls between batches and before the
+    heartbeat/event publishes -- returns a `FakeLiveSessionWatch`
+    (`watch_open_calls` counts calls to it).
     """
 
     def __init__(
@@ -111,10 +139,12 @@ class FakePublisher(Publisher):
         connect_should_fail: bool = False,
         fail_at_channel_call: int | None = None,
         live_session_beat: dict | None = None,
+        live_session_beat_after_batch: int | None = None,
     ) -> None:
         self.connect_should_fail = connect_should_fail
         self.fail_at_channel_call = fail_at_channel_call
         self.live_session_beat = live_session_beat
+        self.live_session_beat_after_batch = live_session_beat_after_batch
         self.connect_calls = 0
         self.schema_calls: list[dict] = []
         self.channel_calls: list[dict] = []
@@ -126,6 +156,8 @@ class FakePublisher(Publisher):
         self.calls: list[str] = []
         self.live_session_probe_calls = 0
         self.disconnect_without_publishing_calls = 0
+        self.watch_open_calls = 0
+        self._watch: FakeLiveSessionWatch | None = None
         self._connected = False
 
     def connect(self) -> None:
@@ -139,6 +171,12 @@ class FakePublisher(Publisher):
         self.calls.append("live_session_probe")
         self.live_session_probe_calls += 1
         return self.live_session_beat
+
+    def watch_live_session(self) -> FakeLiveSessionWatch:
+        self.calls.append("watch_open")
+        self.watch_open_calls += 1
+        self._watch = FakeLiveSessionWatch()
+        return self._watch
 
     def disconnect_without_publishing(self) -> None:
         self.calls.append("disconnect_without_publishing")
@@ -156,6 +194,12 @@ class FakePublisher(Publisher):
             if self.fail_at_channel_call == call_index:
                 raise PublishError(f"forced failure at channel batch {call_index}")
             self.channel_calls.append(payload)
+            if (
+                self.live_session_beat_after_batch is not None
+                and call_index == self.live_session_beat_after_batch
+                and self._watch is not None
+            ):
+                self._watch.detected.set()
         elif kind == "heartbeat":
             self.heartbeat_calls.append(payload)
         elif kind == "events":

--- a/test/sink/publish/conftest.py
+++ b/test/sink/publish/conftest.py
@@ -89,16 +89,32 @@ class FakePublisher(Publisher):
     force a mid-run failure without a real broker.
 
     `calls` is a single ordered log of every method invocation (`"connect"`,
+    `"live_session_probe"` from `wait_for_retained_heartbeat()`,
     `"schema"`/`"channels"`/`"heartbeat"`/`"events"` from `publish()`, and
     `"close"`) -- Task 7's selftest call-order test asserts against this
     rather than trying to interleave the separate per-kind lists.
+
+    `live_session_beat` (Codex round 3 follow-up, PR #214 P1, comment
+    3927287968) simulates what `wait_for_retained_heartbeat()` would
+    return on a real `MqttPublisher`: `None` (default -- no retained
+    heartbeat, matching a fresh robot/broker), or a payload dict such as
+    `{"online": True}` (a live session connected) / `{"online": False}`
+    (paused/stopped/lwt). `disconnect_without_publishing_calls` counts
+    calls to the matching silent-teardown helper `_check_no_live_session`
+    uses on refusal (comment 3927287968) -- distinct from `close_calls`,
+    since that path must NEVER publish a clean-stop beat.
     """
 
     def __init__(
-        self, *, connect_should_fail: bool = False, fail_at_channel_call: int | None = None
+        self,
+        *,
+        connect_should_fail: bool = False,
+        fail_at_channel_call: int | None = None,
+        live_session_beat: dict | None = None,
     ) -> None:
         self.connect_should_fail = connect_should_fail
         self.fail_at_channel_call = fail_at_channel_call
+        self.live_session_beat = live_session_beat
         self.connect_calls = 0
         self.schema_calls: list[dict] = []
         self.channel_calls: list[dict] = []
@@ -108,6 +124,8 @@ class FakePublisher(Publisher):
         self.close_reasons: list[str] = []
         self.reconnects = 0
         self.calls: list[str] = []
+        self.live_session_probe_calls = 0
+        self.disconnect_without_publishing_calls = 0
         self._connected = False
 
     def connect(self) -> None:
@@ -116,6 +134,16 @@ class FakePublisher(Publisher):
         if self.connect_should_fail:
             raise PublishError("connect failed")
         self._connected = True
+
+    def wait_for_retained_heartbeat(self, timeout_s: float = 1.5) -> dict | None:
+        self.calls.append("live_session_probe")
+        self.live_session_probe_calls += 1
+        return self.live_session_beat
+
+    def disconnect_without_publishing(self) -> None:
+        self.calls.append("disconnect_without_publishing")
+        self.disconnect_without_publishing_calls += 1
+        self._connected = False
 
     def publish(
         self, kind: str, payload: dict, *, retain: bool = False, timeout_s: float = 10.0

--- a/test/sink/publish/test_control.py
+++ b/test/sink/publish/test_control.py
@@ -644,6 +644,26 @@ class TestPersistStreamsManifestHandling:
 
         assert manifest_path.read_text() == original_text
 
+    def test_invalid_utf8_existing_manifest_raises_without_clobbering(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`Path.read_text()` raises `UnicodeDecodeError` on invalid UTF-8
+        bytes -- BEFORE `yaml.safe_load` ever runs -- so the never-clobber
+        guard's original `except yaml.YAMLError` alone let it escape
+        uncaught (Codex round 3 follow-up, PR #214 P2, comment
+        3927023413's sibling finding): a manifest a human corrupted at the
+        byte level crashed `_read_manifest_doc` instead of refusing typed,
+        exactly like the already-guarded unparsable-YAML case."""
+        manifest_path = tmp_path / "manifest.yaml"
+        original_bytes = b"subscriptions: []\n\xff\xfe not valid utf-8"
+        manifest_path.write_bytes(original_bytes)
+        monkeypatch.setattr(settings, "STARTUP_PIPELINES_FILE", str(manifest_path))
+
+        with pytest.raises(StreamConfigError, match="manifest"):
+            control._persist_streams({"channels": [], "events": []})
+
+        assert manifest_path.read_bytes() == original_bytes
+
     def test_missing_manifest_file_persists_from_empty(
         self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/test/sink/publish/test_control.py
+++ b/test/sink/publish/test_control.py
@@ -8,6 +8,7 @@ raises before the holder is ever touched.
 """
 
 import importlib
+import os
 import pathlib
 import stat
 import sys
@@ -738,6 +739,39 @@ class TestStreamTopics:
         assert "persist_error" in result
         assert "unparsable manifest" in result["persist_error"]
         assert manifest_path.read_text() == original_text
+
+    @pytest.mark.skipif(
+        hasattr(os, "geteuid") and os.geteuid() == 0,
+        reason="root bypasses directory permission checks",
+    )
+    def test_read_only_manifest_directory_does_not_undo_a_successful_restart(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """P2 follow-up (Codex round 3, PR #214): `_persist_or_report` widened
+        to also catch `OSError` -- a read-only manifest directory (disk full,
+        permission denied, etc) must not undo an already-successful restart
+        either, same as the unparsable-manifest StreamConfigError case."""
+        old_service = self._running_multi_topic_service(tmp_path)
+        manifest_dir = tmp_path / "readonly"
+        manifest_dir.mkdir(mode=0o555)
+        manifest_path = manifest_dir / "manifest.yaml"
+        monkeypatch.setattr(settings, "STARTUP_PIPELINES_FILE", str(manifest_path))
+
+        try:
+            result = control.stream_topics(
+                channels=[{"topic": "/odom", "fields": ["y"], "rate_hz": 2}], events=None
+            )
+
+            new_service = startup.fleet_service()
+            assert new_service is not None
+            assert new_service is not old_service
+            names = {c["c"] for c in new_service.channels}
+            assert {"imu.x", "odom.y"} <= names
+            assert result["persisted"] is False
+            assert "persist_error" in result
+            assert not manifest_path.exists()
+        finally:
+            manifest_dir.chmod(0o755)  # restore write access so tmp_path cleanup can proceed
 
     def test_same_topic_rule_is_replaced_not_duplicated(self, tmp_path: pathlib.Path) -> None:
         self._running_multi_topic_service(tmp_path)

--- a/test/sink/publish/test_control.py
+++ b/test/sink/publish/test_control.py
@@ -33,7 +33,7 @@ from src.sink.publish import (
     identity,
 )
 from src.sink.publish.service import FleetService
-from src.sink.publish.spool import Spool
+from src.sink.publish.spool import Spool, SpoolCorruptError
 
 # `fake_server` is imported only to be re-exported as a pytest fixture (used
 # by parameter name in TestEnrollIdentity, never referenced by name in this
@@ -241,6 +241,56 @@ class TestFleetStatusNoGate:
         assert status["enrolled"] is False
         assert status["identity"] is None
 
+    def test_find_spec_raising_module_not_found_reports_not_installed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """P2 (Codex round 3): `find_spec("paho.mqtt")` itself can raise when the
+        parent `paho` package on the path is a half-installed namespace package
+        -- must degrade to "not installed", never propagate out of a
+        never-raises function."""
+
+        def _boom(_name: str) -> None:
+            raise ModuleNotFoundError("paho")
+
+        monkeypatch.setattr(control.importlib.util, "find_spec", _boom)
+
+        status = control.fleet_status()
+
+        assert status["installed"] is False
+
+    def test_find_spec_raising_value_error_reports_not_installed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Same guard, the other exception `find_spec` can raise for a broken
+        namespace package."""
+
+        def _boom(_name: str) -> None:
+            raise ValueError("half-installed namespace package")
+
+        monkeypatch.setattr(control.importlib.util, "find_spec", _boom)
+
+        status = control.fleet_status()
+
+        assert status["installed"] is False
+
+    def test_corrupt_spool_status_reports_error_instead_of_raising(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """P2 (Codex round 3): `FleetService.status()` rescans spool segments on
+        first access and can raise `SpoolCorruptError` -- `fleet_status()` must
+        surface that as `status: {"error": ...}`, never let it propagate."""
+        service, _pub = _running_service(tmp_path)
+        startup.set_fleet_service(service)
+
+        def _boom() -> dict:
+            raise SpoolCorruptError("lane 'channels': segment corrupt")
+
+        monkeypatch.setattr(service, "status", _boom)
+
+        status = control.fleet_status()
+
+        assert status["status"] == {"error": "SpoolCorruptError: lane 'channels': segment corrupt"}
+
 
 def test_control_module_does_not_import_paho_or_cryptography_eagerly(
     monkeypatch: pytest.MonkeyPatch,
@@ -300,6 +350,27 @@ class TestPauseStreaming:
         result = control.pause_streaming(discard=True)
 
         assert result == {"service": "paused", "changed": True, "discarded": True}
+        assert list(spool.pending("channels")) == []
+
+    def test_discard_true_while_already_paused_still_empties_and_reports_unchanged(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        """P2 (Codex round 3): `changed: False` (the service was already
+        paused) but `discarded: True` still actually empties the backlog --
+        the tool-level ruling `{"service": "paused", "changed": False,
+        "discarded": True}`."""
+        service, _pub = _running_service(tmp_path)
+        spool = service._spool
+        startup.set_fleet_service(service)
+        control.pause_streaming()  # first pause, no discard
+
+        seq = spool.next_seq("channels")
+        spool.append("channels", seq, {"v": 1, "samples": []})
+        assert list(spool.pending("channels"))
+
+        result = control.pause_streaming(discard=True)
+
+        assert result == {"service": "paused", "changed": False, "discarded": True}
         assert list(spool.pending("channels")) == []
 
     def test_no_service_is_idempotent_no_op(self) -> None:
@@ -637,7 +708,36 @@ class TestStreamTopics:
         names = {c["c"] for c in new_service.channels}
         assert {"imu.x", "odom.y"} <= names
         assert result["service"] == "running"
-        assert result["events"] == []
+        assert result["events_configured"] == []
+        assert result["events_active"] is False
+
+    def test_unparsable_manifest_does_not_undo_a_successful_restart(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """P2 (Codex round 3): live-vs-persisted atomicity -- a valid rule
+        change against a RUNNING service (so `_current_streams()` never
+        touches the manifest) must still restart the service even when the
+        configured manifest file is unparsable; the persist failure is
+        reported, not raised, and the bad file is left untouched."""
+        old_service = self._running_multi_topic_service(tmp_path)
+        manifest_path = tmp_path / "manifest.yaml"
+        original_text = "not: valid: yaml: ["
+        manifest_path.write_text(original_text)
+        monkeypatch.setattr(settings, "STARTUP_PIPELINES_FILE", str(manifest_path))
+
+        result = control.stream_topics(
+            channels=[{"topic": "/odom", "fields": ["y"], "rate_hz": 2}], events=None
+        )
+
+        new_service = startup.fleet_service()
+        assert new_service is not None
+        assert new_service is not old_service
+        names = {c["c"] for c in new_service.channels}
+        assert {"imu.x", "odom.y"} <= names
+        assert result["persisted"] is False
+        assert "persist_error" in result
+        assert "unparsable manifest" in result["persist_error"]
+        assert manifest_path.read_text() == original_text
 
     def test_same_topic_rule_is_replaced_not_duplicated(self, tmp_path: pathlib.Path) -> None:
         self._running_multi_topic_service(tmp_path)
@@ -810,7 +910,40 @@ class TestStreamTopics:
         assert len(new_service.streams.events) == 1
         assert new_service.streams.events[0].predicate == "x < -20"
         assert new_service.streams.events[0].pre_seconds == 5.0
-        assert result["events"] == ["hard_decel"]
+        assert result["events_configured"] == ["hard_decel"]
+        assert result["events_active"] is False
+
+    def test_configuring_an_event_rule_logs_a_not_active_warning(
+        self, tmp_path: pathlib.Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """P1a (Codex round 3): honest-reporting -- event rules are stored and
+        forwarded, but nothing on-robot evaluates them yet, so every call that
+        leaves an event rule configured logs a WARNING saying so."""
+        self._running_multi_topic_service(tmp_path)
+
+        with caplog.at_level("WARNING", logger="src.sink.publish.control"):
+            control.stream_topics(
+                channels=None,
+                events=[{"name": "hard_decel", "topic": "/imu", "predicate": "x < -10"}],
+            )
+
+        assert any(
+            "not evaluated until the event runtime ships" in record.message
+            for record in caplog.records
+        )
+
+    def test_no_event_rules_configured_logs_no_warning(
+        self, tmp_path: pathlib.Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The warning fires only when an event rule is actually configured."""
+        self._running_multi_topic_service(tmp_path)
+
+        with caplog.at_level("WARNING", logger="src.sink.publish.control"):
+            control.stream_topics(
+                channels=[{"topic": "/odom", "fields": ["y"], "rate_hz": 2}], events=None
+            )
+
+        assert caplog.records == []
 
     def test_disabled_raises_before_any_state_change(
         self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
@@ -946,6 +1079,29 @@ class TestStopStreams:
 
         assert startup.fleet_service().streams.events == []
         assert result["changed"] is True
+        assert result["events_configured"] == []
+        assert result["events_active"] is False
+
+    def test_leftover_event_rule_after_stop_streams_logs_a_not_active_warning(
+        self, tmp_path: pathlib.Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """P1a: the same honest-reporting warning fires from stop_streams too,
+        whenever event rules remain configured after the call."""
+        streams = config.StreamsConfig.build(
+            {
+                "channels": [{"topic": "/imu", "fields": ["x"], "rate_hz": 50}],
+                "events": [{"name": "hard_decel", "topic": "/imu", "predicate": "true"}],
+            }
+        )
+        self._service_with_streams(tmp_path, streams)
+
+        with caplog.at_level("WARNING", logger="src.sink.publish.control"):
+            control.stop_streams(channels=["imu.x"], events=None)
+
+        assert any(
+            "not evaluated until the event runtime ships" in record.message
+            for record in caplog.records
+        )
 
     def test_unknown_name_is_a_no_op_and_does_not_restart(self, tmp_path: pathlib.Path) -> None:
         service, _pub = _running_service(tmp_path)
@@ -1018,6 +1174,33 @@ class TestStopStreams:
         assert resume_result == {"service": "running", "changed": True}
         assert new_service.paused is False
 
+    def test_unparsable_manifest_does_not_undo_a_successful_restart(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """P2 (Codex round 3): same live-vs-persisted atomicity ruling as
+        stream_topics's -- a rule removal that actually changes and restarts
+        a running service must not be undone by an unparsable manifest;
+        the persist failure is reported, not raised."""
+        streams = config.StreamsConfig.build(
+            {"channels": [{"topic": "/imu", "fields": ["x", "y"], "rate_hz": 50}]}
+        )
+        old_service = self._service_with_streams(tmp_path, streams)
+        manifest_path = tmp_path / "manifest.yaml"
+        original_text = "not: valid: yaml: ["
+        manifest_path.write_text(original_text)
+        monkeypatch.setattr(settings, "STARTUP_PIPELINES_FILE", str(manifest_path))
+
+        result = control.stop_streams(channels=["imu.x"], events=None)
+
+        new_service = startup.fleet_service()
+        assert new_service is not old_service
+        assert {c["c"] for c in new_service.channels} == {"imu.y"}
+        assert result["changed"] is True
+        assert result["persisted"] is False
+        assert "persist_error" in result
+        assert "unparsable manifest" in result["persist_error"]
+        assert manifest_path.read_text() == original_text
+
     def test_no_service_persist_only_reports_stopped(
         self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -1043,7 +1226,8 @@ class TestStopStreams:
         assert result == {
             "service": "stopped",
             "channels": [],
-            "events": [],
+            "events_configured": [],
+            "events_active": False,
             "changed": True,
             "persisted": True,
         }

--- a/test/sink/publish/test_control.py
+++ b/test/sink/publish/test_control.py
@@ -1235,6 +1235,79 @@ class TestStopStreams:
         assert "unparsable manifest" in result["persist_error"]
         assert manifest_path.read_text() == original_text
 
+    def test_no_service_persist_failure_stream_config_error_propagates(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """P2 follow-up (Codex round 3, PR #214, comment 3924387659): the
+        persist-only path (no live service) has no successful restart for a
+        swallowed persist failure to protect -- this call's ENTIRE effect
+        IS the manifest write, so a `StreamConfigError` from it must
+        propagate typed, not be folded into `persisted: False` /
+        `persist_error` the way the restarted case's failure is (see
+        `test_unparsable_manifest_does_not_undo_a_successful_restart`
+        above -- that's the WITH-a-live-service path, deliberately
+        unaffected by this ruling)."""
+        manifest_path = tmp_path / "manifest.yaml"
+        manifest_path.write_text(
+            yaml.safe_dump(
+                {
+                    "subscriptions": [],
+                    "streams": {
+                        "channels": [{"topic": "/imu", "fields": ["x"], "rate_hz": 50}],
+                        "events": [],
+                    },
+                }
+            )
+        )
+        monkeypatch.setattr(settings, "STARTUP_PIPELINES_FILE", str(manifest_path))
+        startup.set_fleet_service(None)
+
+        def boom(_streams_manifest: dict | None) -> bool:
+            raise StreamConfigError("manifest", "boom: simulated persist failure")
+
+        monkeypatch.setattr(control, "_persist_streams", boom)
+
+        with pytest.raises(StreamConfigError, match="boom"):
+            control.stop_streams(channels=["imu.x"], events=None)
+
+        assert startup.fleet_service() is None
+
+    @pytest.mark.skipif(
+        hasattr(os, "geteuid") and os.geteuid() == 0,
+        reason="root bypasses directory permission checks",
+    )
+    def test_no_service_persist_failure_os_error_propagates(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Same ruling, the other exception `_persist_or_report` normally
+        swallows for the restarted case: an `OSError` (read-only manifest
+        directory, full disk, etc) from the persist-only path must also
+        propagate, not be folded into `persisted: False` / `persist_error`."""
+        manifest_dir = tmp_path / "readonly"
+        manifest_dir.mkdir()
+        manifest_path = manifest_dir / "manifest.yaml"
+        manifest_path.write_text(
+            yaml.safe_dump(
+                {
+                    "subscriptions": [],
+                    "streams": {
+                        "channels": [{"topic": "/imu", "fields": ["x"], "rate_hz": 50}],
+                        "events": [],
+                    },
+                }
+            )
+        )
+        manifest_dir.chmod(0o555)  # read-only AFTER writing: reads still work, writes fail
+        monkeypatch.setattr(settings, "STARTUP_PIPELINES_FILE", str(manifest_path))
+        startup.set_fleet_service(None)
+
+        try:
+            with pytest.raises(OSError):
+                control.stop_streams(channels=["imu.x"], events=None)
+            assert startup.fleet_service() is None
+        finally:
+            manifest_dir.chmod(0o755)  # restore write access so tmp_path cleanup can proceed
+
     def test_no_service_persist_only_reports_stopped(
         self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/test/sink/publish/test_heartbeat.py
+++ b/test/sink/publish/test_heartbeat.py
@@ -9,6 +9,7 @@ import time
 import pytest
 
 from src.sink.publish import heartbeat as heartbeat_mod
+from src.sink.publish import spool as spool_mod
 from src.sink.publish.heartbeat import HEARTBEAT_INTERVAL_S, HeartbeatThread, build_heartbeat
 from src.sink.publish.publisher import Publisher, PublishError
 from src.sink.publish.spool import Spool, SpoolFullError
@@ -338,6 +339,80 @@ class TestHeartbeatThread:
         assert pending[0][1] == payload
         assert thread.spool_failures == 0  # the spool write itself succeeded
 
+    def test_publish_failure_spool_fallback_uses_append_next(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Codex round 3 P1 follow-up (comment 3924082774): the never-drop
+        heartbeat-lane fallback must go through `Spool.append_next()`, never
+        a separate `next_seq()` + `append()` pair -- that shape left a gap a
+        concurrent writer could land in, and while this path's own
+        `except Exception` already prevented it from being a thread-killer
+        (unlike the router's unguarded batch-flush path), it still silently
+        dropped this beat's heartbeat from the never-drop lane on a
+        spurious collision."""
+        pub = FakePublisher()
+        pub.fail_next(1)
+        spool = Spool(tmp_path / "spool")
+        calls: list[str] = []
+        original_next_seq = spool_mod.Spool.next_seq
+        original_append = spool_mod.Spool.append
+        original_append_next = spool_mod.Spool.append_next
+
+        def spy_next_seq(self: Spool, lane: str) -> int:
+            calls.append("next_seq")
+            return original_next_seq(self, lane)
+
+        def spy_append(self: Spool, lane: str, seq: int, payload: dict) -> None:
+            calls.append("append")
+            return original_append(self, lane, seq, payload)
+
+        def spy_append_next(self: Spool, lane: str, build: object) -> int:
+            calls.append("append_next")
+            return original_append_next(self, lane, build)
+
+        monkeypatch.setattr(spool_mod.Spool, "next_seq", spy_next_seq)
+        monkeypatch.setattr(spool_mod.Spool, "append", spy_append)
+        monkeypatch.setattr(spool_mod.Spool, "append_next", spy_append_next)
+
+        payload = {"v": 1, "marker": "spooled"}
+        thread = HeartbeatThread(pub, lambda: payload, interval_s=10.0, spool=spool)
+        thread._tick()
+
+        assert calls == ["append_next"]
+        _seq, spooled_payload = next(iter(spool.pending("heartbeat")))
+        assert spooled_payload == payload
+        assert thread.spool_failures == 0
+
+    def test_a_prior_writer_on_the_lane_does_not_drop_the_beat(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        """Sanity coverage alongside the call-order spy test above (which is
+        what actually has RED/GREEN evidence for this fix): a competing
+        writer (e.g. a selftest run holding `spool.exclusive()`) having
+        already written to the "heartbeat" lane must not stop this beat
+        from being correctly recorded right after it, at the next seq --
+        `append_next()` re-derives the floor fresh rather than trusting any
+        earlier peek, so there's nothing for a prior writer to go stale
+        against."""
+        pub = FakePublisher()
+        pub.fail_next(1)
+        spool = Spool(tmp_path / "spool")
+        competitor = Spool(tmp_path / "spool")  # a SEPARATE instance, same root
+
+        with competitor.exclusive(timeout=1.0):
+            competitor.append_next("heartbeat", lambda seq: {"marker": "competitor", "seq": seq})
+
+        payload = {"v": 1, "marker": "spooled"}
+        thread = HeartbeatThread(pub, lambda: payload, interval_s=10.0, spool=spool)
+        thread._tick()
+
+        assert thread.spool_failures == 0  # no collision, no dropped beat
+        pending = list(spool.pending("heartbeat"))
+        assert [p for _, p in pending] == [
+            {"marker": "competitor", "seq": 1},
+            payload,
+        ]
+
     def test_publish_failure_without_spool_swallowed(self) -> None:
         pub = FakePublisher()
         pub.fail_next(1)
@@ -357,12 +432,18 @@ class TestHeartbeatThread:
         pub.fail_next(1000)  # every tick's publish fails
 
         class BoomSpool:
-            """Duck-typed Spool stand-in: next_seq works, append always fails."""
+            """Duck-typed Spool stand-in: append_next always fails.
 
-            def next_seq(self, lane: str) -> int:
-                return 1
+            Codex round 3 P1 follow-up (comment 3924082774): `_tick` now
+            calls `append_next`, not a separate `next_seq()` + `append()`
+            pair -- this stand-in must implement the method that's actually
+            called, or the failure this test is pinning (a genuine
+            `SpoolFullError` from the write itself) would silently become a
+            different exception (an `AttributeError` from the missing
+            method) that happens to still get caught by the same handler.
+            """
 
-            def append(self, lane: str, seq: int, payload: dict) -> None:
+            def append_next(self, lane: str, build: object) -> int:
                 raise SpoolFullError(f"lane '{lane}': disk full")
 
         thread = HeartbeatThread(pub, lambda: {"v": 1}, interval_s=10.0, spool=BoomSpool())

--- a/test/sink/publish/test_identity.py
+++ b/test/sink/publish/test_identity.py
@@ -1797,6 +1797,27 @@ class TestDeleteIdentity:
     ) -> None:
         assert identity_mod.delete_identity(tmp_path / "never-enrolled") == []
 
+    def test_missing_identity_yaml_still_sweeps_orphaned_key_material(
+        self, tmp_path: object
+    ) -> None:
+        """P2 (Codex round 3): an enroll that crashed between writing key
+        material and writing identity.yaml itself must still be cleanable --
+        the pattern sweep must run even with no identity.yaml to key off of."""
+        directory = tmp_path / "identity"
+        directory.mkdir()
+        (directory / "robot.key").write_bytes(b"orphan-key")
+        (directory / "robot.crt").write_bytes(b"orphan-crt")
+        (directory / "ca.crt").write_bytes(b"orphan-ca")
+        assert not (directory / "identity.yaml").exists()
+
+        deleted = identity_mod.delete_identity(directory)
+
+        assert deleted == sorted(["robot.key", "robot.crt", "ca.crt"])
+        assert "identity.yaml" not in deleted
+        assert not directory.exists()
+        # Idempotent: nothing left, second call is a clean no-op.
+        assert identity_mod.delete_identity(directory) == []
+
     def test_missing_identity_yaml_is_idempotent_on_repeat_calls(
         self, fake_server: str, tmp_path: object
     ) -> None:

--- a/test/sink/publish/test_mqtt_publisher.py
+++ b/test/sink/publish/test_mqtt_publisher.py
@@ -58,6 +58,7 @@ class FakeFleetPaho:
         # traffic.
         self.on_message: object = None
         self.subscribed_topics: list[str] = []
+        self.subscribe_options: list[object] = []
         self.unsubscribed_topics: list[str] = []
         self.queued_message: FakeMqttMessage | None = None
 
@@ -91,15 +92,25 @@ class FakeFleetPaho:
         self.calls.append(("publish", topic, payload, qos, retain))
         return self.next_info
 
-    def subscribe(self, topic: str, qos: int = 0) -> None:
-        self.calls.append(("subscribe", topic, qos))
+    def subscribe(self, topic: str, qos: int = 0, options: object = None) -> None:
+        self.calls.append(("subscribe", topic, qos, options))
         self.subscribed_topics.append(topic)
+        self.subscribe_options.append(options)
         if self.queued_message is not None and self.on_message is not None:
             self.on_message(self, None, self.queued_message)
 
     def unsubscribe(self, topic: str) -> None:
         self.calls.append(("unsubscribe", topic))
         self.unsubscribed_topics.append(topic)
+
+
+class FakeSubscribeOptions:
+    """Minimal stand-in for paho's MQTT5 `SubscribeOptions` -- just enough to
+    let `mqtt.py` construct one and this fake record what it asked for."""
+
+    def __init__(self, qos: int = 0, noLocal: bool = False, **_kw: object) -> None:  # noqa: N803
+        self.qos = qos
+        self.noLocal = noLocal
 
 
 @pytest.fixture()
@@ -115,6 +126,7 @@ def fake(monkeypatch: pytest.MonkeyPatch) -> dict[str, FakeFleetPaho]:
         CallbackAPIVersion=types.SimpleNamespace(VERSION2="v2"),
         MQTTv5=5,
         MQTT_ERR_SUCCESS=0,
+        SubscribeOptions=FakeSubscribeOptions,
     )
     monkeypatch.setattr(publish_mqtt, "_paho", lambda: fake_module)
     return holder
@@ -386,9 +398,42 @@ class TestWaitForRetainedHeartbeat:
 
         assert result is None
 
-    def test_no_message_returns_none_within_timeout(
-        self, fake: dict[str, FakeFleetPaho]
-    ) -> None:
+    def test_garbage_bytes_fail_closed(self, fake: dict[str, FakeFleetPaho]) -> None:
+        """Codex round 3 follow-up (PR #214, P2, comment 3927023413's
+        sibling finding): a retained payload that isn't even valid UTF-8/
+        JSON must never be silently treated the same as "nothing retained,
+        proceed" -- something IS on the topic and this process cannot tell
+        what it means, so the safe default is to refuse."""
+        p = _publisher()
+        p.connect()
+        fake["client"].queued_message = FakeMqttMessage(
+            topic="bagel/v1/acme/r7/heartbeat",
+            payload=b"\xff\xfe not valid utf-8 or json",
+            retain=True,
+        )
+
+        with pytest.raises(PublishError, match="heartbeat"):
+            p.wait_for_retained_heartbeat(timeout_s=0.05)
+
+        # Still tears itself down cleanly even on the fail-closed path.
+        assert fake["client"].unsubscribed_topics == ["bagel/v1/acme/r7/heartbeat"]
+
+    def test_non_object_json_fails_closed(self, fake: dict[str, FakeFleetPaho]) -> None:
+        """Valid JSON that isn't a mapping (e.g. a bare array) is just as
+        unusable as garbage bytes -- `.get("online")` would either crash or
+        (worse) silently misbehave; refuse instead of guessing."""
+        p = _publisher()
+        p.connect()
+        fake["client"].queued_message = FakeMqttMessage(
+            topic="bagel/v1/acme/r7/heartbeat",
+            payload=json.dumps([1, 2, 3]).encode(),
+            retain=True,
+        )
+
+        with pytest.raises(PublishError, match="heartbeat"):
+            p.wait_for_retained_heartbeat(timeout_s=0.05)
+
+    def test_no_message_returns_none_within_timeout(self, fake: dict[str, FakeFleetPaho]) -> None:
         """A fresh robot/broker with nothing retained: times out, returns
         `None` (not an error -- `None` means "proceed" to the caller)."""
         p = _publisher()
@@ -421,6 +466,154 @@ class TestWaitForRetainedHeartbeat:
             p.wait_for_retained_heartbeat()
 
 
+class TestWatchLiveSession:
+    """Codex round 3 follow-up (PR #214, P1, comment 3927287968's own
+    follow-up): unlike `wait_for_retained_heartbeat` (a bounded, one-shot,
+    START-only probe), `watch_live_session()` keeps the heartbeat
+    subscription open so a beat arriving ANY time later -- not just the
+    state retained at subscribe time -- still sets `.detected`.
+    """
+
+    def test_subscribes_and_does_not_block(self, fake: dict[str, FakeFleetPaho]) -> None:
+        p = _publisher()
+        p.connect()
+
+        watch = p.watch_live_session()
+
+        assert fake["client"].subscribed_topics == ["bagel/v1/acme/r7/heartbeat"]
+        assert not watch.detected.is_set()
+
+    def test_subscribes_with_no_local_so_this_clients_own_beats_are_not_echoed(
+        self, fake: dict[str, FakeFleetPaho]
+    ) -> None:
+        """Critical: without MQTT5's `noLocal` subscribe option, a broker
+        delivers a client's OWN publishes back to itself when it's
+        subscribed to a matching topic -- so `run_selftest`'s own,
+        perfectly healthy heartbeat publish (before the events publish)
+        would loop back through this exact watch and be mistaken for a
+        DIFFERENT, live session appearing mid-run. Caught only by the live-
+        broker e2e suite (`FakeFleetPaho` doesn't simulate broker echo),
+        traced back to this missing option."""
+        p = _publisher()
+        p.connect()
+
+        p.watch_live_session()
+
+        [options] = fake["client"].subscribe_options
+        assert options is not None
+        assert options.noLocal is True
+
+    def test_a_later_online_true_message_sets_detected(
+        self, fake: dict[str, FakeFleetPaho]
+    ) -> None:
+        """The core fix: a message arriving well AFTER `watch_live_session()`
+        returns -- simulating a live service that resumes mid-selftest-run
+        -- must still be caught, not just the state present at subscribe
+        time."""
+        p = _publisher()
+        p.connect()
+        client = fake["client"]
+
+        watch = p.watch_live_session()
+        assert not watch.detected.is_set()
+
+        # A later message, delivered well after subscribe() returned --
+        # mirroring a live FleetService publishing its own heartbeat while
+        # this watch is still open. Per MQTT-3.3.1-9, a message delivered
+        # to an ALREADY-established subscription carries retain=False
+        # regardless of how the publisher published it -- so this must not
+        # depend on the retain flag the way the START-only probe does.
+        client.on_message(
+            client,
+            None,
+            FakeMqttMessage(
+                topic="bagel/v1/acme/r7/heartbeat",
+                payload=json.dumps({"v": 1, "online": True}).encode(),
+                retain=False,
+            ),
+        )
+
+        assert watch.detected.is_set()
+
+    def test_an_online_false_message_does_not_set_detected(
+        self, fake: dict[str, FakeFleetPaho]
+    ) -> None:
+        p = _publisher()
+        p.connect()
+        client = fake["client"]
+
+        watch = p.watch_live_session()
+        client.on_message(
+            client,
+            None,
+            FakeMqttMessage(
+                topic="bagel/v1/acme/r7/heartbeat",
+                payload=json.dumps({"v": 1, "online": False, "reason": "paused"}).encode(),
+                retain=False,
+            ),
+        )
+
+        assert not watch.detected.is_set()
+
+    def test_an_unparsable_message_fails_closed_by_setting_detected(
+        self, fake: dict[str, FakeFleetPaho]
+    ) -> None:
+        """Same fail-closed rule as `wait_for_retained_heartbeat`: an
+        unparsable beat means "can't tell", which is treated as unsafe, not
+        safe."""
+        p = _publisher()
+        p.connect()
+        client = fake["client"]
+
+        watch = p.watch_live_session()
+        client.on_message(
+            client,
+            None,
+            FakeMqttMessage(
+                topic="bagel/v1/acme/r7/heartbeat",
+                payload=b"\xff\xfe garbage",
+                retain=False,
+            ),
+        )
+
+        assert watch.detected.is_set()
+
+    def test_stop_unsubscribes_and_restores_prior_handler(
+        self, fake: dict[str, FakeFleetPaho]
+    ) -> None:
+        p = _publisher()
+        p.connect()
+        client = fake["client"]
+
+        def _prior_handler(*_args: object) -> None:
+            pass
+
+        client.on_message = _prior_handler
+        watch = p.watch_live_session()
+        assert client.on_message is not _prior_handler
+
+        watch.stop()
+
+        assert client.unsubscribed_topics == ["bagel/v1/acme/r7/heartbeat"]
+        assert client.on_message is _prior_handler
+
+    def test_stop_is_idempotent(self, fake: dict[str, FakeFleetPaho]) -> None:
+        p = _publisher()
+        p.connect()
+        client = fake["client"]
+
+        watch = p.watch_live_session()
+        watch.stop()
+        watch.stop()  # must not raise, must not double-unsubscribe
+
+        assert client.unsubscribed_topics == ["bagel/v1/acme/r7/heartbeat"]
+
+    def test_raises_when_not_connected(self, fake: dict[str, FakeFleetPaho]) -> None:
+        p = _publisher()
+        with pytest.raises(PublishError):
+            p.watch_live_session()
+
+
 class TestDisconnectWithoutPublishing:
     """Codex round 3 follow-up (PR #214, P1, comment 3927287968): the
     silent-teardown helper `_check_no_live_session` uses on refusal --
@@ -428,9 +621,7 @@ class TestDisconnectWithoutPublishing:
     publishing a clean-stop beat that could itself mislead a live watcher.
     """
 
-    def test_tears_down_without_publishing_anything(
-        self, fake: dict[str, FakeFleetPaho]
-    ) -> None:
+    def test_tears_down_without_publishing_anything(self, fake: dict[str, FakeFleetPaho]) -> None:
         p = _publisher()
         p.connect()
         client = fake["client"]
@@ -442,9 +633,7 @@ class TestDisconnectWithoutPublishing:
         assert not any(c[0] == "publish" for c in client.calls)
         assert p.connected is False
 
-    def test_idempotent_and_safe_when_never_connected(
-        self, fake: dict[str, FakeFleetPaho]
-    ) -> None:
+    def test_idempotent_and_safe_when_never_connected(self, fake: dict[str, FakeFleetPaho]) -> None:
         p = _publisher()
         p.disconnect_without_publishing()  # must not raise
         p.disconnect_without_publishing()  # a second call must not raise either

--- a/test/sink/publish/test_mqtt_publisher.py
+++ b/test/sink/publish/test_mqtt_publisher.py
@@ -293,6 +293,92 @@ class TestClose:
         assert json.loads(stop[2])["reason"] == reason
 
 
+class TestRetainMessages:
+    """Codex round 3 follow-up (PR #214, P1, comment 3927023413):
+    `retain_messages=False` (the selftest) must leave no retained residue
+    on the SAME shared robot topics the live service publishes to -- its
+    fixture schema staying retained would make a late subscriber decode
+    live batches against the wrong schema until the live service's next
+    reconnect, and its close() beat leaving a retained `online: false`
+    would make the robot look dead until the next live beat.
+    """
+
+    def test_selftest_publisher_forces_schema_unretained(
+        self, fake: dict[str, FakeFleetPaho]
+    ) -> None:
+        p = _publisher(retain_messages=False)
+        p.connect()
+        p.publish_schema({"v": 1, "channels": []})
+        call = [c for c in fake["client"].calls if c[0] == "publish"][-1]
+        assert call[1].endswith("/schema")
+        assert call[4] is False  # retain
+
+    def test_selftest_publisher_forces_heartbeat_unretained(
+        self, fake: dict[str, FakeFleetPaho]
+    ) -> None:
+        p = _publisher(retain_messages=False)
+        p.connect()
+        p.publish_heartbeat({"v": 1, "online": True})
+        call = [c for c in fake["client"].calls if c[0] == "publish"][-1]
+        assert call[1].endswith("/heartbeat")
+        assert call[4] is False  # retain
+
+    def test_selftest_publisher_forces_close_beat_unretained(
+        self, fake: dict[str, FakeFleetPaho]
+    ) -> None:
+        p = _publisher(retain_messages=False)
+        p.connect()
+        p.close()
+        stop = [c for c in fake["client"].calls if c[0] == "publish"][-1]
+        assert json.loads(stop[2])["online"] is False
+        assert stop[4] is False  # retain
+
+    def test_selftest_publisher_arms_no_last_will(self, fake: dict[str, FakeFleetPaho]) -> None:
+        p = _publisher(retain_messages=False)
+        p.connect()
+        assert fake["client"].will is None
+
+    def test_live_default_publisher_schema_still_retained(
+        self, fake: dict[str, FakeFleetPaho]
+    ) -> None:
+        """Re-pin (retain_messages defaults to True, unchanged for the live
+        service): a retained schema is load-bearing there -- a late
+        subscriber must be able to decode live batches without waiting."""
+        p = _publisher()
+        p.connect()
+        p.publish_schema({"v": 1, "channels": []})
+        call = [c for c in fake["client"].calls if c[0] == "publish"][-1]
+        assert call[1].endswith("/schema")
+        assert call[4] is True  # retain
+
+    def test_live_default_publisher_heartbeat_still_retained(
+        self, fake: dict[str, FakeFleetPaho]
+    ) -> None:
+        p = _publisher()
+        p.connect()
+        p.publish_heartbeat({"v": 1, "online": True})
+        call = [c for c in fake["client"].calls if c[0] == "publish"][-1]
+        assert call[1].endswith("/heartbeat")
+        assert call[4] is True  # retain
+
+    def test_live_default_publisher_close_beat_still_retained(
+        self, fake: dict[str, FakeFleetPaho]
+    ) -> None:
+        p = _publisher()
+        p.connect()
+        p.close()
+        stop = [c for c in fake["client"].calls if c[0] == "publish"][-1]
+        assert stop[4] is True  # retain
+
+    def test_live_default_publisher_still_arms_a_retained_last_will(
+        self, fake: dict[str, FakeFleetPaho]
+    ) -> None:
+        p = _publisher()
+        p.connect()
+        _topic, _payload, _qos, retain = fake["client"].will
+        assert retain is True
+
+
 class TestSetTls:
     """CRITICAL fix: a post-renewal reconnect must pick up the NEW cert/key paths.
 

--- a/test/sink/publish/test_mqtt_publisher.py
+++ b/test/sink/publish/test_mqtt_publisher.py
@@ -108,9 +108,16 @@ class FakeSubscribeOptions:
     """Minimal stand-in for paho's MQTT5 `SubscribeOptions` -- just enough to
     let `mqtt.py` construct one and this fake record what it asked for."""
 
-    def __init__(self, qos: int = 0, noLocal: bool = False, **_kw: object) -> None:  # noqa: N803
+    def __init__(
+        self,
+        qos: int = 0,
+        noLocal: bool = False,  # noqa: N803
+        retainHandling: int = 0,  # noqa: N803
+        **_kw: object,
+    ) -> None:
         self.qos = qos
         self.noLocal = noLocal
+        self.retainHandling = retainHandling
 
 
 @pytest.fixture()
@@ -467,49 +474,96 @@ class TestWaitForRetainedHeartbeat:
 
 
 class TestWatchLiveSession:
-    """Codex round 3 follow-up (PR #214, P1, comment 3927287968's own
-    follow-up): unlike `wait_for_retained_heartbeat` (a bounded, one-shot,
-    START-only probe), `watch_live_session()` keeps the heartbeat
-    subscription open so a beat arriving ANY time later -- not just the
-    state retained at subscribe time -- still sets `.detected`.
+    """Codex round 3 follow-up (PR #214, P1, comment 3927287968; widened by
+    comment 3928569268): unlike `wait_for_retained_heartbeat` (a bounded,
+    one-shot, START-only probe), `watch_live_session()` keeps BOTH the
+    heartbeat topic AND the schema topic subscribed so ANY message arriving
+    on either, ANY time later, sets `.detected` -- watching for the
+    pollution act itself (a schema/heartbeat publish reaching a real
+    subscriber), independent of whatever internal lock a resuming
+    `FleetService`'s heartbeat thread might be stuck behind.
+
+    Comment 3928569268: a resuming service's heartbeat thread can block
+    indefinitely in `spool.stats()` on the exclusive lock this selftest
+    run holds, so it may NEVER emit the `online: true` beat the OLD
+    (heartbeat-only, content-parsing) watch depended on -- while its
+    ROUTER (a separate, lock-free pending/reconnect path) reconnects and
+    publishes the live schema regardless. Watching the schema topic too,
+    content-agnostically (no more `online: true` parsing -- ANY delivery
+    counts), closes that gap: the schema publish itself IS the pollution,
+    so its mere arrival is sufficient, and simpler to reason about than
+    trying to parse yet another topic's payload shape.
     """
 
-    def test_subscribes_and_does_not_block(self, fake: dict[str, FakeFleetPaho]) -> None:
+    def test_subscribes_to_heartbeat_and_schema_topics_and_does_not_block(
+        self, fake: dict[str, FakeFleetPaho]
+    ) -> None:
         p = _publisher()
         p.connect()
 
         watch = p.watch_live_session()
 
-        assert fake["client"].subscribed_topics == ["bagel/v1/acme/r7/heartbeat"]
+        assert fake["client"].subscribed_topics == [
+            "bagel/v1/acme/r7/heartbeat",
+            "bagel/v1/acme/r7/schema",
+        ]
         assert not watch.detected.is_set()
 
-    def test_subscribes_with_no_local_so_this_clients_own_beats_are_not_echoed(
+    def test_subscribes_with_no_local_so_this_clients_own_publishes_are_not_echoed(
         self, fake: dict[str, FakeFleetPaho]
     ) -> None:
         """Critical: without MQTT5's `noLocal` subscribe option, a broker
-        delivers a client's OWN publishes back to itself when it's
-        subscribed to a matching topic -- so `run_selftest`'s own,
-        perfectly healthy heartbeat publish (before the events publish)
-        would loop back through this exact watch and be mistaken for a
-        DIFFERENT, live session appearing mid-run. Caught only by the live-
-        broker e2e suite (`FakeFleetPaho` doesn't simulate broker echo),
-        traced back to this missing option."""
+        delivers a client's OWN publishes back to itself on a topic it's
+        subscribed to -- so `run_selftest`'s own, perfectly healthy schema
+        and heartbeat publishes would loop back through this exact watch
+        and be mistaken for a DIFFERENT, live session appearing mid-run.
+        Caught only by the live-broker e2e suite (`FakeFleetPaho` doesn't
+        simulate broker echo), traced back to this missing option."""
         p = _publisher()
         p.connect()
 
         p.watch_live_session()
 
-        [options] = fake["client"].subscribe_options
-        assert options is not None
-        assert options.noLocal is True
+        options_by_topic = dict(
+            zip(fake["client"].subscribed_topics, fake["client"].subscribe_options, strict=True)
+        )
+        assert options_by_topic["bagel/v1/acme/r7/heartbeat"].noLocal is True
+        assert options_by_topic["bagel/v1/acme/r7/schema"].noLocal is True
 
-    def test_a_later_online_true_message_sets_detected(
+    def test_subscribes_with_retain_handling_do_not_send(
         self, fake: dict[str, FakeFleetPaho]
     ) -> None:
-        """The core fix: a message arriving well AFTER `watch_live_session()`
-        returns -- simulating a live service that resumes mid-selftest-run
-        -- must still be caught, not just the state present at subscribe
-        time."""
+        """Codex round 3 follow-up, comment 3928569268: a retained schema
+        ALWAYS exists on a robot's schema topic once anything has ever run
+        there (the live service's own pre-pause schema, if nothing else)
+        -- MQTT5's default `retainHandling` (`RETAIN_SEND_ON_SUBSCRIBE`, 0)
+        would replay it the instant this subscribes, and a content-
+        agnostic "ANY delivery = abort" watch would then false-abort every
+        single run, instantly, even with no other session anywhere near
+        the robot. `retainHandling=2` (`RETAIN_DO_NOT_SEND`) suppresses
+        that replay entirely: only a message actually PUBLISHED after this
+        subscribes can ever arrive, which is exactly what "a NEW publish
+        from another session" means."""
+        p = _publisher()
+        p.connect()
+
+        p.watch_live_session()
+
+        options_by_topic = dict(
+            zip(fake["client"].subscribed_topics, fake["client"].subscribe_options, strict=True)
+        )
+        assert options_by_topic["bagel/v1/acme/r7/heartbeat"].retainHandling == 2
+        assert options_by_topic["bagel/v1/acme/r7/schema"].retainHandling == 2
+
+    def test_a_later_heartbeat_message_sets_detected_regardless_of_content(
+        self, fake: dict[str, FakeFleetPaho]
+    ) -> None:
+        """A message arriving well AFTER `watch_live_session()` returns --
+        simulating a live service that resumes mid-selftest-run -- must
+        still be caught. No content parsing any more (comment 3928569268):
+        the mere fact that ANOTHER session (noLocal already ruled out
+        ourselves) is publishing on this robot's own heartbeat topic at
+        all is the signal, regardless of what it says."""
         p = _publisher()
         p.connect()
         client = fake["client"]
@@ -517,32 +571,6 @@ class TestWatchLiveSession:
         watch = p.watch_live_session()
         assert not watch.detected.is_set()
 
-        # A later message, delivered well after subscribe() returned --
-        # mirroring a live FleetService publishing its own heartbeat while
-        # this watch is still open. Per MQTT-3.3.1-9, a message delivered
-        # to an ALREADY-established subscription carries retain=False
-        # regardless of how the publisher published it -- so this must not
-        # depend on the retain flag the way the START-only probe does.
-        client.on_message(
-            client,
-            None,
-            FakeMqttMessage(
-                topic="bagel/v1/acme/r7/heartbeat",
-                payload=json.dumps({"v": 1, "online": True}).encode(),
-                retain=False,
-            ),
-        )
-
-        assert watch.detected.is_set()
-
-    def test_an_online_false_message_does_not_set_detected(
-        self, fake: dict[str, FakeFleetPaho]
-    ) -> None:
-        p = _publisher()
-        p.connect()
-        client = fake["client"]
-
-        watch = p.watch_live_session()
         client.on_message(
             client,
             None,
@@ -553,14 +581,38 @@ class TestWatchLiveSession:
             ),
         )
 
+        assert watch.detected.is_set()
+
+    def test_a_later_schema_message_sets_detected(self, fake: dict[str, FakeFleetPaho]) -> None:
+        """The round-11 fix itself (comment 3928569268): a resuming
+        service's heartbeat thread can be stuck behind the selftest's own
+        `spool.exclusive()` lock (blocked in `spool.stats()`) and never
+        emit the beat the old, heartbeat-only watch depended on -- while
+        its lock-free ROUTER reconnects and republishes the live schema
+        regardless. This is the schema-topic message that OLD watch could
+        never see; the new one must abort on it."""
+        p = _publisher()
+        p.connect()
+        client = fake["client"]
+
+        watch = p.watch_live_session()
         assert not watch.detected.is_set()
 
-    def test_an_unparsable_message_fails_closed_by_setting_detected(
-        self, fake: dict[str, FakeFleetPaho]
-    ) -> None:
-        """Same fail-closed rule as `wait_for_retained_heartbeat`: an
-        unparsable beat means "can't tell", which is treated as unsafe, not
-        safe."""
+        client.on_message(
+            client,
+            None,
+            FakeMqttMessage(
+                topic="bagel/v1/acme/r7/schema",
+                payload=json.dumps({"v": 1, "channels": []}).encode(),
+                retain=False,
+            ),
+        )
+
+        assert watch.detected.is_set()
+
+    def test_a_garbage_payload_still_sets_detected(self, fake: dict[str, FakeFleetPaho]) -> None:
+        """No parsing happens at all any more -- mere arrival is the
+        signal, so even a payload that wouldn't parse still counts."""
         p = _publisher()
         p.connect()
         client = fake["client"]
@@ -570,7 +622,7 @@ class TestWatchLiveSession:
             client,
             None,
             FakeMqttMessage(
-                topic="bagel/v1/acme/r7/heartbeat",
+                topic="bagel/v1/acme/r7/schema",
                 payload=b"\xff\xfe garbage",
                 retain=False,
             ),
@@ -578,7 +630,7 @@ class TestWatchLiveSession:
 
         assert watch.detected.is_set()
 
-    def test_stop_unsubscribes_and_restores_prior_handler(
+    def test_stop_unsubscribes_both_topics_and_restores_prior_handler(
         self, fake: dict[str, FakeFleetPaho]
     ) -> None:
         p = _publisher()
@@ -594,7 +646,10 @@ class TestWatchLiveSession:
 
         watch.stop()
 
-        assert client.unsubscribed_topics == ["bagel/v1/acme/r7/heartbeat"]
+        assert client.unsubscribed_topics == [
+            "bagel/v1/acme/r7/heartbeat",
+            "bagel/v1/acme/r7/schema",
+        ]
         assert client.on_message is _prior_handler
 
     def test_stop_is_idempotent(self, fake: dict[str, FakeFleetPaho]) -> None:
@@ -606,7 +661,10 @@ class TestWatchLiveSession:
         watch.stop()
         watch.stop()  # must not raise, must not double-unsubscribe
 
-        assert client.unsubscribed_topics == ["bagel/v1/acme/r7/heartbeat"]
+        assert client.unsubscribed_topics == [
+            "bagel/v1/acme/r7/heartbeat",
+            "bagel/v1/acme/r7/schema",
+        ]
 
     def test_raises_when_not_connected(self, fake: dict[str, FakeFleetPaho]) -> None:
         p = _publisher()

--- a/test/sink/publish/test_mqtt_publisher.py
+++ b/test/sink/publish/test_mqtt_publisher.py
@@ -29,6 +29,15 @@ class FakeMsgInfo:
         return self._published
 
 
+class FakeMqttMessage:
+    """Minimal stand-in for paho's `MQTTMessage`: `topic`/`payload`/`retain`."""
+
+    def __init__(self, topic: str, payload: bytes, retain: bool) -> None:
+        self.topic = topic
+        self.payload = payload
+        self.retain = retain
+
+
 class FakeFleetPaho:
     MQTT_ERR_SUCCESS = 0
 
@@ -40,6 +49,17 @@ class FakeFleetPaho:
         self.userpass: tuple[str, str | None] | None = None
         self._connected = False
         self.next_info = FakeMsgInfo()
+        # Codex round 3 follow-up (PR #214, P1, comment 3927287968):
+        # subscribe/unsubscribe/on_message support for
+        # `wait_for_retained_heartbeat`'s own unit tests. `queued_message`,
+        # if set, is delivered synchronously (via `on_message`) the instant
+        # `subscribe()` is called -- mirroring a real broker replaying a
+        # retained message immediately upon subscribing, before any live
+        # traffic.
+        self.on_message: object = None
+        self.subscribed_topics: list[str] = []
+        self.unsubscribed_topics: list[str] = []
+        self.queued_message: FakeMqttMessage | None = None
 
     def will_set(self, topic: str, payload: str, qos: int = 0, retain: bool = False) -> None:
         self.will = (topic, payload, qos, retain)
@@ -70,6 +90,16 @@ class FakeFleetPaho:
     def publish(self, topic: str, payload: str, qos: int = 0, retain: bool = False) -> FakeMsgInfo:
         self.calls.append(("publish", topic, payload, qos, retain))
         return self.next_info
+
+    def subscribe(self, topic: str, qos: int = 0) -> None:
+        self.calls.append(("subscribe", topic, qos))
+        self.subscribed_topics.append(topic)
+        if self.queued_message is not None and self.on_message is not None:
+            self.on_message(self, None, self.queued_message)
+
+    def unsubscribe(self, topic: str) -> None:
+        self.calls.append(("unsubscribe", topic))
+        self.unsubscribed_topics.append(topic)
 
 
 @pytest.fixture()
@@ -171,13 +201,38 @@ class TestConnect:
 
     def test_client_id_suffix_is_appended(self, fake: dict[str, FakeFleetPaho]) -> None:
         """Codex round 3 follow-up (PR #214, P2, comment 3925391258): the
-        selftest CLI passes `client_id_suffix="-selftest"` so its
+        selftest CLI passes `client_id_suffix="/selftest"` so its
         MqttPublisher never derives the SAME client id as the live
         service's own (same tenant/robot) -- a broker kicks the existing
         session when a new connection claims an already-connected client
         id, so without this the selftest would displace live streaming."""
-        _publisher(client_id_suffix="-selftest").connect()
-        assert fake["client"].kwargs["client_id"] == "bagel/acme/r7-selftest"
+        _publisher(client_id_suffix="/selftest").connect()
+        assert fake["client"].kwargs["client_id"] == "bagel/acme/r7/selftest"
+
+    def test_client_id_suffix_uses_a_provably_collision_free_delimiter(
+        self, fake: dict[str, FakeFleetPaho]
+    ) -> None:
+        """Codex round 3 follow-up (PR #214, P2, comment 3927231074): a
+        hyphen suffix ("-selftest") reintroduces exactly the
+        hyphen-injectivity ambiguity the "/" delimiter between
+        tenant/robot was already fixed for -- robot "r7" with a "-selftest"
+        suffix and a robot actually NAMED "r7-selftest" would collide on
+        the same client id. "/" is outside both id charsets (robot ids
+        match ^[a-z0-9][a-z0-9_-]{0,62}$), so "/selftest" is provably
+        collision-free the same way the tenant/robot delimiter is."""
+        _publisher(tenant="acme", robot="r7").connect()
+        id_a = fake["client"].kwargs["client_id"]
+
+        _publisher(tenant="acme", robot="r7", client_id_suffix="/selftest").connect()
+        id_b = fake["client"].kwargs["client_id"]
+
+        _publisher(tenant="acme", robot="r7-selftest").connect()
+        id_c = fake["client"].kwargs["client_id"]
+
+        assert id_a == "bagel/acme/r7"
+        assert id_b == "bagel/acme/r7/selftest"
+        assert id_c == "bagel/acme/r7-selftest"
+        assert len({id_a, id_b, id_c}) == 3  # no collision
 
     def test_client_id_suffix_is_deterministic_across_reconnects(
         self, fake: dict[str, FakeFleetPaho]
@@ -185,12 +240,12 @@ class TestConnect:
         """Same determinism guarantee as the unsuffixed id: a suffixed
         client id must still be identical on every reconnect, not merely
         different from the live service's."""
-        p = _publisher(client_id_suffix="-selftest")
+        p = _publisher(client_id_suffix="/selftest")
         p.connect()
         first_id = fake["client"].kwargs["client_id"]
         p.connect()
         second_id = fake["client"].kwargs["client_id"]
-        assert first_id == second_id == "bagel/acme/r7-selftest"
+        assert first_id == second_id == "bagel/acme/r7/selftest"
 
     def test_connect_raises_when_fleet_disabled_before_touching_paho(
         self, fake: dict[str, FakeFleetPaho], monkeypatch: pytest.MonkeyPatch
@@ -291,6 +346,108 @@ class TestClose:
         p.close(reason=reason)
         stop = [c for c in fake["client"].calls if c[0] == "publish"][-1]
         assert json.loads(stop[2])["reason"] == reason
+
+
+class TestWaitForRetainedHeartbeat:
+    """Codex round 3 follow-up (PR #214, P1, comment 3927287968): the
+    selftest-only probe `run_selftest` uses (via `_check_no_live_session`)
+    to detect a live session before publishing anything.
+    """
+
+    def test_retained_message_is_returned(self, fake: dict[str, FakeFleetPaho]) -> None:
+        p = _publisher()
+        p.connect()
+        client = fake["client"]
+        client.queued_message = FakeMqttMessage(
+            topic="bagel/v1/acme/r7/heartbeat",
+            payload=json.dumps({"v": 1, "online": True}).encode(),
+            retain=True,
+        )
+
+        result = p.wait_for_retained_heartbeat(timeout_s=0.05)
+
+        assert result == {"v": 1, "online": True}
+        assert client.subscribed_topics == ["bagel/v1/acme/r7/heartbeat"]
+        assert client.unsubscribed_topics == ["bagel/v1/acme/r7/heartbeat"]
+
+    def test_non_retained_message_is_ignored(self, fake: dict[str, FakeFleetPaho]) -> None:
+        """A message arriving during the probe window without its `retain`
+        flag set (live traffic, not a replayed retained message) must not
+        satisfy the wait."""
+        p = _publisher()
+        p.connect()
+        fake["client"].queued_message = FakeMqttMessage(
+            topic="bagel/v1/acme/r7/heartbeat",
+            payload=json.dumps({"v": 1, "online": True}).encode(),
+            retain=False,
+        )
+
+        result = p.wait_for_retained_heartbeat(timeout_s=0.05)
+
+        assert result is None
+
+    def test_no_message_returns_none_within_timeout(
+        self, fake: dict[str, FakeFleetPaho]
+    ) -> None:
+        """A fresh robot/broker with nothing retained: times out, returns
+        `None` (not an error -- `None` means "proceed" to the caller)."""
+        p = _publisher()
+        p.connect()
+
+        result = p.wait_for_retained_heartbeat(timeout_s=0.05)
+
+        assert result is None
+
+    def test_unsubscribes_and_restores_prior_handler_even_on_timeout(
+        self, fake: dict[str, FakeFleetPaho]
+    ) -> None:
+        p = _publisher()
+        p.connect()
+        client = fake["client"]
+
+        def _prior_handler(*_args: object) -> None:
+            pass
+
+        client.on_message = _prior_handler
+
+        p.wait_for_retained_heartbeat(timeout_s=0.05)
+
+        assert client.unsubscribed_topics == ["bagel/v1/acme/r7/heartbeat"]
+        assert client.on_message is _prior_handler
+
+    def test_raises_when_not_connected(self, fake: dict[str, FakeFleetPaho]) -> None:
+        p = _publisher()
+        with pytest.raises(PublishError):
+            p.wait_for_retained_heartbeat()
+
+
+class TestDisconnectWithoutPublishing:
+    """Codex round 3 follow-up (PR #214, P1, comment 3927287968): the
+    silent-teardown helper `_check_no_live_session` uses on refusal --
+    releases this session's deterministic client id promptly, WITHOUT
+    publishing a clean-stop beat that could itself mislead a live watcher.
+    """
+
+    def test_tears_down_without_publishing_anything(
+        self, fake: dict[str, FakeFleetPaho]
+    ) -> None:
+        p = _publisher()
+        p.connect()
+        client = fake["client"]
+
+        p.disconnect_without_publishing()
+
+        assert ("loop_stop",) in client.calls
+        assert ("disconnect",) in client.calls
+        assert not any(c[0] == "publish" for c in client.calls)
+        assert p.connected is False
+
+    def test_idempotent_and_safe_when_never_connected(
+        self, fake: dict[str, FakeFleetPaho]
+    ) -> None:
+        p = _publisher()
+        p.disconnect_without_publishing()  # must not raise
+        p.disconnect_without_publishing()  # a second call must not raise either
 
 
 class TestRetainMessages:

--- a/test/sink/publish/test_mqtt_publisher.py
+++ b/test/sink/publish/test_mqtt_publisher.py
@@ -161,6 +161,37 @@ class TestConnect:
         assert id_a == "bagel/acme-west/r7"
         assert id_b == "bagel/acme/west-r7"
 
+    def test_client_id_suffix_defaults_to_empty_unchanged_live_id(
+        self, fake: dict[str, FakeFleetPaho]
+    ) -> None:
+        """The live service's own publisher never passes `client_id_suffix`
+        -- its id must stay exactly what it always was."""
+        _publisher().connect()
+        assert fake["client"].kwargs["client_id"] == "bagel/acme/r7"
+
+    def test_client_id_suffix_is_appended(self, fake: dict[str, FakeFleetPaho]) -> None:
+        """Codex round 3 follow-up (PR #214, P2, comment 3925391258): the
+        selftest CLI passes `client_id_suffix="-selftest"` so its
+        MqttPublisher never derives the SAME client id as the live
+        service's own (same tenant/robot) -- a broker kicks the existing
+        session when a new connection claims an already-connected client
+        id, so without this the selftest would displace live streaming."""
+        _publisher(client_id_suffix="-selftest").connect()
+        assert fake["client"].kwargs["client_id"] == "bagel/acme/r7-selftest"
+
+    def test_client_id_suffix_is_deterministic_across_reconnects(
+        self, fake: dict[str, FakeFleetPaho]
+    ) -> None:
+        """Same determinism guarantee as the unsuffixed id: a suffixed
+        client id must still be identical on every reconnect, not merely
+        different from the live service's."""
+        p = _publisher(client_id_suffix="-selftest")
+        p.connect()
+        first_id = fake["client"].kwargs["client_id"]
+        p.connect()
+        second_id = fake["client"].kwargs["client_id"]
+        assert first_id == second_id == "bagel/acme/r7-selftest"
+
     def test_connect_raises_when_fleet_disabled_before_touching_paho(
         self, fake: dict[str, FakeFleetPaho], monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/test/sink/publish/test_router.py
+++ b/test/sink/publish/test_router.py
@@ -13,6 +13,7 @@ import pytest
 
 from src.message.base import AccessPath
 from src.sink.publish import router as router_mod
+from src.sink.publish import spool as spool_mod
 from src.sink.publish.config import ResolvedChannel
 from src.sink.publish.publisher import Publisher, PublishError
 from src.sink.publish.router import RouterCore, SampleQueue, StreamRouter, extract_value
@@ -412,6 +413,95 @@ class TestStreamRouterTick:
         assert pub.channel_calls == []
         assert not router.online
         assert [seq for seq, _ in spool.pending("channels")] == [1]
+
+
+class TestTickUsesAppendNext:
+    """Codex round 3 follow-up (PR #214, P1, comment 3924082774): the
+    batch-flush path must go through `Spool.append_next()`, never a
+    separate `next_seq()` + `append()` pair -- see `StreamRouter.run`'s and
+    `Spool.append_next`'s docstrings for why that shape used to be able to
+    kill the router thread outright.
+    """
+
+    def test_flushed_batch_uses_append_next_with_correctly_embedded_seq(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        router, q, spool, pub = _router(tmp_path)
+        calls: list[str] = []
+        original_next_seq = spool_mod.Spool.next_seq
+        original_append = spool_mod.Spool.append
+        original_append_next = spool_mod.Spool.append_next
+
+        def spy_next_seq(self: Spool, lane: str) -> int:
+            calls.append("next_seq")
+            return original_next_seq(self, lane)
+
+        def spy_append(self: Spool, lane: str, seq: int, payload: dict) -> None:
+            calls.append("append")
+            return original_append(self, lane, seq, payload)
+
+        def spy_append_next(self: Spool, lane: str, build: object) -> int:
+            calls.append("append_next")
+            return original_append_next(self, lane, build)
+
+        monkeypatch.setattr(spool_mod.Spool, "next_seq", spy_next_seq)
+        monkeypatch.setattr(spool_mod.Spool, "append", spy_append)
+        monkeypatch.setattr(spool_mod.Spool, "append_next", spy_append_next)
+
+        q.put(("/imu", 1.0, {"x": 1.0}))
+        router._tick(now=10.0)
+
+        # The batch-flush path uses append_next exclusively -- never the old
+        # two-call next_seq()+append() pair.
+        assert calls == ["append_next"]
+        # The embedded seq in the published payload is the atomically
+        # allocated one.
+        assert pub.channel_calls[0]["seq"] == 1
+        # And it's what's actually durable on disk too: acked_seq reflects
+        # append_next's write having advanced the watermark to 1.
+        assert spool.stats()["channels"].acked_seq == 1
+
+    def test_concurrent_exclusive_held_writer_no_longer_raises_during_tick(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        """Regression test: reproduces the exact scenario that used to kill
+        the router thread. Investigation (Codex round 3 P1, comment
+        3924082774) confirmed `_tick`'s old batch-flush loop
+        (`next_seq()` then `append()`) was completely UNGUARDED -- only
+        `PublishError` is caught, inside `_pump`, several lines below.  A
+        `ValueError` from a stale-floor `append()` call propagated straight
+        out of `_tick()` into `run()`'s broad `except Exception`, which
+        treated it as a fatal `Spool`/`RouterCore` bug: logged it, set
+        `_fatal_error`, and RETURNED -- ending the thread's loop for good.
+        `alive` would go false and stay false; streaming would stay dead
+        until the `FleetService` (and its `StreamRouter`) was rebuilt via a
+        restart or a `stream_topics`/`stop_streams` call.
+
+        With `append_next()`, the exact interleaving that used to trigger
+        this -- a competing writer's `exclusive()`-held run landing between
+        allocation and write -- can no longer land in a gap that no longer
+        exists. This proves `_tick()` no longer raises at all when that
+        happens, so `run()`'s fatal catch-all is never reached.
+        """
+        router, q, spool, pub = _router(tmp_path)
+        competitor = Spool(tmp_path / "spool")  # a SEPARATE instance, same root
+
+        q.put(("/imu", 1.0, {"x": 1.0}))
+
+        # A competing writer -- e.g. a selftest run -- writes to the SAME
+        # lane via an exclusive()-held append_next, exactly mirroring
+        # `run_selftest`'s own pattern, before the router's own flush runs.
+        with competitor.exclusive(timeout=1.0):
+            competitor.append_next("channels", lambda seq: {"seq": seq, "who": "competitor"})
+
+        router._tick(now=10.0)  # must not raise
+
+        # _pump publishes everything pending in seq order: the competitor's
+        # seq=1 (still unacked -- it's a legitimate write on the same real
+        # spool) first, then the router's own batch, correctly allocated
+        # seq=2 (not a stale/colliding value) and not raising along the way.
+        assert [c["seq"] for c in pub.channel_calls] == [1, 2]
+        assert list(spool.pending("channels")) == []
 
 
 class TestStreamRouterThread:

--- a/test/sink/publish/test_selftest.py
+++ b/test/sink/publish/test_selftest.py
@@ -806,3 +806,199 @@ def test_selftest_e2e_refuses_while_a_live_session_is_connected(
     finally:
         fake_live.loop_stop()
         fake_live.disconnect()
+
+
+# -- round-11 (Codex review, comment 3928569268): the mid-run watch must
+# trigger on any live session activity, not just an `online: true` beat, and
+# must not depend on the heartbeat topic alone (a resuming service's
+# heartbeat thread can be stuck behind this selftest's own spool lock while
+# its router still reconnects and republishes the schema regardless). ------
+
+
+@pytest.mark.skipif(not BROKER, reason="MQTT_TEST_BROKER not set")
+def test_selftest_e2e_pre_existing_retained_schema_does_not_false_abort(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path, capsys: pytest.CaptureFixture
+) -> None:
+    """Codex round 3 follow-up (PR #214, P1, comment 3928569268), proof (a):
+    a retained schema ALWAYS exists on a robot's schema topic once
+    anything has ever run there for real (the live service's own pre-pause
+    schema, if nothing else). `watch_live_session()`'s `retainHandling=2`
+    subscribe option must suppress that replay -- otherwise a content-
+    agnostic "ANY delivery = abort" watch would false-abort every single
+    run, instantly, even with no other session anywhere near the robot."""
+    import paho.mqtt.client as paho
+
+    import src.sink.publish.selftest as selftest_mod
+
+    monkeypatch.setattr(settings, "FLEET_ENABLED", True)
+    monkeypatch.setattr(settings, "FLEET_DEV_INSECURE", True)
+    monkeypatch.setattr(settings, "FLEET_IDENTITY_DIRECTORY", str(tmp_path / "identity"))
+    monkeypatch.setattr(settings, "CACHE_DIRECTORY", str(tmp_path))
+
+    schema_topic = "bagel/v1/dev/robot/schema"
+    parsed = urlparse(BROKER)
+    injector = paho.Client(
+        callback_api_version=paho.CallbackAPIVersion.VERSION2,
+        client_id=f"pre-existing-schema-{uuid.uuid4().hex[:8]}",
+        protocol=paho.MQTTv5,
+    )
+    injector.connect(parsed.hostname, parsed.port or 1883)
+    injector.loop_start()
+
+    try:
+        # Simulate a real robot's own pre-pause retained schema, already
+        # sitting on the broker before this selftest run ever subscribes.
+        info = injector.publish(
+            schema_topic, json.dumps({"v": 1, "channels": [{"c": "imu.x"}]}), qos=1, retain=True
+        )
+        info.wait_for_publish(timeout=5.0)
+        time.sleep(0.3)  # give the broker a moment to actually retain it
+
+        rc = selftest_mod.main(["--broker", BROKER, "--batches", "2", "--interval-s", "0.1"])
+        err = capsys.readouterr().err
+        assert rc == 0, err
+    finally:
+        # Clear the retained schema -- don't leave residue for later tests.
+        info = injector.publish(schema_topic, "", qos=1, retain=True)
+        info.wait_for_publish(timeout=5.0)
+        time.sleep(0.2)
+        injector.loop_stop()
+        injector.disconnect()
+
+
+@pytest.mark.skipif(not BROKER, reason="MQTT_TEST_BROKER not set")
+def test_selftest_e2e_new_schema_publish_mid_run_aborts(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path, capsys: pytest.CaptureFixture
+) -> None:
+    """Codex round 3 follow-up (PR #214, P1, comment 3928569268), proof (b)
+    -- the core fix itself, end to end: a resuming service's heartbeat
+    thread can be stuck behind this selftest run's own spool lock and
+    never emit a beat, while its router still reconnects and republishes
+    the schema regardless. A NEW (non-retained) schema publish from a
+    DIFFERENT client, injected partway through a real multi-batch run,
+    must abort it before the run completes -- proving the watch doesn't
+    depend on the heartbeat topic, or on any lock, at all."""
+    import paho.mqtt.client as paho
+
+    import src.sink.publish.selftest as selftest_mod
+
+    monkeypatch.setattr(settings, "FLEET_ENABLED", True)
+    monkeypatch.setattr(settings, "FLEET_DEV_INSECURE", True)
+    monkeypatch.setattr(settings, "FLEET_IDENTITY_DIRECTORY", str(tmp_path / "identity"))
+    monkeypatch.setattr(settings, "CACHE_DIRECTORY", str(tmp_path))
+
+    schema_topic = "bagel/v1/dev/robot/schema"
+    parsed = urlparse(BROKER)
+    injector = paho.Client(
+        callback_api_version=paho.CallbackAPIVersion.VERSION2,
+        client_id=f"mid-run-schema-{uuid.uuid4().hex[:8]}",
+        protocol=paho.MQTTv5,
+    )
+    injector.connect(parsed.hostname, parsed.port or 1883)
+    injector.loop_start()
+
+    # The START-of-run probe (`_check_no_live_session`) has NO retained
+    # heartbeat to find here, so it blocks for the full
+    # `DEFAULT_LIVE_SESSION_PROBE_TIMEOUT_S` before the ongoing watch even
+    # opens -- the injection must land safely AFTER that fixed delay, not
+    # merely "partway through main()", or it fires before anything is
+    # subscribed and is simply never seen.
+    probe_wait_s = selftest_mod.DEFAULT_LIVE_SESSION_PROBE_TIMEOUT_S
+
+    def _inject_mid_run() -> None:
+        time.sleep(probe_wait_s + 0.2)  # land after the watch opens, mid-batch-phase
+        info = injector.publish(
+            schema_topic, json.dumps({"v": 1, "channels": [{"c": "imu.x"}]}), qos=1, retain=False
+        )
+        info.wait_for_publish(timeout=5.0)
+
+    injector_thread = threading.Thread(target=_inject_mid_run)
+    injector_thread.start()
+    try:
+        rc = selftest_mod.main(["--broker", BROKER, "--batches", "10", "--interval-s", "0.2"])
+        err = capsys.readouterr().err
+        assert rc == 1
+        assert "live fleet session" in err
+    finally:
+        injector_thread.join()
+        injector.loop_stop()
+        injector.disconnect()
+
+
+@pytest.mark.skipif(not BROKER, reason="MQTT_TEST_BROKER not set")
+def test_selftest_e2e_online_true_beat_mid_run_aborts(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path, capsys: pytest.CaptureFixture
+) -> None:
+    """Codex round 3 follow-up (PR #214, P1, comment 3928569268), proof (c):
+    the pre-existing heartbeat-topic trigger, proven again specifically
+    MID-run -- `test_selftest_e2e_refuses_while_a_live_session_is_connected`
+    only proves the START-of-run case. A resumed service's own live
+    `online: true` heartbeat, injected partway through a real multi-batch
+    run, must still abort it."""
+    import paho.mqtt.client as paho
+
+    import src.sink.publish.selftest as selftest_mod
+
+    monkeypatch.setattr(settings, "FLEET_ENABLED", True)
+    monkeypatch.setattr(settings, "FLEET_DEV_INSECURE", True)
+    monkeypatch.setattr(settings, "FLEET_IDENTITY_DIRECTORY", str(tmp_path / "identity"))
+    monkeypatch.setattr(settings, "CACHE_DIRECTORY", str(tmp_path))
+
+    heartbeat_topic = "bagel/v1/dev/robot/heartbeat"
+    parsed = urlparse(BROKER)
+    injector = paho.Client(
+        callback_api_version=paho.CallbackAPIVersion.VERSION2,
+        client_id=f"mid-run-heartbeat-{uuid.uuid4().hex[:8]}",
+        protocol=paho.MQTTv5,
+    )
+    injector.connect(parsed.hostname, parsed.port or 1883)
+    injector.loop_start()
+
+    # Same timing note as the schema-topic sibling test above: the
+    # START-of-run probe blocks for the full
+    # `DEFAULT_LIVE_SESSION_PROBE_TIMEOUT_S` before the ongoing watch opens.
+    probe_wait_s = selftest_mod.DEFAULT_LIVE_SESSION_PROBE_TIMEOUT_S
+
+    def _inject_mid_run() -> None:
+        time.sleep(probe_wait_s + 0.2)
+        info = injector.publish(
+            heartbeat_topic, json.dumps({"v": 1, "online": True}), qos=1, retain=True
+        )
+        info.wait_for_publish(timeout=5.0)
+
+    injector_thread = threading.Thread(target=_inject_mid_run)
+    injector_thread.start()
+    try:
+        rc = selftest_mod.main(["--broker", BROKER, "--batches", "10", "--interval-s", "0.2"])
+        err = capsys.readouterr().err
+        assert rc == 1
+        assert "live fleet session" in err
+    finally:
+        injector_thread.join()
+        # Clear the retained heartbeat -- don't leave residue for later tests.
+        info = injector.publish(heartbeat_topic, "", qos=1, retain=True)
+        info.wait_for_publish(timeout=5.0)
+        time.sleep(0.2)
+        injector.loop_stop()
+        injector.disconnect()
+
+
+@pytest.mark.skipif(not BROKER, reason="MQTT_TEST_BROKER not set")
+def test_selftest_e2e_clean_run_is_stable_across_repeats(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path, capsys: pytest.CaptureFixture
+) -> None:
+    """Codex round 3 follow-up (PR #214, P1, comment 3928569268), proof
+    (d): the new two-topic, `noLocal` + `retainHandling=2` watch must not
+    itself introduce flakiness into the ordinary clean-run case -- run it
+    three times back to back and require every run to succeed."""
+    import src.sink.publish.selftest as selftest_mod
+
+    monkeypatch.setattr(settings, "FLEET_ENABLED", True)
+    monkeypatch.setattr(settings, "FLEET_DEV_INSECURE", True)
+    monkeypatch.setattr(settings, "FLEET_IDENTITY_DIRECTORY", str(tmp_path / "identity"))
+    monkeypatch.setattr(settings, "CACHE_DIRECTORY", str(tmp_path))
+
+    for attempt in range(3):
+        rc = selftest_mod.main(["--broker", BROKER, "--batches", "2", "--interval-s", "0"])
+        err = capsys.readouterr().err
+        assert rc == 0, f"attempt {attempt}: {err}"

--- a/test/sink/publish/test_selftest.py
+++ b/test/sink/publish/test_selftest.py
@@ -6,6 +6,7 @@ import os
 import pathlib
 import queue
 import sys
+import threading
 import time
 import uuid
 from urllib.parse import urlparse
@@ -199,6 +200,70 @@ class TestRunSelftest:
         result = run_selftest(pub, spool, batches=1, interval_s=0.0)
 
         assert result["batches"] == 1
+
+
+class TestExclusiveLockDuringRun:
+    """P1b (Codex round 3): the whole run holds `spool.exclusive()`, so a
+    concurrent writer on the same spool root either waits for it or the run
+    refuses cleanly up front -- never an interleaved seq race mid-run."""
+
+    def test_refuses_before_any_side_effect_when_another_writer_holds_the_lock(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        from src.sink.publish.selftest import SelftestPreconditionError, run_selftest
+
+        root = tmp_path / "spool"
+        holder_spool = Spool(root)
+        run_spool = Spool(root)
+        holding = threading.Event()
+        release = threading.Event()
+
+        def hold_the_lock() -> None:
+            with holder_spool.exclusive(timeout=1.0):
+                holding.set()
+                release.wait(timeout=2.0)
+
+        t = threading.Thread(target=hold_the_lock)
+        t.start()
+        holding.wait(timeout=2.0)
+
+        pub = FakePublisher()
+        try:
+            with pytest.raises(SelftestPreconditionError, match="another writer holds the spool"):
+                run_selftest(pub, run_spool, batches=1, interval_s=0.0, lock_timeout_s=0.1)
+        finally:
+            release.set()
+            t.join()
+
+        # Refused before connecting or touching the spool at all.
+        assert pub.calls == []
+        assert list(run_spool.pending("channels")) == []
+
+    def test_waits_out_a_briefly_held_lock_then_runs_normally(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        from src.sink.publish.selftest import run_selftest
+
+        root = tmp_path / "spool"
+        holder_spool = Spool(root)
+        run_spool = Spool(root)
+        holding = threading.Event()
+
+        def hold_briefly() -> None:
+            with holder_spool.exclusive(timeout=1.0):
+                holding.set()
+                time.sleep(0.15)
+
+        t = threading.Thread(target=hold_briefly)
+        t.start()
+        holding.wait(timeout=2.0)
+
+        pub = FakePublisher()
+        result = run_selftest(pub, run_spool, batches=1, interval_s=0.0, lock_timeout_s=2.0)
+        t.join()
+
+        assert result["batches"] == 1
+        assert list(run_spool.pending("channels")) == []
 
 
 class TestMain:

--- a/test/sink/publish/test_selftest.py
+++ b/test/sink/publish/test_selftest.py
@@ -420,6 +420,50 @@ class TestMain:
         assert rc == 0
         assert captured["kwargs"]["client_id_suffix"] == "-selftest"
 
+    def test_publisher_gets_retain_messages_false(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Codex round 3 follow-up (PR #214, P1, comment 3927023413): the
+        selftest keeps publishing AS the robot on the SAME shared topics,
+        so its retained publishes would otherwise linger with nothing to
+        overwrite them once the run ends -- its fixture schema staying
+        retained (a late subscriber decodes live batches against the WRONG
+        schema until the live service's next reconnect) and its close()
+        beat leaving a retained online:false (the robot looks dead until
+        the next live beat)."""
+        import src.sink.publish.selftest as selftest_mod
+
+        monkeypatch.setattr(settings, "FLEET_ENABLED", True)
+        monkeypatch.setattr(settings, "FLEET_DEV_INSECURE", True)
+        monkeypatch.setattr(settings, "FLEET_IDENTITY_DIRECTORY", str(tmp_path / "identity"))
+        monkeypatch.setattr(settings, "CACHE_DIRECTORY", str(tmp_path))
+
+        captured: dict = {}
+
+        def fake_mqtt_publisher(*args: object, **kwargs: object) -> object:
+            captured["kwargs"] = kwargs
+            return object()
+
+        monkeypatch.setattr(selftest_mod, "MqttPublisher", fake_mqtt_publisher)
+        monkeypatch.setattr(
+            selftest_mod,
+            "run_selftest",
+            lambda publisher, spool, **kwargs: {
+                "channels": 4,
+                "batches": 1,
+                "samples": 4,
+                "heartbeat": 1,
+                "events": 1,
+            },
+        )
+
+        rc = selftest_mod.main(
+            ["--broker", "mqtt://localhost:1883", "--batches", "1", "--interval-s", "0"]
+        )
+
+        assert rc == 0
+        assert captured["kwargs"]["retain_messages"] is False
+
     def test_load_identity_or_none_is_a_single_load_not_check_then_load(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -502,6 +546,65 @@ def test_selftest_e2e_round_trip(monkeypatch: pytest.MonkeyPatch, tmp_path: path
             "online": False,
             "reason": "stopped",
         }
+
+        # Codex round 3 follow-up (PR #214, P1, comment 3927023413): every
+        # schema/heartbeat publish this run made -- including the final
+        # close() beat, captured above -- must be non-retained.
+        assert all(retain is False for _, retain in got[schema_topic])
+        assert all(retain is False for _, retain in got[heartbeat_topic])
+    finally:
+        client.loop_stop()
+        client.disconnect()
+
+
+@pytest.mark.skipif(not BROKER, reason="MQTT_TEST_BROKER not set")
+def test_selftest_e2e_leaves_no_retained_residue(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
+    """Codex round 3 follow-up (PR #214, P1, comment 3927023413): after a
+    selftest run, a subscriber that only subscribes AFTER the run has
+    finished (never watching live) must receive NOTHING retained on the
+    schema/heartbeat topics -- `retain_messages=False` must leave no
+    residue for a late subscriber to find, not merely avoid delivering
+    retained flags to a subscriber that was already watching."""
+    import paho.mqtt.client as paho
+
+    import src.sink.publish.selftest as selftest_mod
+
+    monkeypatch.setattr(settings, "FLEET_ENABLED", True)
+    monkeypatch.setattr(settings, "FLEET_DEV_INSECURE", True)
+    monkeypatch.setattr(settings, "FLEET_IDENTITY_DIRECTORY", str(tmp_path / "identity"))
+    monkeypatch.setattr(settings, "CACHE_DIRECTORY", str(tmp_path))
+
+    rc = selftest_mod.main(["--broker", BROKER, "--batches", "1", "--interval-s", "0"])
+    assert rc == 0
+
+    inbox: queue.Queue[tuple[str, bytes, bool]] = queue.Queue()
+    client = paho.Client(
+        callback_api_version=paho.CallbackAPIVersion.VERSION2,
+        client_id=f"fresh-sub-{uuid.uuid4().hex[:8]}",
+        protocol=paho.MQTTv5,
+    )
+    client.on_message = lambda cl, ud, msg: inbox.put((msg.topic, msg.payload, msg.retain))
+    parsed = urlparse(BROKER)
+    client.connect(parsed.hostname, parsed.port or 1883)
+    client.loop_start()
+    # Subscribed only now, well after main() (and its close()) returned --
+    # any retained message on these topics would be replayed immediately.
+    client.subscribe("bagel/v1/dev/robot/#", qos=1)
+    time.sleep(0.5)
+
+    try:
+        retained_topics: list[str] = []
+        deadline = time.time() + 1.0
+        while time.time() < deadline:
+            try:
+                topic, _payload, retain = inbox.get(timeout=max(0.0, deadline - time.time()))
+            except queue.Empty:
+                break
+            if retain:
+                retained_topics.append(topic)
+        assert retained_topics == []
     finally:
         client.loop_stop()
         client.disconnect()

--- a/test/sink/publish/test_selftest.py
+++ b/test/sink/publish/test_selftest.py
@@ -61,9 +61,10 @@ class TestRunSelftest:
 
         result = run_selftest(pub, spool, batches=5, interval_s=0.0, now=lambda: 1000.0)
 
-        # -- call order: connect, schema first, then 5 channel batches, then
-        # heartbeat, then one event, then close last.
-        assert pub.calls == ["connect", "schema"] + ["channels"] * 5 + [
+        # -- call order: connect, the live-session probe (Codex round 3
+        # follow-up, P1, comment 3927287968), schema, then 5 channel
+        # batches, then heartbeat, then one event, then close last.
+        assert pub.calls == ["connect", "live_session_probe", "schema"] + ["channels"] * 5 + [
             "heartbeat",
             "events",
             "close",
@@ -196,6 +197,85 @@ class TestRunSelftest:
 
         spool = Spool(tmp_path / "spool")
         pub = FakePublisher()
+
+        result = run_selftest(pub, spool, batches=1, interval_s=0.0)
+
+        assert result["batches"] == 1
+
+
+class TestRefusesWhileLiveSessionConnected:
+    """Codex round 3 follow-up (PR #214, P1, comment 3927287968): even
+    non-retained (round 8) and even under a distinct client id (round 6),
+    the selftest's fixture schema still reaches a CONNECTED live
+    subscriber as a schema update -- the only structural fix is to never
+    publish at all while a live session exists. Detection: a bounded probe
+    for a retained heartbeat right after connect(), before any publish.
+    """
+
+    def test_retained_online_true_refuses_before_any_publish(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        from src.sink.publish.selftest import SelftestPreconditionError, run_selftest
+
+        spool = Spool(tmp_path / "spool")
+        pub = FakePublisher(live_session_beat={"v": 1, "online": True})
+
+        with pytest.raises(SelftestPreconditionError, match="live fleet session"):
+            run_selftest(pub, spool, batches=2, interval_s=0.0)
+
+        # Refused right after connect + the probe -- the connection is torn
+        # down silently (never close(), which would publish a clean-stop
+        # beat and could itself mislead a live watcher), and nothing
+        # published, no spool side effect, no residue.
+        assert pub.calls == ["connect", "live_session_probe", "disconnect_without_publishing"]
+        assert pub.disconnect_without_publishing_calls == 1
+        assert pub.schema_calls == []
+        assert pub.channel_calls == []
+        assert pub.heartbeat_calls == []
+        assert pub.event_calls == []
+        assert pub.close_calls == 0
+        assert list(spool.pending("channels")) == []
+        assert list(spool.pending("events")) == []
+
+    def test_retained_online_false_proceeds(self, tmp_path: pathlib.Path) -> None:
+        """A paused/stopped service (or an unclean disconnect's last-will)
+        retains `online: False` -- not a live session, must proceed."""
+        from src.sink.publish.selftest import run_selftest
+
+        spool = Spool(tmp_path / "spool")
+        pub = FakePublisher(live_session_beat={"v": 1, "online": False, "reason": "stopped"})
+
+        result = run_selftest(pub, spool, batches=1, interval_s=0.0)
+
+        assert result["batches"] == 1
+        assert pub.calls[:3] == ["connect", "live_session_probe", "schema"]
+
+    def test_no_retained_beat_proceeds(self, tmp_path: pathlib.Path) -> None:
+        """A fresh robot/broker with nothing retained yet -- must proceed,
+        not be treated as "unknown, refuse to be safe"."""
+        from src.sink.publish.selftest import run_selftest
+
+        spool = Spool(tmp_path / "spool")
+        pub = FakePublisher(live_session_beat=None)
+
+        result = run_selftest(pub, spool, batches=1, interval_s=0.0)
+
+        assert result["batches"] == 1
+        assert pub.live_session_probe_calls == 1
+
+    def test_publisher_without_the_probe_capability_proceeds(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        """A `Publisher` implementation that doesn't offer
+        `wait_for_retained_heartbeat` (not part of the ABC) must not break
+        -- the check is skipped entirely, matching pre-round-9 behavior."""
+        from src.sink.publish.selftest import run_selftest
+
+        class BareFakePublisher(FakePublisher):
+            wait_for_retained_heartbeat = None  # type: ignore[assignment]
+
+        spool = Spool(tmp_path / "spool")
+        pub = BareFakePublisher()
 
         result = run_selftest(pub, spool, batches=1, interval_s=0.0)
 
@@ -418,7 +498,7 @@ class TestMain:
         )
 
         assert rc == 0
-        assert captured["kwargs"]["client_id_suffix"] == "-selftest"
+        assert captured["kwargs"]["client_id_suffix"] == "/selftest"
 
     def test_publisher_gets_retain_messages_false(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path, capsys: pytest.CaptureFixture
@@ -608,3 +688,62 @@ def test_selftest_e2e_leaves_no_retained_residue(
     finally:
         client.loop_stop()
         client.disconnect()
+
+
+@pytest.mark.skipif(not BROKER, reason="MQTT_TEST_BROKER not set")
+def test_selftest_e2e_refuses_while_a_live_session_is_connected(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """Codex round 3 follow-up (PR #214, P1, comment 3927287968): a fake
+    "live" retained heartbeat (`online: true`) on the robot's own
+    heartbeat topic -- exactly what a real, connected `FleetService` would
+    leave retained -- must make the selftest refuse cleanly before
+    publishing anything. Once that retained message is cleared (a
+    paused/stopped service, or nothing at all), the identical selftest
+    command succeeds."""
+    import paho.mqtt.client as paho
+
+    import src.sink.publish.selftest as selftest_mod
+
+    monkeypatch.setattr(settings, "FLEET_ENABLED", True)
+    monkeypatch.setattr(settings, "FLEET_DEV_INSECURE", True)
+    monkeypatch.setattr(settings, "FLEET_IDENTITY_DIRECTORY", str(tmp_path / "identity"))
+    monkeypatch.setattr(settings, "CACHE_DIRECTORY", str(tmp_path))
+
+    heartbeat_topic = "bagel/v1/dev/robot/heartbeat"
+    parsed = urlparse(BROKER)
+    fake_live = paho.Client(
+        callback_api_version=paho.CallbackAPIVersion.VERSION2,
+        client_id=f"fake-live-{uuid.uuid4().hex[:8]}",
+        protocol=paho.MQTTv5,
+    )
+    fake_live.connect(parsed.hostname, parsed.port or 1883)
+    fake_live.loop_start()
+
+    try:
+        # Simulate a live, connected service's own retained heartbeat.
+        info = fake_live.publish(
+            heartbeat_topic, json.dumps({"v": 1, "online": True}), qos=1, retain=True
+        )
+        info.wait_for_publish(timeout=5.0)
+        time.sleep(0.3)  # give the broker a moment to actually retain it
+
+        rc = selftest_mod.main(["--broker", BROKER, "--batches", "1", "--interval-s", "0"])
+        err = capsys.readouterr().err
+        assert rc == 1
+        assert "live fleet session" in err
+
+        # Clear the fake live beat -- an empty retained payload deletes it,
+        # same as a real broker's retained state once nothing claims it.
+        info = fake_live.publish(heartbeat_topic, "", qos=1, retain=True)
+        info.wait_for_publish(timeout=5.0)
+        time.sleep(0.3)
+
+        rc2 = selftest_mod.main(["--broker", BROKER, "--batches", "1", "--interval-s", "0"])
+        capsys.readouterr()
+        assert rc2 == 0
+    finally:
+        fake_live.loop_stop()
+        fake_live.disconnect()

--- a/test/sink/publish/test_selftest.py
+++ b/test/sink/publish/test_selftest.py
@@ -61,14 +61,24 @@ class TestRunSelftest:
 
         result = run_selftest(pub, spool, batches=5, interval_s=0.0, now=lambda: 1000.0)
 
-        # -- call order: connect, the live-session probe (Codex round 3
-        # follow-up, P1, comment 3927287968), schema, then 5 channel
-        # batches, then heartbeat, then one event, then close last.
-        assert pub.calls == ["connect", "live_session_probe", "schema"] + ["channels"] * 5 + [
+        # -- call order: connect, the START live-session probe (Codex
+        # round 3 follow-up, P1, comment 3927287968), the ONGOING watch
+        # opening right after it (comment 3927287968's own follow-up --
+        # kept open for the whole run so a live service resuming mid-run
+        # is still caught), schema, then 5 channel batches, then
+        # heartbeat, then one event, then close last.
+        assert pub.calls == [
+            "connect",
+            "live_session_probe",
+            "watch_open",
+            "schema",
+        ] + ["channels"] * 5 + [
             "heartbeat",
             "events",
             "close",
         ]
+        assert pub._watch is not None
+        assert pub._watch.stop_calls == 1
 
         # -- schema payload is the fixed four-channel conformance schema.
         assert pub.schema_calls == [{"v": 1, "channels": SELFTEST_CHANNELS}]
@@ -212,9 +222,7 @@ class TestRefusesWhileLiveSessionConnected:
     for a retained heartbeat right after connect(), before any publish.
     """
 
-    def test_retained_online_true_refuses_before_any_publish(
-        self, tmp_path: pathlib.Path
-    ) -> None:
+    def test_retained_online_true_refuses_before_any_publish(self, tmp_path: pathlib.Path) -> None:
         from src.sink.publish.selftest import SelftestPreconditionError, run_selftest
 
         spool = Spool(tmp_path / "spool")
@@ -248,7 +256,7 @@ class TestRefusesWhileLiveSessionConnected:
         result = run_selftest(pub, spool, batches=1, interval_s=0.0)
 
         assert result["batches"] == 1
-        assert pub.calls[:3] == ["connect", "live_session_probe", "schema"]
+        assert pub.calls[:4] == ["connect", "live_session_probe", "watch_open", "schema"]
 
     def test_no_retained_beat_proceeds(self, tmp_path: pathlib.Path) -> None:
         """A fresh robot/broker with nothing retained yet -- must proceed,
@@ -263,9 +271,7 @@ class TestRefusesWhileLiveSessionConnected:
         assert result["batches"] == 1
         assert pub.live_session_probe_calls == 1
 
-    def test_publisher_without_the_probe_capability_proceeds(
-        self, tmp_path: pathlib.Path
-    ) -> None:
+    def test_publisher_without_the_probe_capability_proceeds(self, tmp_path: pathlib.Path) -> None:
         """A `Publisher` implementation that doesn't offer
         `wait_for_retained_heartbeat` (not part of the ABC) must not break
         -- the check is skipped entirely, matching pre-round-9 behavior."""
@@ -280,6 +286,61 @@ class TestRefusesWhileLiveSessionConnected:
         result = run_selftest(pub, spool, batches=1, interval_s=0.0)
 
         assert result["batches"] == 1
+
+
+class TestRefusesWhileLiveSessionConnectsMidRun:
+    """Codex round 3 follow-up (PR #214, P1, comment 3927287968's own
+    follow-up): the original live-session refusal probe only checked the
+    heartbeat topic's state right after `connect()`, at the START of the
+    run -- a live `FleetService` that RESUMES partway through a (multi-
+    batch, `interval_s`-spaced) selftest run reopens the exact same
+    schema-pollution window. The fix keeps the heartbeat subscription open
+    for the whole run and checks it between batches and before the
+    heartbeat/event publishes, aborting the instant a live beat is seen."""
+
+    def test_online_true_beat_after_batch_two_aborts_before_batch_three(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        from src.sink.publish.selftest import SelftestPreconditionError, run_selftest
+
+        spool = Spool(tmp_path / "spool")
+        pub = FakePublisher(live_session_beat_after_batch=2)
+
+        with pytest.raises(SelftestPreconditionError, match="live fleet session"):
+            run_selftest(pub, spool, batches=5, interval_s=0.0)
+
+        # Batches 1-2 published (and immediately acked, per the existing
+        # per-batch ack order) before the mid-run beat was seen; batch 3
+        # never attempted, and nothing past it (heartbeat/events/close) was
+        # ever reached.
+        assert len(pub.channel_calls) == 2
+        assert pub.heartbeat_calls == []
+        assert pub.event_calls == []
+        assert pub.close_calls == 0
+
+        # Same silent-teardown contract as the START-only refusal: no
+        # close-beat, connection torn down via disconnect_without_publishing.
+        assert pub.disconnect_without_publishing_calls == 1
+
+        # Both lanes end zero-pending -- the two successful batches were
+        # already acked in-loop; the events lane was never touched.
+        assert list(spool.pending("channels")) == []
+        assert list(spool.pending("events")) == []
+
+    def test_no_beat_ever_arriving_runs_to_completion_normally(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        """Regression guard: the new ongoing watch must not itself break the
+        (still far more common) case where no live session ever appears."""
+        from src.sink.publish.selftest import run_selftest
+
+        spool = Spool(tmp_path / "spool")
+        pub = FakePublisher()
+
+        result = run_selftest(pub, spool, batches=3, interval_s=0.0)
+
+        assert result["batches"] == 3
+        assert pub.close_calls == 1
 
 
 class TestExclusiveLockDuringRun:
@@ -319,9 +380,7 @@ class TestExclusiveLockDuringRun:
         assert pub.calls == []
         assert list(run_spool.pending("channels")) == []
 
-    def test_waits_out_a_briefly_held_lock_then_runs_normally(
-        self, tmp_path: pathlib.Path
-    ) -> None:
+    def test_waits_out_a_briefly_held_lock_then_runs_normally(self, tmp_path: pathlib.Path) -> None:
         from src.sink.publish.selftest import run_selftest
 
         root = tmp_path / "spool"

--- a/test/sink/publish/test_selftest.py
+++ b/test/sink/publish/test_selftest.py
@@ -377,6 +377,49 @@ class TestMain:
         assert captured["kwargs"]["batches"] == 3
         assert captured["kwargs"]["interval_s"] == 0.0
 
+    def test_publisher_gets_the_selftest_client_id_suffix(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Codex round 3 follow-up (PR #214, P2, comment 3925391258):
+        without a distinct client id, the selftest's MqttPublisher would
+        derive the SAME deterministic client id as the live service's own
+        (same tenant/robot) -- the broker kicks the existing session when a
+        new connection claims an already-connected client id, so running
+        the selftest against an enrolled robot's broker while its real
+        streaming service is connected would silently displace it."""
+        import src.sink.publish.selftest as selftest_mod
+
+        monkeypatch.setattr(settings, "FLEET_ENABLED", True)
+        monkeypatch.setattr(settings, "FLEET_DEV_INSECURE", True)
+        monkeypatch.setattr(settings, "FLEET_IDENTITY_DIRECTORY", str(tmp_path / "identity"))
+        monkeypatch.setattr(settings, "CACHE_DIRECTORY", str(tmp_path))
+
+        captured: dict = {}
+
+        def fake_mqtt_publisher(*args: object, **kwargs: object) -> object:
+            captured["kwargs"] = kwargs
+            return object()
+
+        monkeypatch.setattr(selftest_mod, "MqttPublisher", fake_mqtt_publisher)
+        monkeypatch.setattr(
+            selftest_mod,
+            "run_selftest",
+            lambda publisher, spool, **kwargs: {
+                "channels": 4,
+                "batches": 1,
+                "samples": 4,
+                "heartbeat": 1,
+                "events": 1,
+            },
+        )
+
+        rc = selftest_mod.main(
+            ["--broker", "mqtt://localhost:1883", "--batches", "1", "--interval-s", "0"]
+        )
+
+        assert rc == 0
+        assert captured["kwargs"]["client_id_suffix"] == "-selftest"
+
     def test_load_identity_or_none_is_a_single_load_not_check_then_load(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/test/sink/publish/test_selftest.py
+++ b/test/sink/publish/test_selftest.py
@@ -266,6 +266,49 @@ class TestExclusiveLockDuringRun:
         assert list(run_spool.pending("channels")) == []
 
 
+class TestSelftestBetweenServiceAppendsDoesNotCauseADuplicate:
+    """P1 follow-up (Codex round 3, PR #214): `exclusive()` (P1b) only
+    serializes concurrent DISK ACCESS -- it does nothing to refresh a
+    DIFFERENT already-open `Spool` instance's in-process seq cache. A
+    `FleetService`'s long-lived `Spool` whose cache predates a selftest run
+    against the same real spool must get a clean `ValueError` on its next
+    append, never a silent duplicate seq."""
+
+    def test_service_next_append_raises_cleanly_instead_of_duplicating(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        from src.sink.publish.selftest import run_selftest
+
+        root = tmp_path / "spool"
+
+        # The "service": a long-lived Spool instance that has already
+        # written and acked one channels record (so nothing is pending when
+        # the selftest's precondition check runs against the same root).
+        service_spool = Spool(root)
+        service_spool.append("channels", 1, {"v": 1, "samples": []})
+        service_spool.ack("channels", 1)
+
+        # A selftest run happens on a SEPARATE Spool instance -- simulating
+        # a different process (the CLI) against the SAME real spool root.
+        selftest_spool = Spool(root)
+        pub = FakePublisher()
+        run_selftest(pub, selftest_spool, batches=2, interval_s=0.0)
+
+        # The service's cache still says last_seq=1 -- it never saw the
+        # selftest's writes. Its next append (seq=2) collides with what the
+        # selftest already wrote to disk; this must raise cleanly, not
+        # silently duplicate.
+        with pytest.raises(ValueError, match="monotonic"):
+            service_spool.append("channels", 2, {"v": 1, "samples": []})
+
+        # Disk state is untouched by the rejected call, and the service
+        # recovers cleanly via the disk-authoritative next_seq().
+        assert list(service_spool.pending("channels")) == []
+        correct_seq = service_spool.next_seq("channels")
+        assert correct_seq > 2
+        service_spool.append("channels", correct_seq, {"v": 1, "samples": []})
+
+
 class TestMain:
     def test_fleet_disabled_returns_1_no_publisher_constructed(
         self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture

--- a/test/sink/publish/test_service.py
+++ b/test/sink/publish/test_service.py
@@ -274,6 +274,59 @@ class TestPauseResume:
         finally:
             service.stop()
 
+    def test_pause_discard_true_while_already_paused_still_empties_backlog(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        """P2 (Codex round 3): an explicit discard request must actually
+        discard even when the service was already paused -- the already-
+        paused early-return used to skip the discard entirely, silently
+        keeping backlog a caller explicitly asked to drop."""
+        writer = FakeWriter(_imu_struct())
+        sink = FakeSink({"/imu": writer})
+        pub = FakePublisher(connect_should_fail=True)
+        spool = Spool(tmp_path / "spool")
+        service = FleetService(sink=sink, streams=_imu_streams(), publisher=pub, spool=spool)
+        service.start()
+        try:
+            seq = spool.next_seq("channels")
+            spool.append("channels", seq, {"v": 1, "samples": []})
+
+            service.pause(discard=False)  # already offline now; backlog kept
+            assert list(spool.pending("channels"))
+
+            service.pause(discard=True)  # same already-paused state, discard=True this time
+            assert list(spool.pending("channels")) == []
+        finally:
+            service.stop()
+
+    def test_pause_discard_true_twice_in_a_row_discards_both_times(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        """The other order: discard=True while running, then more backlog
+        accrues while paused, then discard=True again (now already-paused)
+        must drop that too -- not just the first call's."""
+        writer = FakeWriter(_imu_struct())
+        sink = FakeSink({"/imu": writer})
+        pub = FakePublisher(connect_should_fail=True)
+        spool = Spool(tmp_path / "spool")
+        service = FleetService(sink=sink, streams=_imu_streams(), publisher=pub, spool=spool)
+        service.start()
+        try:
+            seq = spool.next_seq("channels")
+            spool.append("channels", seq, {"v": 1, "samples": []})
+
+            service.pause(discard=True)
+            assert list(spool.pending("channels")) == []
+
+            seq2 = spool.next_seq("channels")
+            spool.append("channels", seq2, {"v": 1, "samples": []})
+            assert list(spool.pending("channels"))
+
+            service.pause(discard=True)  # already paused; must discard again
+            assert list(spool.pending("channels")) == []
+        finally:
+            service.stop()
+
     def test_pause_and_resume_are_idempotent_and_restart_threads(
         self, tmp_path: pathlib.Path
     ) -> None:

--- a/test/sink/publish/test_spool.py
+++ b/test/sink/publish/test_spool.py
@@ -524,9 +524,7 @@ class TestStats:
         assert st.acked_seq == 1
         assert st.bytes > 0
 
-    def test_stats_last_seq_is_disk_authoritative_on_a_warm_cache(
-        self, root: pathlib.Path
-    ) -> None:
+    def test_stats_last_seq_is_disk_authoritative_on_a_warm_cache(self, root: pathlib.Path) -> None:
         """Codex round 3 follow-up (PR #214, P2, comment 3925391258):
         `stats()`'s `last_seq` must reflect disk, not this instance's own
         possibly-stale cache -- `acked_seq` (`_watermarks()`) and `pending`
@@ -831,7 +829,7 @@ class TestUnterminatedTailReseal:
     a trustworthy seq; (b) a genuinely partial/mid-write tail failed to
     parse, but nothing then truncated it before the next write landed
     directly on top of it. Either way, `append()`'s next `write()` (append
-    mode) grafted new bytes onto the untermianted tail with no separating
+    mode) grafted new bytes onto the unterminated tail with no separating
     newline -- permanent mid-file corruption, discovered only later when
     `pending()` raises `SpoolCorruptError`.
     """
@@ -1068,9 +1066,7 @@ class TestAppendNext:
         assert actual_seq == 2  # correctly re-derived, not the stale peeked=1
         assert [seq for seq, _ in a.pending("channels")] == [1, 2]
 
-    def test_competitor_cannot_land_between_allocation_and_write(
-        self, root: pathlib.Path
-    ) -> None:
+    def test_competitor_cannot_land_between_allocation_and_write(self, root: pathlib.Path) -> None:
         """Direct proof of atomicity: while A's `append_next` is mid-flight
         (its `build` callable deliberately blocked, so we can observe it
         running -- `build` runs INSIDE the lock), B's `append_next` must be
@@ -1150,6 +1146,28 @@ class TestExclusiveLock:
     across a multi-call critical section, cross-process-safe, bounded wait.
     """
 
+    def test_negative_timeout_raises_value_error_at_entry(self, root: pathlib.Path) -> None:
+        """`filelock` treats a negative `timeout` as "wait forever" (Codex
+        round 3 follow-up, PR #214 P2, comment 3927023413's sibling
+        finding): silently accepting one would break `exclusive()`'s own
+        documented bounded-wait contract (`SelftestPreconditionError` after
+        `lock_timeout_s`, never an indefinite hang). Refused up front,
+        before ever touching `filelock.FileLock.acquire`, so this can never
+        depend on `filelock`'s own undocumented behavior for negative
+        values."""
+        s = Spool(root)
+        with pytest.raises(ValueError, match="timeout"):
+            s.exclusive(timeout=-1.0)
+
+    def test_zero_timeout_is_still_accepted_not_treated_as_negative(
+        self, root: pathlib.Path
+    ) -> None:
+        """The fix must reject only `timeout < 0`, not `timeout == 0`
+        (a legitimate "don't wait at all" bounded wait)."""
+        s = Spool(root)
+        with s.exclusive(timeout=0.0):
+            pass
+
     def test_reentrant_with_mutators_on_the_same_instance(self, root: pathlib.Path) -> None:
         """Calls made inside the `with` block must not deadlock on their own lock."""
         s = Spool(root)
@@ -1160,26 +1178,36 @@ class TestExclusiveLock:
             s.stats()
         assert list(s.pending("channels")) == []
 
-    def test_second_instance_blocks_until_released_then_proceeds(
-        self, root: pathlib.Path
-    ) -> None:
+    def test_second_instance_blocks_until_released_then_proceeds(self, root: pathlib.Path) -> None:
         """A second `Spool` on the same root waits for the first to release,
         then succeeds -- this is a real OS-level lock, not merely advisory
-        within one instance."""
+        within one instance.
+
+        The s1-before-s2 handoff is proven deterministically via `acquired`
+        (Codex round 3 follow-up, PR #214 P2, comment 3927153842's sibling
+        finding on this test): a fixed `time.sleep(0.05)` before starting s2
+        only made it *likely* s1 had the lock first, not certain -- a slow
+        enough scheduler could still let s2 attempt before s1's thread even
+        started running. Waiting on `acquired`, set from INSIDE s1's
+        critical section, proves s1 already holds the lock before s2 ever
+        calls `exclusive()`.
+        """
         s1 = Spool(root)
         s2 = Spool(root)
+        acquired = threading.Event()
         released = threading.Event()
         acquired_order: list[str] = []
 
         def hold_then_release() -> None:
             with s1.exclusive(timeout=1.0):
                 acquired_order.append("s1")
+                acquired.set()
                 time.sleep(0.2)
             released.set()
 
         t = threading.Thread(target=hold_then_release)
         t.start()
-        time.sleep(0.05)  # let s1 grab the lock first
+        assert acquired.wait(timeout=2.0)  # s1 provably holds the lock now
 
         with s2.exclusive(timeout=2.0):
             acquired_order.append("s2")

--- a/test/sink/publish/test_spool.py
+++ b/test/sink/publish/test_spool.py
@@ -849,6 +849,119 @@ class TestUnterminatedTailReseal:
         assert calls == []  # no reseal once every tail stays properly terminated
 
 
+class TestAppendNext:
+    """Codex round 3 follow-up (PR #214, P1, comment 3924082774): `append_next()`
+    closes the allocate-then-append race structurally. The old shape --
+    `next_seq()` then a separate `append()` call -- was TWO lock
+    acquisitions with a gap between them; a competing writer (another
+    `Spool` instance's own call, or a `spool.exclusive()`-held run, e.g. the
+    selftest) could land in that gap and advance the lane first, making the
+    original caller's `append()` raise `ValueError` against a seq it
+    allocated against a now-stale floor. `append_next()` derives the floor,
+    assigns the seq, and writes all under ONE lock acquisition, so there is
+    no gap left for a competitor to land in.
+    """
+
+    def test_old_two_call_windows_collision_is_now_impossible(self, root: pathlib.Path) -> None:
+        """Directly reproduces what used to be exploitable: A peeks via the
+        (still-legitimate, read-only) `next_seq()`, then B interleaves in
+        exactly the window that peek would have left open in the old
+        `next_seq()` + `append()` shape, via an `exclusive()`-held run
+        (mirroring the selftest's own pattern). A's ACTUAL write, routed
+        through `append_next()` instead of the old `append(peeked, ...)`,
+        must succeed with a freshly re-derived (not stale) seq -- zero
+        `ValueError`."""
+        a = Spool(root)
+        b = Spool(root)
+
+        peeked = a.next_seq("channels")
+        assert peeked == 1  # what A would have (incorrectly) tried to write at, pre-fix
+
+        with b.exclusive(timeout=1.0):
+            b.append_next("channels", lambda seq: {"seq": seq, "who": "b"})
+
+        actual_seq = a.append_next("channels", lambda seq: {"seq": seq, "who": "a"})
+
+        assert actual_seq == 2  # correctly re-derived, not the stale peeked=1
+        assert [seq for seq, _ in a.pending("channels")] == [1, 2]
+
+    def test_competitor_cannot_land_between_allocation_and_write(
+        self, root: pathlib.Path
+    ) -> None:
+        """Direct proof of atomicity: while A's `append_next` is mid-flight
+        (its `build` callable deliberately blocked, so we can observe it
+        running -- `build` runs INSIDE the lock), B's `append_next` must be
+        BLOCKED until A's single critical section completes. In the old
+        `next_seq()` + `append()` shape, the lock was already released by
+        this point (right after `next_seq()` returned), leaving exactly
+        this window open for B to land in."""
+        a = Spool(root)
+        b = Spool(root)
+        a_entered_build = threading.Event()
+        release_a = threading.Event()
+        order: list[str] = []
+
+        def slow_build(seq: int) -> dict:
+            order.append("a-build-entered")
+            a_entered_build.set()
+            release_a.wait(timeout=2.0)
+            order.append("a-build-exit")
+            return {"seq": seq}
+
+        t_a = threading.Thread(target=lambda: a.append_next("channels", slow_build))
+        t_a.start()
+        a_entered_build.wait(timeout=2.0)
+
+        def run_b() -> None:
+            b.append_next("channels", lambda seq: {"seq": seq})
+            order.append("b-append_next-done")
+
+        t_b = threading.Thread(target=run_b)
+        t_b.start()
+        time.sleep(0.1)  # give B a chance to attempt -- it must still be blocked
+        assert "b-append_next-done" not in order
+
+        release_a.set()
+        t_a.join()
+        t_b.join()
+
+        assert order.index("a-build-exit") < order.index("b-append_next-done")
+
+    def test_two_instances_stress_interleaved_yield_unique_contiguous_seqs(
+        self, root: pathlib.Path
+    ) -> None:
+        """Broader stress complement to the two directed tests above: many
+        concurrent `append_next` calls from two separate `Spool` instances,
+        zero `ValueError`, every seq 1..N allocated exactly once."""
+        a = Spool(root)
+        b = Spool(root)
+        errors: list[BaseException] = []
+        seqs: list[int] = []
+        seqs_lock = threading.Lock()
+        per_writer = 25
+
+        def writer(spool: Spool, tag: str) -> None:
+            for i in range(per_writer):
+                try:
+                    seq = spool.append_next("channels", lambda seq, i=i: {"seq": seq, "i": i})
+                except BaseException as exc:  # collected, asserted below (not swallowed)
+                    errors.append(exc)
+                else:
+                    with seqs_lock:
+                        seqs.append(seq)
+
+        t_a = threading.Thread(target=writer, args=(a, "a"))
+        t_b = threading.Thread(target=writer, args=(b, "b"))
+        t_a.start()
+        t_b.start()
+        t_a.join()
+        t_b.join()
+
+        assert errors == []
+        assert sorted(seqs) == list(range(1, 2 * per_writer + 1))
+        assert len(set(seqs)) == 2 * per_writer
+
+
 class TestExclusiveLock:
     """`Spool.exclusive()` (Codex round 3, P1b): hold the spool's real lock
     across a multi-call critical section, cross-process-safe, bounded wait.

--- a/test/sink/publish/test_spool.py
+++ b/test/sink/publish/test_spool.py
@@ -849,6 +849,131 @@ class TestUnterminatedTailReseal:
         assert calls == []  # no reseal once every tail stays properly terminated
 
 
+class TestEmptyOrUnparsableActiveSegmentFloorsAtFilename:
+    """Codex round 3 follow-up (PR #214, P1/P2, comment 3924387659).
+
+    P1: a `None` tail on an EXISTING active segment (empty -- a roll that
+    crashed before its first record landed -- or unparsable) must be
+    treated exactly like an unterminated tail: reseal via the full
+    `_scan_last_seq` path, which derives the FILENAME floor
+    (`_first_seq_of(segment) - 1`). The old fast path fell back to the
+    watermark ALONE in this case, ignoring both the filename floor and any
+    earlier segments' still-live (unacked) records -- a floor REGRESSION
+    that let a warm cache's `append_next()` allocate a seq that collides
+    with data already durably on disk (not merely a stale-but-safe
+    undercount).
+
+    P2: the disk-derived floor on the NORMAL (non-reseal) read path must be
+    stored back into `self._last_seq[lane]` -- previously computed fresh
+    every call but discarded, letting the cache silently lag behind what
+    this instance's own reads had already established. Safe because it's
+    folded through `max()`, so it can only advance.
+    """
+
+    def test_empty_active_segment_on_a_warm_cache_floors_at_filename_not_watermark(
+        self, root: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(spool_mod, "SEGMENT_MAX_BYTES", 32)
+        a = Spool(root)
+        a.append("channels", 1, {"n": 1})  # segment-1
+
+        b = Spool(root)
+        assert b.next_seq("channels") == 2  # warms b's cache at the OLD value (last=1)
+
+        a.append("channels", 2, {"n": 2})  # segment-2 (cap forces a roll every append)
+        a.append("channels", 3, {"n": 3})  # segment-3
+        segments = sorted((root / "channels").glob("segment-*.jsonl"))
+        assert len(segments) == 3
+
+        # Simulate the crashed roller: a 4th append started a roll (created
+        # the next segment, named for the seq it was about to write) but
+        # crashed before any bytes landed -- b never saw any of this, its
+        # cache still says 1.
+        next_segment = root / "channels" / spool_mod._segment_name(4)
+        next_segment.write_bytes(b"")
+
+        allocated = b.append_next("channels", lambda seq: {"n": seq})
+
+        # The filename floor (segment-4 => floor 3) plus the live records
+        # 1-3 already on disk means the correct next seq is 4 -- never
+        # watermark(0)+1 == 1, which would collide with record 1, or worse
+        # get silently written INTO segment-4 under a mismatched name.
+        assert allocated == 4
+        assert [seq for seq, _ in b.pending("channels")] == [1, 2, 3, 4]
+
+    def test_unparsable_terminated_tail_on_a_warm_cache_also_reseals(
+        self, root: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Same ruling, the other `None`-tail sub-case: a properly
+        newline-terminated segment whose content still doesn't parse as a
+        usable record (e.g. a stray newline-only segment) must reseal too --
+        not silently trust the watermark alone, which here would ignore
+        both the filename floor and an earlier segment's still-live
+        (unacked) record."""
+        monkeypatch.setattr(spool_mod, "SEGMENT_MAX_BYTES", 32)
+        a = Spool(root)
+        a.append("channels", 1, {"n": 1})  # segment-1
+
+        b = Spool(root)
+        assert b.next_seq("channels") == 2  # warms b's cache at 1
+
+        a.append("channels", 2, {"n": 2})  # segment-2 (cap forces a roll)
+        segments = sorted((root / "channels").glob("segment-*.jsonl"))
+        assert len(segments) == 2
+
+        # A stray newline-only segment named for seq 3 -- terminated
+        # (`\n`), but nothing parses out of it: the "unparsable" sub-case
+        # of a `None` tail.
+        stray_segment = root / "channels" / spool_mod._segment_name(3)
+        stray_segment.write_bytes(b"\n")
+
+        allocated = b.append_next("channels", lambda seq: {"n": seq})
+
+        assert allocated == 3  # filename floor (segment-3 => floor 2), never watermark(0)+1 == 1
+        assert [seq for seq, _ in b.pending("channels")] == [1, 2, 3]
+
+    def test_disk_derived_floor_is_stored_back_into_the_cache(self, root: pathlib.Path) -> None:
+        """P2: a pure peek (`next_seq()`) that derives a fresher floor than
+        this instance's own stale cache must store that fresher value back,
+        not just return it and discard it."""
+        a = Spool(root)
+        a.append_next("channels", lambda seq: {"n": seq})  # a's cache: last_seq=1
+
+        b = Spool(root)
+        b.append_next("channels", lambda seq: {"n": seq})  # disk now at seq=2; a's cache still 1
+
+        peeked = a.next_seq("channels")  # a pure read -- must reflect disk (2), not stale (1)
+        assert peeked == 3
+
+        # The freshly-derived floor (2) must be stored back into a's own
+        # cache, not merely returned -- observable by reading it directly.
+        assert a._last_seq["channels"] == 2
+
+    def test_stored_back_floor_does_not_cause_extra_full_scans(
+        self, root: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The store-back must not regress the existing cheap-path
+        guarantee: `_scan_last_seq` (the expensive full-segment parse)
+        still only ever runs on a lane's first touch, never on a repeated
+        read/peek."""
+        a = Spool(root)
+        a.append_next("channels", lambda seq: {"n": seq})  # first touch
+
+        calls: list[str] = []
+        original = spool_mod.Spool._scan_last_seq
+
+        def spy(self: Spool, lane: str) -> int:
+            calls.append(lane)
+            return original(self, lane)
+
+        monkeypatch.setattr(spool_mod.Spool, "_scan_last_seq", spy)
+
+        for _ in range(5):
+            a.next_seq("channels")
+
+        assert calls == []  # no re-derivation via the expensive path
+
+
 class TestAppendNext:
     """Codex round 3 follow-up (PR #214, P1, comment 3924082774): `append_next()`
     closes the allocate-then-append race structurally. The old shape --

--- a/test/sink/publish/test_spool.py
+++ b/test/sink/publish/test_spool.py
@@ -492,6 +492,32 @@ class TestStats:
         assert st.acked_seq == 1
         assert st.bytes > 0
 
+    def test_stats_last_seq_is_disk_authoritative_on_a_warm_cache(
+        self, root: pathlib.Path
+    ) -> None:
+        """Codex round 3 follow-up (PR #214, P2, comment 3925391258):
+        `stats()`'s `last_seq` must reflect disk, not this instance's own
+        possibly-stale cache -- `acked_seq` (`_watermarks()`) and `pending`
+        (`self.pending()`) already re-read fresh from disk on every call;
+        `last_seq` must too, or a heartbeat calling `stats()` on a warm
+        instance reports a `last_seq` (and the backlog-depth picture that
+        implies) that lags behind what another writer already put on disk."""
+        a = Spool(root)
+        a.append_next("channels", lambda seq: {"n": seq})  # seq=1
+        a.ack("channels", 1)
+
+        b = Spool(root)
+        assert b.next_seq("channels") == 2  # warms b's cache at the OLD value (1)
+
+        a.append_next("channels", lambda seq: {"n": seq})  # seq=2, on disk now
+        a.ack("channels", 2)
+
+        # b never performs any mutator itself -- stats() alone must catch up.
+        st = b.stats()["channels"]
+        assert st.last_seq == 2
+        assert st.acked_seq == 2
+        assert st.pending == 0
+
 
 class TestNeverCappedLanes:
     def test_init_rejects_heartbeat_in_capped_lanes(self, root: pathlib.Path) -> None:

--- a/test/sink/publish/test_spool.py
+++ b/test/sink/publish/test_spool.py
@@ -464,8 +464,16 @@ class TestEvictionAndCaps:
         s = Spool(root)
         s.append("events", 1, {"n": 1})
 
-        def boom(*a: object, **k: object) -> object:
-            raise OSError(28, "No space left on device")
+        real_open = open
+
+        def boom(file: object, mode: str = "r", *a: object, **k: object) -> object:
+            # A real "disk full" only breaks writes -- reads (including the
+            # disk-authoritative tail peek append() now does on every call,
+            # Codex round 3 follow-up) keep working. Only fail append/write
+            # modes, so this stays a faithful simulation.
+            if "a" in mode or "w" in mode:
+                raise OSError(28, "No space left on device")
+            return real_open(file, mode, *a, **k)
 
         monkeypatch.setattr("builtins.open", boom)
         with pytest.raises(spool_mod.SpoolFullError, match="events"):
@@ -602,6 +610,93 @@ class TestForRobot:
     def test_for_robot_rejects_dot_segment(self) -> None:
         with pytest.raises(ValueError, match="must be non-empty and not"):
             Spool.for_robot(".")
+
+
+class TestDiskAuthoritativeMonotonicity:
+    """Codex round 3 follow-up (PR #214, P1): `append()`'s monotonicity check
+    must be disk-authoritative ACROSS `Spool` instances, not just within one.
+
+    `exclusive()` (P1b) only serializes concurrent DISK ACCESS -- it does
+    nothing to refresh a DIFFERENT already-open `Spool` instance's
+    in-process `_last_seq` cache. A long-lived instance (e.g. a
+    `FleetService`) whose cache predates an intervening writer on the same
+    real spool (e.g. a selftest run, or another process entirely) must not
+    accept/allocate a seq that collides with what's already on disk -- that
+    would silently duplicate a seq instead of raising the clean `ValueError`
+    the single-writer invariant promises.
+    """
+
+    def test_stale_cached_writer_raises_instead_of_duplicating(self, root: pathlib.Path) -> None:
+        a = Spool(root)
+        a.append("channels", 1, {"n": 1})
+        a.append("channels", 2, {"n": 2})
+        a.append("channels", 3, {"n": 3})
+
+        # B is a fresh instance on the same root: first touch, scans disk,
+        # continues the sequence correctly.
+        b = Spool(root)
+        b.append("channels", 4, {"n": 4})
+        before = list(b.pending("channels"))
+
+        # A's in-process cache still says last_seq=3 -- it never saw B's
+        # write. A disk-authoritative check must catch this collision.
+        with pytest.raises(ValueError, match="monotonic"):
+            a.append("channels", 4, {"n": "duplicate-attempt"})
+
+        # Nothing was written by the rejected call -- disk state intact.
+        after = list(b.pending("channels"))
+        assert after == before
+        assert [seq for seq, _ in after] == [1, 2, 3, 4]
+
+    def test_stale_cached_writer_can_still_append_the_true_next_seq(
+        self, root: pathlib.Path
+    ) -> None:
+        """After the collision above, the same stale instance must recover
+        cleanly once given the actually-correct next seq -- not get stuck."""
+        a = Spool(root)
+        a.append("channels", 1, {"n": 1})
+        b = Spool(root)
+        b.append("channels", 2, {"n": 2})
+
+        with pytest.raises(ValueError, match="monotonic"):
+            a.append("channels", 2, {"n": "stale"})
+
+        a.append("channels", 3, {"n": 3})  # the true next seq -- must succeed
+        assert [seq for seq, _ in a.pending("channels")] == [1, 2, 3]
+
+    def test_stale_next_seq_also_reflects_disk_not_the_cache(self, root: pathlib.Path) -> None:
+        """`next_seq()` must see a concurrent writer's advance too, not just
+        `append()`'s rejection path -- so next_seq() -> append() never
+        re-collides on the second try."""
+        a = Spool(root)
+        a.append("channels", 1, {"n": 1})
+        b = Spool(root)
+        b.append("channels", 2, {"n": 2})
+
+        assert a.next_seq("channels") == 3
+
+    def test_full_scan_last_seq_only_runs_on_first_touch_not_every_append(
+        self, root: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Perf guard: the disk-authoritative check must not degrade every
+        `append()` into an O(whole active segment) full re-parse -- only the
+        lane's first touch in this instance's lifetime may call the
+        expensive `_scan_last_seq` (crash-tail recovery); every later call
+        must use the cheap tail-only read."""
+        s = Spool(root)
+        calls: list[str] = []
+        original = spool_mod.Spool._scan_last_seq
+
+        def spy(self: Spool, lane: str) -> int:
+            calls.append(lane)
+            return original(self, lane)
+
+        monkeypatch.setattr(spool_mod.Spool, "_scan_last_seq", spy)
+
+        for i in range(1, 6):
+            s.append("channels", i, {"n": i})
+
+        assert calls == ["channels"]  # only the very first append's first-touch scan
 
 
 class TestExclusiveLock:

--- a/test/sink/publish/test_spool.py
+++ b/test/sink/publish/test_spool.py
@@ -2,11 +2,13 @@
 
 import json
 import pathlib
+import threading
+import time
 
 import pytest
 
 from src.sink.publish import spool as spool_mod
-from src.sink.publish.spool import Spool, SpoolCorruptError
+from src.sink.publish.spool import Spool, SpoolCorruptError, SpoolLockedError
 
 
 @pytest.fixture()
@@ -600,6 +602,98 @@ class TestForRobot:
     def test_for_robot_rejects_dot_segment(self) -> None:
         with pytest.raises(ValueError, match="must be non-empty and not"):
             Spool.for_robot(".")
+
+
+class TestExclusiveLock:
+    """`Spool.exclusive()` (Codex round 3, P1b): hold the spool's real lock
+    across a multi-call critical section, cross-process-safe, bounded wait.
+    """
+
+    def test_reentrant_with_mutators_on_the_same_instance(self, root: pathlib.Path) -> None:
+        """Calls made inside the `with` block must not deadlock on their own lock."""
+        s = Spool(root)
+        with s.exclusive(timeout=1.0):
+            seq = s.next_seq("channels")
+            s.append("channels", seq, {"n": 1})
+            s.ack("channels", seq)
+            s.stats()
+        assert list(s.pending("channels")) == []
+
+    def test_second_instance_blocks_until_released_then_proceeds(
+        self, root: pathlib.Path
+    ) -> None:
+        """A second `Spool` on the same root waits for the first to release,
+        then succeeds -- this is a real OS-level lock, not merely advisory
+        within one instance."""
+        s1 = Spool(root)
+        s2 = Spool(root)
+        released = threading.Event()
+        acquired_order: list[str] = []
+
+        def hold_then_release() -> None:
+            with s1.exclusive(timeout=1.0):
+                acquired_order.append("s1")
+                time.sleep(0.2)
+            released.set()
+
+        t = threading.Thread(target=hold_then_release)
+        t.start()
+        time.sleep(0.05)  # let s1 grab the lock first
+
+        with s2.exclusive(timeout=2.0):
+            acquired_order.append("s2")
+            assert released.is_set()  # s2 only got in after s1 let go
+
+        t.join()
+        assert acquired_order == ["s1", "s2"]
+
+    def test_second_instance_times_out_with_typed_error_while_first_holds(
+        self, root: pathlib.Path
+    ) -> None:
+        """The bounded-wait refusal: a lock held elsewhere for longer than the
+        timeout raises `SpoolLockedError`, not an indefinite hang."""
+        s1 = Spool(root)
+        s2 = Spool(root)
+        holding = threading.Event()
+        release = threading.Event()
+
+        def hold_until_told() -> None:
+            with s1.exclusive(timeout=1.0):
+                holding.set()
+                release.wait(timeout=2.0)
+
+        t = threading.Thread(target=hold_until_told)
+        t.start()
+        holding.wait(timeout=2.0)
+
+        with pytest.raises(SpoolLockedError, match="locked by another writer"):
+            s2.exclusive(timeout=0.1)
+
+        release.set()
+        t.join()
+
+    def test_a_plain_mutator_still_waits_indefinitely_not_a_typed_refusal(
+        self, root: pathlib.Path
+    ) -> None:
+        """Only `exclusive()`'s bounded wait times out -- the ordinary per-call
+        mutators keep their existing block-forever behavior (unchanged)."""
+        s1 = Spool(root)
+        s2 = Spool(root)
+        holding = threading.Event()
+
+        def hold_briefly() -> None:
+            with s1.exclusive(timeout=1.0):
+                holding.set()
+                time.sleep(0.15)
+
+        t = threading.Thread(target=hold_briefly)
+        t.start()
+        holding.wait(timeout=2.0)
+
+        # s2.next_seq blocks on the same lock but has no timeout -- it must
+        # simply wait for s1 to finish, not raise.
+        assert s2.next_seq("channels") == 1
+        t.join()
 
 
 def test_spool_module_does_not_import_paho_eagerly(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/test/sink/publish/test_spool.py
+++ b/test/sink/publish/test_spool.py
@@ -699,6 +699,68 @@ class TestDiskAuthoritativeMonotonicity:
         assert calls == ["channels"]  # only the very first append's first-touch scan
 
 
+class TestTailLastSeqWindowGrowth:
+    """Codex round 3 follow-up (PR #214, P1): `_tail_last_seq`'s backward-read
+    loop must grow its window GEOMETRICALLY (double each retry), not by a
+    fixed 8KiB step re-reading the whole (growing) window every iteration --
+    the fixed step is quadratic total bytes read for a final record bigger
+    than one chunk (worst case a segment-max ~4MB single-line record)."""
+
+    def test_correct_for_a_final_record_well_over_one_chunk(self, root: pathlib.Path) -> None:
+        s = Spool(root)
+        s.append("channels", 1, {"n": 1})
+        # ~100KiB payload -- comfortably more than one 8KiB read chunk, so
+        # the loop must retry (grow the window) to reach the newline that
+        # separates it from record 1.
+        s.append("channels", 2, {"pad": "x" * 100_000})
+
+        assert s._tail_last_seq("channels") == 2
+
+    def test_read_call_count_is_geometric_not_linear(
+        self, root: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        s = Spool(root)
+        s.append("channels", 1, {"n": 1})
+        s.append("channels", 2, {"pad": "x" * 100_000})
+
+        real_open = open
+        read_calls: list[int] = []
+
+        class _CountingHandle:
+            """Wraps a real binary file handle, counting `.read()` calls."""
+
+            def __init__(self, real: object) -> None:
+                self._real = real
+
+            def seek(self, *a: object, **k: object) -> object:
+                return self._real.seek(*a, **k)
+
+            def read(self, *a: object, **k: object) -> bytes:
+                read_calls.append(1)
+                return self._real.read(*a, **k)
+
+            def __enter__(self) -> "_CountingHandle":
+                return self
+
+            def __exit__(self, *exc: object) -> object:
+                return self._real.__exit__(*exc)
+
+        def fake_open(file: object, mode: str = "r", *a: object, **k: object) -> object:
+            handle = real_open(file, mode, *a, **k)
+            return _CountingHandle(handle) if mode == "rb" else handle
+
+        monkeypatch.setattr("builtins.open", fake_open)
+
+        result = s._tail_last_seq("channels")
+
+        assert result == 2
+        # Geometric doubling from 8KiB needs ~5 reads to cover ~100KiB
+        # (8, 16, 32, 64, then the size-capped final read); a fixed 8KiB
+        # linear step would need ~13+. 8 is a robust dividing line between
+        # the two.
+        assert len(read_calls) <= 8, f"expected geometric (<=8) reads, got {len(read_calls)}"
+
+
 class TestExclusiveLock:
     """`Spool.exclusive()` (Codex round 3, P1b): hold the spool's real lock
     across a multi-call critical section, cross-process-safe, bounded wait.

--- a/test/sink/publish/test_spool.py
+++ b/test/sink/publish/test_spool.py
@@ -288,6 +288,38 @@ class TestOversizedRecord:
         assert [seq for seq, _ in s.pending("heartbeat")] == [1]
         assert s.stats()["heartbeat"].evicted == 0
 
+    def test_oversized_drop_on_a_never_touched_lane_survives_a_rescan(
+        self, root: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Codex round 3 follow-up (PR #214, P2, comment 3925663134): an
+        oversized-drop consumes its seq in the cache ONLY -- no segment is
+        ever written for a dropped record, so when a lane's FIRST-EVER
+        record is oversized, disk shows nothing for it at all (no
+        directory). A later call on the SAME (now warm-cached) instance
+        that forces a rescan (`_current_last_seq`'s reseal branch, hit
+        because the lane has no segments -- a `None` tail) must not
+        REGRESS the cache back down to the watermark (0): the
+        already-consumed seq must survive, or the next oversized record
+        would reuse it instead of advancing past it."""
+        monkeypatch.setattr(spool_mod, "SEGMENT_MAX_BYTES", 200)
+        s = Spool(root)
+        giant = {"pad": "x" * 1000}
+
+        first_seq = s.append_next("channels", lambda seq: giant)  # oversized: dropped, no write
+        assert first_seq == 1
+        assert list((root / "channels").glob("segment-*.jsonl")) == []  # nothing on disk
+        assert s.stats()["channels"].evicted == 1
+
+        # Force the rescan path: stats()'s last_seq (itself disk-
+        # authoritative, Codex round 3 P2 comment 3925391258) routes
+        # through _current_last_seq, whose reseal branch is exactly what
+        # regressed the cache before this fix.
+        assert s.stats()["channels"].last_seq == 1  # must NOT regress to 0
+
+        second_seq = s.append_next("channels", lambda seq: giant)  # another oversized drop
+        assert second_seq == 2  # consumes seq 2 -- never reuses the already-consumed 1
+        assert s.stats()["channels"].evicted == 2
+
 
 class TestPendingToleratesConcurrentEviction:
     def test_segment_evicted_mid_iteration_is_skipped_not_raised(

--- a/test/sink/publish/test_spool.py
+++ b/test/sink/publish/test_spool.py
@@ -714,7 +714,7 @@ class TestTailLastSeqWindowGrowth:
         # separates it from record 1.
         s.append("channels", 2, {"pad": "x" * 100_000})
 
-        assert s._tail_last_seq("channels") == 2
+        assert s._tail_last_seq("channels") == (2, True)
 
     def test_read_call_count_is_geometric_not_linear(
         self, root: pathlib.Path, monkeypatch: pytest.MonkeyPatch
@@ -753,12 +753,100 @@ class TestTailLastSeqWindowGrowth:
 
         result = s._tail_last_seq("channels")
 
-        assert result == 2
-        # Geometric doubling from 8KiB needs ~5 reads to cover ~100KiB
-        # (8, 16, 32, 64, then the size-capped final read); a fixed 8KiB
-        # linear step would need ~13+. 8 is a robust dividing line between
-        # the two.
-        assert len(read_calls) <= 8, f"expected geometric (<=8) reads, got {len(read_calls)}"
+        assert result == (2, True)
+        # +1 read for the O(1) last-byte terminator check, then geometric
+        # doubling from 8KiB needs ~5 reads to cover ~100KiB (8, 16, 32, 64,
+        # then the size-capped final read); a fixed 8KiB linear step would
+        # need ~13+ on top of that. 9 is a robust dividing line between the
+        # two.
+        assert len(read_calls) <= 9, f"expected geometric (<=9) reads, got {len(read_calls)}"
+
+
+class TestUnterminatedTailReseal:
+    """Codex round 3 follow-up (PR #214, P1, comment 3923824688): a torn
+    (non-newline-terminated) active-segment tail must be sealed (truncated)
+    BEFORE the next append, on a WARM cache too -- not just on a lane's
+    first touch. Before this fix, `_tail_last_seq` inferred terminatedness
+    from whether the tail happened to parse, which is wrong two ways: (a) a
+    crash landing right after a complete JSON payload but before its
+    trailing newline parses FINE without the newline, so it was reported as
+    a trustworthy seq; (b) a genuinely partial/mid-write tail failed to
+    parse, but nothing then truncated it before the next write landed
+    directly on top of it. Either way, `append()`'s next `write()` (append
+    mode) grafted new bytes onto the untermianted tail with no separating
+    newline -- permanent mid-file corruption, discovered only later when
+    `pending()` raises `SpoolCorruptError`.
+    """
+
+    def _active_segment(self, root: pathlib.Path, lane: str) -> pathlib.Path:
+        return sorted((root / lane).glob("segment-*.jsonl"))[-1]
+
+    def test_complete_json_without_trailing_newline_is_resealed_before_append(
+        self, root: pathlib.Path
+    ) -> None:
+        s = Spool(root)
+        s.append("channels", 1, {"n": 1})  # warms this instance's cache
+
+        # Simulate a crash landing exactly after a COMPLETE JSON payload but
+        # before its trailing newline -- parses fine on its own, which is
+        # exactly what made the old parse-based check trust it.
+        segment = self._active_segment(root, "channels")
+        with open(segment, "ab") as handle:
+            handle.write(json.dumps({"seq": 2, "payload": {"n": "never-committed"}}).encode())
+        assert not segment.read_bytes().endswith(b"\n")
+
+        # The cache is warm (this instance already appended once) -- the
+        # torn tail must still be caught here, not just on first touch.
+        seq = s.next_seq("channels")
+        assert seq == 2  # the torn seq=2 bytes were never durably committed
+        s.append("channels", seq, {"n": 2})
+
+        assert segment.read_bytes().endswith(b"\n")  # resealed to a clean boundary
+        replayed = list(s.pending("channels"))  # must not raise SpoolCorruptError
+        assert [seq for seq, _ in replayed] == [1, 2]
+        assert replayed[1][1] == {"n": 2}
+
+    def test_partial_json_tail_is_resealed_before_append(self, root: pathlib.Path) -> None:
+        s = Spool(root)
+        s.append("channels", 1, {"n": 1})  # warms this instance's cache
+
+        # Simulate a crash mid-write: not even valid JSON, no newline.
+        segment = self._active_segment(root, "channels")
+        with open(segment, "ab") as handle:
+            handle.write(b'{"seq": 2, "payload": {"n": ')
+        assert not segment.read_bytes().endswith(b"\n")
+
+        seq = s.next_seq("channels")
+        assert seq == 2
+        s.append("channels", seq, {"n": 2})
+
+        assert segment.read_bytes().endswith(b"\n")
+        replayed = list(s.pending("channels"))
+        assert [seq for seq, _ in replayed] == [1, 2]
+        assert replayed[1][1] == {"n": 2}
+
+    def test_normal_terminated_tail_never_triggers_a_reseal(
+        self, root: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The healthy path must stay cheap: a properly newline-terminated
+        tail must never fall back to the full `_scan_last_seq` reseal --
+        the warm cache stays effective, pinned by a call-counting probe."""
+        s = Spool(root)
+        s.append("channels", 1, {"n": 1})  # first touch: its own _scan_last_seq call
+
+        calls: list[str] = []
+        original = spool_mod.Spool._scan_last_seq
+
+        def spy(self: Spool, lane: str) -> int:
+            calls.append(lane)
+            return original(self, lane)
+
+        monkeypatch.setattr(spool_mod.Spool, "_scan_last_seq", spy)
+
+        for i in range(2, 6):
+            s.append("channels", i, {"n": i})
+
+        assert calls == []  # no reseal once every tail stays properly terminated
 
 
 class TestExclusiveLock:

--- a/test/test_compose_bindings.py
+++ b/test/test_compose_bindings.py
@@ -85,13 +85,18 @@ def test_every_fleet_enabled_service_forwards_enrollment_settings() -> None:
     FLEET_ENROLL_TOKEN/FLEET_ENROLL_URL, so `maybe_enroll_on_first_boot()`
     silently no-ops even when an operator exports both on the host --
     production mqtts:// startup fails with no obvious cause. Also requires
-    FLEET_IDENTITY_DIRECTORY and FLEET_DEV_INSECURE passthrough, matching
-    FLEET_ENABLED's own ``${VAR:-default}`` style.
+    FLEET_DEV_INSECURE passthrough, matching FLEET_ENABLED's own
+    ``${VAR:-default}`` style.
+
+    FLEET_IDENTITY_DIRECTORY is deliberately excluded (Codex round 3): the
+    volume mount already fixes the container-side path, and forwarding a
+    host-set override would let the container write identity material
+    off-volume where it's lost on recreation. See
+    test_fleet_identity_directory_is_not_forwarded below.
     """
     required = {
         "FLEET_ENROLL_TOKEN": "${FLEET_ENROLL_TOKEN:-}",
         "FLEET_ENROLL_URL": "${FLEET_ENROLL_URL:-}",
-        "FLEET_IDENTITY_DIRECTORY": "${FLEET_IDENTITY_DIRECTORY:-/home/ubuntu/.bagel/identity}",
         "FLEET_DEV_INSECURE": "${FLEET_DEV_INSECURE:-false}",
     }
     offenders = []
@@ -105,6 +110,25 @@ def test_every_fleet_enabled_service_forwards_enrollment_settings() -> None:
     assert not offenders, f"FLEET_ENABLED services missing enrollment passthrough: {offenders}"
 
 
+def test_fleet_identity_directory_is_not_forwarded() -> None:
+    """FLEET_IDENTITY_DIRECTORY must never be forwarded into the container.
+
+    Codex review (round 3): forwarding this var let an operator override the
+    in-container identity path independently of the bind mount below,
+    silently steering enrollment writes off the persisted volume where a
+    container recreation would lose them. The bind mount is the only thing
+    that defines the container-side identity path now.
+    """
+    offenders = []
+    for name, service in _services().items():
+        env = service.get("environment", {}) or {}
+        if "FLEET_ENABLED" not in env:
+            continue
+        if "FLEET_IDENTITY_DIRECTORY" in env:
+            offenders.append(name)
+    assert not offenders, f"must not forward FLEET_IDENTITY_DIRECTORY: {offenders}"
+
+
 def test_every_fleet_enabled_service_persists_identity_directory() -> None:
     """The identity directory must be mounted from the host, not left in the container layer.
 
@@ -112,8 +136,9 @@ def test_every_fleet_enabled_service_persists_identity_directory() -> None:
     workflow, an unmounted identity directory lives only in the one-off
     container's writable layer and is lost on exit; because
     FLEET_ENROLL_TOKEN is single-use, a later run can't re-enroll to replace
-    it. The host-side mount must match FLEET_IDENTITY_DIRECTORY's
-    container-side default (/home/ubuntu/.bagel/identity) set above.
+    it. The bind mount's container-side path (/home/ubuntu/.bagel/identity)
+    is now the sole definition of where identity material lives -- see
+    test_fleet_identity_directory_is_not_forwarded (Codex round 3).
     """
     expected = "${HOME}/.bagel/identity:/home/ubuntu/.bagel/identity"
     offenders = []


### PR DESCRIPTION
## Summary

Follow-up carrying the fixes for Codex's final-round findings on #212 and #213 (both merged while the fixes were in flight; all nine findings triaged, none launch-blocking).

- **Selftest cross-process safety (P1)**: `run_selftest` now holds the spool's own file lock (`Spool.exclusive()`, bounded wait) for its entire run — a concurrent live service can no longer race sequence allocation; contention yields a clean typed refusal instead of a nondeterministic collision. The runbook's run-it-paused guidance remains as a courtesy, no longer load-bearing for correctness.
- **Event-rule honesty (P1)**: `stream_live_topics`/`stop_live_streams` results now report `events_configured` + `events_active: false`, with a WARNING at configure time and matching docs — event rules are stored and forwarded but not evaluated until the event runtime ships. No caller can mistake a stored predicate for a live one.
- **Compose identity-dir foot-gun (P1)**: `FLEET_IDENTITY_DIRECTORY` is no longer forwarded into containers — the bind mount alone defines the container path, so an env override can't redirect identity writes off-volume and burn an enrollment token.
- **Control-plane hardenings (P2s)**: `pause(discard=True)` honors the discard when already paused; `fleet_status` survives a half-installed paho namespace and a corrupt spool (reports, never raises); `delete_identity` sweeps renewal orphans even when `identity.yaml` is missing; a persist failure after a successful rule-change restart is reported in the result (`persist_error`) instead of masking the live change behind an exception.

One finding was reply-only per the spec's binding annotation matrix (pause stays `destructive=False`; the discard caveat lives in the docstring).

## Testing

- `uv run pytest test/sink/ test/test_tool_annotations.py test/test_compose_bindings.py -q` — 601 passed, 13 skipped, on this branch off current beta.
- Every fix RED-verified against pre-fix code before implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
