### PR TITLE
fix(agent): robot_health matches what the tools actually support

### DIFF
--- a/src/agent/diagnose/robot_health.poml
+++ b/src/agent/diagnose/robot_health.poml
@@ -24,14 +24,31 @@
                             `vehicle_status_*`/`commander_state_*` (status).
                         </item>
                         <item>
-                            <b>ArduPilot (.bin/.log)</b>: `BAT` (power), `IMU`/`VIBE` (IMU),
-                            `GPS` (GPS), `MSG` (status text).
+                            <b>ArduPilot (.bin)</b>: `BAT` (power), `IMU`/`VIBE` (IMU),
+                            `GPS` (GPS), `MSG` (status text). Only the binary DataFlash
+                            `.bin` format is supported (detected by magic bytes, not
+                            extension); a text-format `.log` export is not recognized and
+                            will fail before any inventory - tell the user to re-export as
+                            `.bin` if that's what they have.
                         </item>
                         <item>
-                            <b>Betaflight (.bbl/.BFL)</b>: the `I`/`P` frame topics carry
-                            `vbatLatest` (power) and `gyroADC[0..2]`/`gyroUnfilt[0..2]` (IMU)
-                            in one table; treat GPS as absent unless a GPS frame type shows
-                            up in `describe_data_source`.
+                            <b>Betaflight (.bbl/.BFL)</b>: `describe_data_source` on a
+                            `.bbl` REQUIRES `args={"log_index": 1}` for the first flight
+                            log - a `.bbl` can combine several flight logs recorded to
+                            onboard flash, and there's no default, so the call fails
+                            without it. If it errors, the error names the valid index
+                            range; adapt and retry. `.BFL` files need no `log_index`.
+                            `vbatLatest` (power) and `gyroADC[0..2]`/`gyroUnfilt[0..2]`
+                            (IMU) live on the `I` and `P` frame topics, which
+                            `describe_data_source` exposes as SEPARATE topics (`I` =
+                            keyframes at a lower rate, `P` = delta frames) - query each
+                            with its own `query_messages` call, and don't infer a data
+                            gap from either topic alone. `describe_topic` gives no
+                            unit or scale for `vbatLatest` (it's a raw int); report it as
+                            the raw value with an explicit units-unknown caveat, never
+                            asserting volts or applying an unconfirmed conversion. Treat
+                            GPS as absent unless a GPS frame type shows up in
+                            `describe_data_source`.
                         </item>
                         <item>
                             <b>ROS 1/2 (.bag/.mcap/.db3)</b>: a topic typed
@@ -65,10 +82,10 @@
                             rest of the log.
                         </item>
                         <item>
-                            <b>IMU / vibration</b>: variance and max absolute value of linear
-                            acceleration (or gyro) per axis. Flag a window whose variance or
+                            <b>IMU / vibration</b>: STDDEV and max absolute value of linear
+                            acceleration (or gyro) per axis. Flag a window whose STDDEV or
                             extreme is far outside the log's own baseline (e.g. several times
-                            the overall STDDEV/AVG), and say when it happens.
+                            the overall STDDEV), and say when it happens.
                         </item>
                         <item>
                             <b>GPS</b>: the fix-quality distribution (fix type / status /
@@ -108,7 +125,7 @@
             sample.ulg - 41.5s, 2018 messages, 74 topics
 
             Power      ✅  min 22.1V, largest drop 0.3V
-            IMU        ⚠️  accel_z variance 4.2x the log baseline at t=28s
+            IMU        ⚠️  accel_z STDDEV 4.2x the log baseline at t=28s
             GPS        —  skipped: no GPS topic
             Data gaps  ✅  no gap > 3x median interval (checked battery_status_0, sensor_accel_0)
             Errors     ❌  2 ERROR messages, first at t=31s: "failsafe triggered"

--- a/src/agent/diagnose/robot_health.poml
+++ b/src/agent/diagnose/robot_health.poml
@@ -26,14 +26,18 @@
                         <item>
                             <b>ArduPilot (.bin)</b>: `BAT` (power), `IMU`/`VIBE` (IMU),
                             `GPS` (GPS), `MSG` (status text). Only the binary DataFlash
-                            `.bin` format is supported (detected by magic bytes, not
-                            extension); a text-format `.log` export is not recognized and
-                            will fail before any inventory - tell the user to re-export as
+                            format is supported, and the file must carry a lowercase
+                            `.bin` suffix (magic bytes get it recognized, but the source
+                            factory still rejects any other extension); a text-format
+                            `.log` export is not recognized and will fail before any
+                            inventory - tell the user to re-export as
                             `.bin` if that's what they have.
                         </item>
                         <item>
-                            <b>Betaflight (.bbl/.BFL)</b>: `describe_data_source` on a
-                            `.bbl` REQUIRES `args={"log_index": 1}` for the first flight
+                            <b>Betaflight (.bbl/.BFL)</b>: EVERY tool call on a `.bbl`
+                            (`describe_data_source`, `describe_topic`, `query_messages`,
+                            `read_loggings` alike - each reconstructs the source) REQUIRES
+                            `args={"log_index": 1}` for the first flight
                             log - a `.bbl` can combine several flight logs recorded to
                             onboard flash, and there's no default, so the call fails
                             without it. If it errors, the error names the valid index


### PR DESCRIPTION
Codex+Copilot review follow-up on #211: five places in `robot_health.poml` promised behavior the underlying tools don't back. Prompt-text-only fixes, no code changes.

1. ArduPilot: `.bin/.log` -> `.bin` only, with a note that the resolver only recognizes `.bin` (DataFlash magic bytes) and a text-format `.log` export fails before any inventory.
2. IMU instruction: "variance ... several times the overall STDDEV/AVG" was dimensionally invalid (variance is squared units, STDDEV is linear). Now compares windowed STDDEV against overall STDDEV throughout, including the hint's "4.2x the log baseline" example.
3. Betaflight `.bbl`: `describe_data_source` requires `args={"log_index": ...}` (no default in `SourceFactory`). Now instructs `args={"log_index": 1}` for the first flight log (confirmed against `orangebox` - 1-indexed, valid range 1 <= x < log_count), notes a `.bbl` can hold multiple flight logs, and says to adapt from the error if it's out of range.
4. Betaflight `I`/`P` frames: the poml said they carried fields "in one table" - `available_topics` actually exposes `I` and `P` as separate topics and `query_messages` takes one topic. Now instructs querying each separately (`I` = keyframes at a lower rate, `P` = deltas) and not inferring data gaps from either alone.
5. Betaflight `vbatLatest`: no unit or scale is exposed via `describe_topic` (it's a raw int). Now instructs reporting the raw value with an explicit units-unknown caveat instead of asserting volts.

Verified defects 1-5 against `src/di/types/data_source.py` (resolver), `src/source/betaflight/bbl.py` plus the vendored `orangebox` package (log_index semantics), and `src/topic/betaflight/bbl.py` and `schema.py` (topic separation and field names).

Tests: `uv run pytest -q test/agent -p no:cacheprovider` - 53 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
