### PR TITLE
ci: publish ros2-kilted as a multi-arch (amd64+arm64) manifest

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,8 +17,9 @@ jobs:
     strategy:
       matrix:
         include:
-          # ROS
-          - service: ros2-kilted
+          # ROS (ros2-kilted excluded: it publishes via the dedicated
+          # kilted-amd64 / publish-arm64 / merge-manifests jobs below, which
+          # produce its multi-arch manifest -- see those jobs' comments).
           - service: ros2-jazzy
           - service: ros2-iron
           - service: ros2-humble
@@ -85,31 +86,50 @@ jobs:
             push_with_retry $IMAGE:$TAG
           fi
 
-          # arm64 phase 1 (ros2-kilted only): push this leg's image under an
-          # -amd64 suffix for each tag that will become multi-arch. The
-          # merge-manifests job below combines it with the -arm64 leg's
-          # image into the final manifest list. Every other service skips
-          # this block entirely, so their tags/pushes are unchanged.
-          if [ "${{ matrix.service }}" = "ros2-kilted" ]; then
-            docker tag $IMAGE:latest $IMAGE:latest-amd64
-            if [ "${GITHUB_REF_NAME}" = "main" ]; then
-              push_with_retry $IMAGE:latest-amd64
-              if docker manifest inspect "$IMAGE:$VERSION" >/dev/null 2>&1; then
-                echo "$IMAGE:$VERSION already published; skipping arch-suffixed $VERSION push"
-              else
-                docker tag $IMAGE:latest $IMAGE:$VERSION-amd64
-                push_with_retry $IMAGE:$VERSION-amd64
-              fi
-            else
-              docker tag $IMAGE:latest "$BETA-amd64"
-              push_with_retry "$BETA-amd64"
-            fi
-          fi
+  # arm64 phase 1, amd64 leg for ros2-kilted: this image is isolated from
+  # the `docker` matrix entirely (see Codex review on PR #215) so that (a)
+  # no single-arch `latest`/$VERSION/beta tag is ever visible to users --
+  # only merge-manifests below ever writes those -- and (b) the merge does
+  # not depend on the other 10 services' matrix legs succeeding. This job
+  # pushes ONLY a run-scoped staging tag, never a final tag, so concurrent
+  # `main` pushes each get their own staging references and can't clobber
+  # each other (finding: shared mutable -amd64/-arm64 tags).
+  kilted-amd64:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Free disk space
+        run: sudo rm -rf /usr/share/dotnet /usr/local/lib/android /usr/lib/jvm
+      - name: Build ros2-kilted
+        run: docker compose build ros2-kilted
+      - name: Push ros2-kilted staging tag (amd64)
+        run: |
+          IMAGE=ghcr.io/extelligence-ai/bagel/ros2-kilted
+          # Same ghcr blob-drop retry as the `docker` job's push step.
+          push_with_retry() {
+            for attempt in 1 2 3; do
+              docker push "$1" && return 0
+              echo "push $1 failed (attempt $attempt); retrying in $((attempt * 20))s"
+              sleep $((attempt * 20))
+            done
+            docker push "$1"
+          }
+          docker tag $IMAGE:latest $IMAGE:staging-${{ github.run_id }}-amd64
+          push_with_retry $IMAGE:staging-${{ github.run_id }}-amd64
 
-  # arm64 phase 1: ros2-kilted only. GitHub-hosted native arm64 runner (free
-  # for public repos), so `docker compose build` targets arm64 without cross
-  # compilation -- compose has no `platforms:` override, so it builds for the
-  # runner's own arch by default.
+  # arm64 phase 1, arm64 leg for ros2-kilted. GitHub-hosted native arm64
+  # runner (free for public repos), so `docker compose build` targets arm64
+  # without cross compilation -- compose has no `platforms:` override, so it
+  # builds for the runner's own arch by default. Same staging-only rule as
+  # kilted-amd64 above: no final tag is ever pushed from this job.
   publish-arm64:
     runs-on: ubuntu-24.04-arm
     permissions:
@@ -126,11 +146,10 @@ jobs:
         run: sudo rm -rf /usr/share/dotnet /usr/local/lib/android /usr/lib/jvm
       - name: Build ros2-kilted
         run: docker compose build ros2-kilted
-      - name: Push ros2-kilted (arm64)
+      - name: Push ros2-kilted staging tag (arm64)
         run: |
           IMAGE=ghcr.io/extelligence-ai/bagel/ros2-kilted
-          VERSION=$(grep -m1 '^version' pyproject.toml | sed 's/.*"\(.*\)"/\1/')
-          # Same ghcr blob-drop retry as the amd64 leg (publish.yaml, docker job).
+          # Same ghcr blob-drop retry as the `docker` job's push step.
           push_with_retry() {
             for attempt in 1 2 3; do
               docker push "$1" && return 0
@@ -139,27 +158,21 @@ jobs:
             done
             docker push "$1"
           }
-          docker tag $IMAGE:latest $IMAGE:latest-arm64
-          if [ "${GITHUB_REF_NAME}" = "main" ]; then
-            push_with_retry $IMAGE:latest-arm64
-            if docker manifest inspect "$IMAGE:$VERSION" >/dev/null 2>&1; then
-              echo "$IMAGE:$VERSION already published; skipping arch-suffixed $VERSION push"
-            else
-              docker tag $IMAGE:latest $IMAGE:$VERSION-arm64
-              push_with_retry $IMAGE:$VERSION-arm64
-            fi
-          else
-            BETA="$IMAGE:${VERSION}-beta.${GITHUB_RUN_NUMBER}"
-            docker tag $IMAGE:latest "$BETA-arm64"
-            push_with_retry "$BETA-arm64"
-          fi
+          docker tag $IMAGE:latest $IMAGE:staging-${{ github.run_id }}-arm64
+          push_with_retry $IMAGE:staging-${{ github.run_id }}-arm64
 
-  # arm64 phase 1: merge the amd64 and arm64 ros2-kilted legs into one
-  # multi-arch manifest per tag. Replicates the amd64 job's tagging rules
-  # exactly (including the $VERSION immutability check on main) so the
-  # user-facing tags behave identically to before, just multi-arch now.
+  # arm64 phase 1: the ONLY place ros2-kilted's final, user-facing tags get
+  # created. Needs just the two staging producers above -- not the 11-service
+  # `docker` matrix -- so an unrelated service's build failure can never
+  # block or skip this (Codex review finding). Assembles every final tag the
+  # run produces from the run-scoped staging pair, replicating the `docker`
+  # job's tagging rules exactly: beta branches get one pre-release tag; main
+  # gets `latest` unconditionally plus $VERSION gated by the same
+  # immutability check the `docker` job uses -- run here, at the only point
+  # the final $VERSION tag is actually created, so a version bump can never
+  # observe a semver tag that a single-arch push already claimed.
   merge-manifests:
-    needs: [docker, publish-arm64]
+    needs: [kilted-amd64, publish-arm64]
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -171,18 +184,26 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Merge ros2-kilted manifest (amd64 + arm64)
+      - name: Publish ros2-kilted manifest (amd64 + arm64)
         run: |
           IMAGE=ghcr.io/extelligence-ai/bagel/ros2-kilted
+          STAGING_AMD64=$IMAGE:staging-${{ github.run_id }}-amd64
+          STAGING_ARM64=$IMAGE:staging-${{ github.run_id }}-arm64
           VERSION=$(grep -m1 '^version' pyproject.toml | sed 's/.*"\(.*\)"/\1/')
           if [ "${GITHUB_REF_NAME}" = "main" ]; then
-            docker buildx imagetools create -t $IMAGE:latest $IMAGE:latest-amd64 $IMAGE:latest-arm64
+            docker buildx imagetools create -t $IMAGE:latest $STAGING_AMD64 $STAGING_ARM64
             if docker manifest inspect "$IMAGE:$VERSION" >/dev/null 2>&1; then
               echo "$IMAGE:$VERSION already published; leaving it untouched"
             else
-              docker buildx imagetools create -t $IMAGE:$VERSION $IMAGE:$VERSION-amd64 $IMAGE:$VERSION-arm64
+              docker buildx imagetools create -t $IMAGE:$VERSION $STAGING_AMD64 $STAGING_ARM64
             fi
           else
             BETA_TAG="${VERSION}-beta.${GITHUB_RUN_NUMBER}"
-            docker buildx imagetools create -t $IMAGE:$BETA_TAG $IMAGE:$BETA_TAG-amd64 $IMAGE:$BETA_TAG-arm64
+            docker buildx imagetools create -t $IMAGE:$BETA_TAG $STAGING_AMD64 $STAGING_ARM64
           fi
+      # Best-effort cleanup: staging-<run_id>-{amd64,arm64} are never used
+      # again after the merge above. Deleting them needs the ghcr package
+      # version API (look up the version id for a tag, then DELETE it),
+      # which is more than a `docker` one-liner; left out of phase 1 to keep
+      # this job small. They accumulate harmlessly -- one pair per run, not
+      # pulled by anything, and cheap to prune later in bulk if needed.

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -84,3 +84,105 @@ jobs:
             push_with_retry "$BETA"
             push_with_retry $IMAGE:$TAG
           fi
+
+          # arm64 phase 1 (ros2-kilted only): push this leg's image under an
+          # -amd64 suffix for each tag that will become multi-arch. The
+          # merge-manifests job below combines it with the -arm64 leg's
+          # image into the final manifest list. Every other service skips
+          # this block entirely, so their tags/pushes are unchanged.
+          if [ "${{ matrix.service }}" = "ros2-kilted" ]; then
+            docker tag $IMAGE:latest $IMAGE:latest-amd64
+            if [ "${GITHUB_REF_NAME}" = "main" ]; then
+              push_with_retry $IMAGE:latest-amd64
+              if docker manifest inspect "$IMAGE:$VERSION" >/dev/null 2>&1; then
+                echo "$IMAGE:$VERSION already published; skipping arch-suffixed $VERSION push"
+              else
+                docker tag $IMAGE:latest $IMAGE:$VERSION-amd64
+                push_with_retry $IMAGE:$VERSION-amd64
+              fi
+            else
+              docker tag $IMAGE:latest "$BETA-amd64"
+              push_with_retry "$BETA-amd64"
+            fi
+          fi
+
+  # arm64 phase 1: ros2-kilted only. GitHub-hosted native arm64 runner (free
+  # for public repos), so `docker compose build` targets arm64 without cross
+  # compilation -- compose has no `platforms:` override, so it builds for the
+  # runner's own arch by default.
+  publish-arm64:
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Free disk space
+        run: sudo rm -rf /usr/share/dotnet /usr/local/lib/android /usr/lib/jvm
+      - name: Build ros2-kilted
+        run: docker compose build ros2-kilted
+      - name: Push ros2-kilted (arm64)
+        run: |
+          IMAGE=ghcr.io/extelligence-ai/bagel/ros2-kilted
+          VERSION=$(grep -m1 '^version' pyproject.toml | sed 's/.*"\(.*\)"/\1/')
+          # Same ghcr blob-drop retry as the amd64 leg (publish.yaml, docker job).
+          push_with_retry() {
+            for attempt in 1 2 3; do
+              docker push "$1" && return 0
+              echo "push $1 failed (attempt $attempt); retrying in $((attempt * 20))s"
+              sleep $((attempt * 20))
+            done
+            docker push "$1"
+          }
+          docker tag $IMAGE:latest $IMAGE:latest-arm64
+          if [ "${GITHUB_REF_NAME}" = "main" ]; then
+            push_with_retry $IMAGE:latest-arm64
+            if docker manifest inspect "$IMAGE:$VERSION" >/dev/null 2>&1; then
+              echo "$IMAGE:$VERSION already published; skipping arch-suffixed $VERSION push"
+            else
+              docker tag $IMAGE:latest $IMAGE:$VERSION-arm64
+              push_with_retry $IMAGE:$VERSION-arm64
+            fi
+          else
+            BETA="$IMAGE:${VERSION}-beta.${GITHUB_RUN_NUMBER}"
+            docker tag $IMAGE:latest "$BETA-arm64"
+            push_with_retry "$BETA-arm64"
+          fi
+
+  # arm64 phase 1: merge the amd64 and arm64 ros2-kilted legs into one
+  # multi-arch manifest per tag. Replicates the amd64 job's tagging rules
+  # exactly (including the $VERSION immutability check on main) so the
+  # user-facing tags behave identically to before, just multi-arch now.
+  merge-manifests:
+    needs: [docker, publish-arm64]
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Merge ros2-kilted manifest (amd64 + arm64)
+        run: |
+          IMAGE=ghcr.io/extelligence-ai/bagel/ros2-kilted
+          VERSION=$(grep -m1 '^version' pyproject.toml | sed 's/.*"\(.*\)"/\1/')
+          if [ "${GITHUB_REF_NAME}" = "main" ]; then
+            docker buildx imagetools create -t $IMAGE:latest $IMAGE:latest-amd64 $IMAGE:latest-arm64
+            if docker manifest inspect "$IMAGE:$VERSION" >/dev/null 2>&1; then
+              echo "$IMAGE:$VERSION already published; leaving it untouched"
+            else
+              docker buildx imagetools create -t $IMAGE:$VERSION $IMAGE:$VERSION-amd64 $IMAGE:$VERSION-arm64
+            fi
+          else
+            BETA_TAG="${VERSION}-beta.${GITHUB_RUN_NUMBER}"
+            docker buildx imagetools create -t $IMAGE:$BETA_TAG $IMAGE:$BETA_TAG-amd64 $IMAGE:$BETA_TAG-arm64
+          fi


### PR DESCRIPTION
## Summary

Phase 1 of arm64 support: `ros2-kilted` becomes a multi-arch
(`linux/amd64` + `linux/arm64`) manifest for every tag it publishes. No
other image changes. This is a CI-only change (`.github/workflows/publish.yaml`);
no application code, Dockerfiles, or `compose.yaml` were touched.

## Design: staged build, atomic publish (revised after Codex review)

`ros2-kilted` is fully isolated from the existing `docker` matrix and
published by three dedicated jobs. Neither per-arch leg ever writes a
final, user-facing tag -- both only push a **run-scoped staging tag**,
and a single downstream job creates every final tag atomically from that
staging pair.

- **`docker` job (existing matrix), unchanged for the 10 services it
  still builds**: `ros2-kilted` is removed from `matrix.include`. Nothing
  else in this job changed -- `git diff <pre-arm64-commit> -- publish.yaml`
  shows the job's steps (checkout, buildx, login, free-disk-space, build,
  push) are byte-for-byte identical; only the matrix entry that named
  `ros2-kilted` (and its comment) is gone.
- **New `kilted-amd64` job**: builds `ros2-kilted` on `ubuntu-latest` and
  pushes exactly one tag: `$IMAGE:staging-${{ github.run_id }}-amd64`.
  Nothing else.
- **New `publish-arm64` job**: builds `ros2-kilted` on `ubuntu-24.04-arm`
  (GitHub-hosted, native arm64, free for public repos -- compose has no
  `platforms:` override, so `docker compose build` targets the runner's
  native arch with no cross-compilation) and pushes exactly one tag:
  `$IMAGE:staging-${{ github.run_id }}-arm64`. Nothing else.
- **New `merge-manifests` job** (`needs: [kilted-amd64, publish-arm64]`
  -- only those two, not the 11-service matrix): this is the *only* place
  any of `ros2-kilted`'s final tags are created, using
  `docker buildx imagetools create -t <final-tag> <staging-amd64> <staging-arm64>`.
  Replicates the `docker` job's tagging rules exactly: on `main`, `latest`
  is created unconditionally and `$VERSION` only if
  `docker manifest inspect "$IMAGE:$VERSION"` doesn't already resolve
  (the immutability check the amd64-only job used to run); on beta
  branches, only `${VERSION}-beta.${GITHUB_RUN_NUMBER}` is created. Both
  architectures are present the instant any final tag exists -- there is
  no window where a final tag resolves to a single-arch image.
- Staging tags (`staging-<run_id>-{amd64,arm64}`) are not cleaned up in
  this PR (see "Not done here"). They're never referenced again after
  the merge step and accumulate harmlessly, one pair per run.
- The per-commit `sha-<sha>` tag stays out of scope, as before: it isn't
  a tag consumers pin to (the MCP registry pins semver), and it's
  produced only by the `docker` job for the 10 remaining services now
  that `ros2-kilted` doesn't go through that job at all.

## What changed from the first draft, and why

The first version of this PR extended the existing `docker` job's push
step with a `ros2-kilted`-only conditional that pushed arch-suffixed
copies of the *same* final tags (`latest-amd64`, `$VERSION-amd64`, ...)
alongside the job's normal single-arch push, and merged them in a
separate job. Codex's review (PR #215) found four P1s, all facets of the
same flaw -- the original amd64 leg still published `ros2-kilted`'s
*final* tags single-arch, before any merge happened:

1. **Single-arch `latest` window**: the amd64 leg pushed `latest`
   directly; arm64 clients could pull a single-arch image until the
   later merge ran.
2. **Immutability check raced the merge**: `$VERSION` was checked and
   published amd64-only by the amd64 leg *before* the arm64 image or the
   merge existed, so a version bump's `$VERSION` tag could get
   permanently pinned to amd64-only, with no way to fix a published
   immutable tag afterward.
3. **Shared mutable staging tags**: `latest-amd64`/`latest-arm64` were
   overwritten on every `main` push; two overlapping runs could merge
   amd64 from one commit with arm64 from another.
4. **Merge depended on the wrong scope**: `merge-manifests` needed the
   entire 11-service `docker` matrix job, so an unrelated service's
   build failure would skip the merge and leave `ros2-kilted:latest`
   downgraded to whatever single-arch state the amd64 leg left it in.

This revision removes the root cause rather than patching each symptom:
no leg publishes a final tag, full stop. Final tags exist only inside
`merge-manifests`, created atomically from two run-scoped staging
references that can't collide across concurrent runs (fixes 1-4 above
directly: no intermediate final-tag state, one place for the
immutability check, no shared mutable tags, and a merge dependency
scoped to exactly the two jobs it needs).

## How the other images were verified unchanged

`git diff <pre-arm64-baseline> -- .github/workflows/publish.yaml`
against the commit before any arm64 work shows the `docker` job's step
bodies are untouched byte-for-byte; the only change inside that job is
the removal of the `ros2-kilted` matrix entry (and its adjacent
comment). `ros2-jazzy`, `ros2-iron`, `ros2-humble`, `ros1-noetic`,
`ros1-noetic-cv`, `px4`, `ardupilot`, `betaflight`, `apache-arrow`, and
`iot` render and execute exactly as they did before this PR.

## Validation performed

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/publish.yaml'))"` — parses clean.
- `actionlint .github/workflows/publish.yaml` — only pre-existing
  `SC2086` info-level findings (unquoted `$IMAGE:$TAG`-style
  expansions), the same class already present in the file before this
  PR; no new finding categories.
- `scripts/check_boundary.sh` — passes.
- Manual review of every `${...}` / `$VAR` expansion in the new jobs,
  including the `$IMAGE:staging-${{ github.run_id }}-amd64` and
  `$IMAGE:$VERSION`-style forms, to confirm no malformed variable
  references.
- No images were built or pushed; no `docker compose build` or `docker
  push`/`docker buildx imagetools create` was run locally as part of
  this change.

## Not done here (by design)

- No other image (px4, ardupilot, betaflight, the other ROS distros,
  apache-arrow, iot) gets an arm64 leg yet.
- No CI guard enforcing that new/robot-facing images stay multi-arch
  going forward.
- Staging tags (`staging-<run_id>-{amd64,arm64}`) are not deleted after
  a successful merge. Real cleanup needs the ghcr package-version API
  (look up the version id behind a tag, then delete it) -- more than a
  one-line `docker` cleanup step, so it's left out of phase 1. They
  don't get pulled by anything and are cheap to prune in bulk later.
- `docker-build.yaml` (PR-time build matrix) is untouched — it doesn't
  publish, so it's out of scope for this phase.

## Phase 2 (follow-up, not in this PR)

Once this proves out (a real beta run producing a working multi-arch
`ros2-kilted` pull on both amd64 and arm64 hosts), phase 2 extends the
same staged-build-then-atomic-merge pattern to the remaining
robot-facing image variants, adds a CI guard so a newly added image
can't silently ship amd64-only, and revisits staging-tag cleanup.
