### PR TITLE
P1/P2: correct pipeline timing, retention, outcomes, and memory use

### DIFF
--- a/doc/runbooks/quality.md
+++ b/doc/runbooks/quality.md
@@ -1,0 +1,34 @@
+# Quality contracts
+
+Pipeline source interpretation belongs in `source_args`, for example
+`source_args: {timestamp_column: t, timestamp_format: seconds}`. Cadence, gates,
+and tasks use the same adapters and timestamp options. Existing operator `setup`
+options are promoted to shared options; conflicting interpretations fail before
+operators are constructed. Cadence intervals must be positive integers; lookbacks
+must be nonnegative; event debounce/forward windows require time units.
+
+Live `once_at_end` runs after subscription shutdown, once, and only if messages
+arrived. Frequency cadence retains its first-message behavior.
+
+`run_pipeline` returns `status: completed`, `partial`, or `failed` and a `runs`
+object with `succeeded`, `skipped`, `failed`, and `errors`. These count cadence runs,
+not individual tasks. `allow_failure` controls continuation, not whether a failed
+run is reported. Batch results also expose partial sources. Artifacts produced
+before a failure remain reported. Callers must handle the new `partial` status.
+
+Previews and reduction share source-bound clipping. `kept_seconds` measures the
+union of windows that intersect the source's timestamp extent, not requested
+time outside the recording. Empty or zero-duration sources report fraction zero.
+The legacy standalone `plan_reduction` helper still accepts a duration without
+bounds; tool and reduce paths always supply explicit bounds.
+
+CSV/JSON readers scan bounded Arrow batches and use DuckDB's external sort to
+preserve timestamp order (including stable ties). Cadence/event scans consume
+bounded result batches. Memory still scales with requested output: a tool that
+returns every row or every detected event necessarily retains that result.
+
+Run the portable suite with isolated test storage through `test/conftest.py`.
+Cache regressions deliberately issue multiple requests within one test. DuckDB
+relations belong to their creating thread; materialize a result before passing it
+between threads. Use `relation.query(name, sql)` instead of registering a Bagel
+relation on DuckDB's global connection.

--- a/server.py
+++ b/server.py
@@ -2,6 +2,7 @@
 
 import logging
 import pathlib
+from dataclasses import asdict
 from typing import Any
 
 import duckdb
@@ -28,6 +29,7 @@ from src.pipeline import (
 )
 from src.pipeline.tasks.waffle import snap as waffle_snap
 from src.sink import startup
+from src.source.context import SourceContext
 
 server = mcp_compat.create_server(
     name="Bagel MCP Server",
@@ -219,14 +221,10 @@ def query_messages(  # noqa: PLR0913
             ... )
 
     """
-    ds_type = resolve(path)
-    factory = module.provide(
-        f"{BaseModule.SOURCE_FACTORY.value}.{ds_type.value}", {**(args or {}), "path": path}
+    source = SourceContext.build(path, args)
+    relation = source.dataset.to_duckdb(
+        source.factory, source.registry, [topic], start_seconds, end_seconds
     )
-    registry = module.provide(f"{BaseModule.TOPIC_REGISTRY.value}.{ds_type.value}", args or {})
-    dataset = module.provide(f"{BaseModule.MESSAGE_DATASET.value}.{ds_type.value}", {})
-
-    relation = dataset.to_duckdb(factory, registry, [topic], start_seconds, end_seconds)
     result = query.sql(relation, topic, sql_statement)
     return result.to_df().to_dict(orient="records")
 
@@ -649,22 +647,23 @@ def preview_pipeline(  # noqa: PLR0913
             ...                  "linear_acceleration_x < -10", pre_seconds=10, post_seconds=10)
 
     """
-    ds_type = resolve(path)
-    factory = module.provide(
-        f"{BaseModule.SOURCE_FACTORY.value}.{ds_type.value}", {**(args or {}), "path": path}
-    )
-    registry = module.provide(f"{BaseModule.TOPIC_REGISTRY.value}.{ds_type.value}", args or {})
-    dataset = module.provide(f"{BaseModule.MESSAGE_DATASET.value}.{ds_type.value}", {})
-
-    relation = dataset.to_duckdb(factory, registry, [event_topic])
+    source = SourceContext.build(path, args)
+    bounds = source.bounds()
+    relation = source.dataset.to_duckdb(source.factory, source.registry, [event_topic])
     ts_column = settings.TIMESTAMP_SECONDS_COLUMN_NAME
-    rows = relation.project(f"{ts_column} AS ts, ({predicate}) AS hit").fetchall()
-
-    timestamps = [float(row[0]) for row in rows]
-    span_seconds = (max(timestamps) - min(timestamps)) if timestamps else 0.0
+    rows = windows.relation_rows(
+        relation.project(f"{ts_column} AS ts, ({predicate}) AS hit").order("ts")
+    )
+    span_seconds = bounds[1] - bounds[0]
 
     plan = windows.plan_reduction(
-        rows, pre_seconds, post_seconds, span_seconds, min_gap_seconds=debounce_seconds
+        rows,
+        pre_seconds,
+        post_seconds,
+        span_seconds,
+        min_gap_seconds=debounce_seconds,
+        bounds=bounds,
+        ordered=True,
     )
     return {
         "event_count": len(plan["events"]),
@@ -751,7 +750,8 @@ def run_pipeline(config: dict[str, Any]) -> dict[str, Any]:
     produced = pipeline.run_all()
     return {
         "pipeline": pipeline.name,
-        "status": "completed",
+        "status": pipeline.summary.status,
+        "runs": asdict(pipeline.summary),
         "artifacts": [str(path) for path in produced],
     }
 

--- a/src/message/base.py
+++ b/src/message/base.py
@@ -180,6 +180,19 @@ class MessageDataset(abc.ABC):
 
         return cache.arrow_relation(arrow_file, schema, batches, self._use_cache)
 
+    def bounds(self, factory: SourceFactory, registry: TopicRegistry) -> tuple[float, float]:
+        """Return the source's overall timestamp bounds, aggregated over all topics.
+
+        Subclasses whose `to_duckdb` expands to every table/measurement when `topics`
+        is omitted (databases, e.g. Postgres/InfluxDB) should override this with a
+        source-specific aggregate over eligible timestamp streams instead of relying
+        on the default full-relation scan below.
+        """
+        relation = self.to_duckdb(factory, registry)
+        timestamp = settings.TIMESTAMP_SECONDS_COLUMN_NAME
+        row = relation.aggregate(f'min("{timestamp}"), max("{timestamp}")').fetchone()
+        return (float(row[0]), float(row[1])) if row and row[0] is not None else (0.0, 0.0)
+
     def _schema(
         self,
         factory: SourceFactory,

--- a/src/message/influxdb.py
+++ b/src/message/influxdb.py
@@ -70,6 +70,30 @@ class MessageDataset(base.MessageDataset):
             f"struct_pack({packed}) AS {quote_identifier(topic)}"
         )
 
+    def bounds(self, factory: SourceFactory, registry: TopicRegistry) -> tuple[float, float]:
+        """Aggregate MIN/MAX time per measurement instead of downloading every row.
+
+        Unlike `to_duckdb()` (which downloads and struct-packs every measurement's
+        full rows to build a relation), this only needs each measurement's min/max
+        `time`, computed by InfluxDB itself. `epoch()` on the Arrow result matches
+        the seconds conversion `_topic_relation` uses for the full relation.
+        """
+        data_source = factory.build()
+        lo: float | None = None
+        hi: float | None = None
+        for topic in registry.available_topics(data_source):
+            arrow_table = data_source.client.query(
+                f'SELECT MIN(time) AS lo, MAX(time) AS hi FROM "{topic}"'  # noqa: S608
+            )
+            if arrow_table.num_rows == 0:
+                continue
+            row = from_arrow(arrow_table).aggregate("epoch(min(lo)), epoch(max(hi))").fetchone()
+            if row is None or row[0] is None:
+                continue
+            lo = float(row[0]) if lo is None else min(lo, float(row[0]))
+            hi = float(row[1]) if hi is None else max(hi, float(row[1]))
+        return (lo, hi) if lo is not None and hi is not None else (0.0, 0.0)
+
     def to_duckdb(  # noqa: PLR0913
         self,
         factory: SourceFactory,

--- a/src/message/postgres.py
+++ b/src/message/postgres.py
@@ -58,6 +58,33 @@ class MessageDataset(base.MessageDataset):
             f"WHERE {' AND '.join(conditions)}"
         )
 
+    def bounds(self, factory: SourceFactory, registry: TopicRegistry) -> tuple[float, float]:
+        """Aggregate MIN/MAX directly over tables with a detectable timestamp column.
+
+        Unlike `to_duckdb()` (which struct-packs every column of every table to build
+        a full relation), this only needs each eligible table's timestamp column, and
+        it must not fail merely because some unrelated table has none -- an event
+        table with a valid timestamp column must still yield bounds even if the
+        database also holds tables `timestamp_column` cannot interpret.
+        """
+        data_source = factory.build()
+        aggregates = []
+        for topic in registry.available_topics(data_source):
+            try:
+                timestamp_column = quote_identifier(data_source.timestamp_column(topic))
+            except ValueError:
+                continue
+            aggregates.append(
+                f"SELECT epoch(MIN({timestamp_column})) AS lo, "  # noqa: S608
+                f"epoch(MAX({timestamp_column})) AS hi "
+                f"FROM {data_source.relation_name(topic)}"
+            )
+        if not aggregates:
+            return (0.0, 0.0)
+        query = " UNION ALL ".join(f"({aggregate})" for aggregate in aggregates)
+        row = connection().sql(f"SELECT MIN(lo), MAX(hi) FROM ({query})").fetchone()  # noqa: S608
+        return (float(row[0]), float(row[1])) if row and row[0] is not None else (0.0, 0.0)
+
     def to_duckdb(  # noqa: PLR0913
         self,
         factory: SourceFactory,

--- a/src/message/pyarrow/base.py
+++ b/src/message/pyarrow/base.py
@@ -1,11 +1,12 @@
 """A message dataset for PyArrow dataset."""
 
-import heapq
 from collections.abc import Iterator
 from typing import Any
 
+import duckdb
 import pyarrow as pa
 
+from src import query
 from src.message import base
 from src.source import errors
 from src.source.pyarrow.base import PyArrowDataset
@@ -25,33 +26,58 @@ class MessageDataset(base.MessageDataset):
         if topics != [TOPIC_NAME]:
             raise ValueError(f"Only '{TOPIC_NAME}' topic is supported for PyArrow data source.")
 
-        heap = []
-
         # dataset construction (_build(), src/source/pyarrow/base.py) can succeed
         # while still holding an unreadable file: e.g. a directory whose schema is
         # taken from one valid file, alongside a malformed sibling that only fails
         # once actually scanned. to_table() is where that scan -- and thus the raw
         # pyarrow.lib.ArrowInvalid/ArrowTypeError (ArrowException) -- happens.
         try:
-            rows = data_source.dataset.to_table().to_pylist()
-        except pa.ArrowException as exc:
+            schema = pa.schema(
+                [
+                    ("ts", pa.float64()),
+                    ("ordinal", pa.int64()),
+                    ("message", pa.struct(data_source.dataset.schema)),
+                ]
+            )
+            reader = pa.RecordBatchReader.from_batches(
+                schema,
+                self._timestamped_batches(
+                    data_source, schema, start_seconds_inclusive, end_seconds_inclusive
+                ),
+            )
+            # DuckDB sorts Arrow batches with disk spill rather than a Python heap
+            # containing the complete decoded source. Ordinal preserves tied timestamps.
+            ordered = query.from_arrow(reader).order("ts, ordinal")
+            while rows := ordered.fetchmany(8192):
+                for timestamp, _, message in rows:
+                    yield (TOPIC_NAME, timestamp, message)
+        except (pa.ArrowException, duckdb.Error) as exc:
             files = getattr(data_source.dataset, "files", None)
             location = ", ".join(files) if files else "the PyArrow dataset"
             raise errors.InvalidPathError(
                 f"{location} could not be parsed: {type(exc).__name__}: {exc}"
             ) from exc
 
-        for tie_breaker, msg in enumerate(rows):
-            timestamp_seconds = data_source.extract_timestamp_seconds(msg)
-            if end_seconds_inclusive is not None and timestamp_seconds > end_seconds_inclusive:
-                continue
-            if start_seconds_inclusive is not None and timestamp_seconds < start_seconds_inclusive:
-                continue
-            heapq.heappush(heap, (timestamp_seconds, tie_breaker, msg))
-
-        while heap:
-            timestamp_seconds, _, msg = heapq.heappop(heap)
-            yield (TOPIC_NAME, timestamp_seconds, msg)
+    def _timestamped_batches(
+        self,
+        data_source: PyArrowDataset,
+        schema: pa.Schema,
+        start_seconds: float | None,
+        end_seconds: float | None,
+    ) -> Iterator[pa.RecordBatch]:
+        ordinal = 0
+        for batch in data_source.dataset.to_batches(batch_size=8192):
+            records = []
+            for msg in batch.to_pylist():
+                timestamp = data_source.extract_timestamp_seconds(msg)
+                ordinal += 1
+                if start_seconds is not None and timestamp < start_seconds:
+                    continue
+                if end_seconds is not None and timestamp > end_seconds:
+                    continue
+                records.append({"ts": timestamp, "ordinal": ordinal, "message": msg})
+            if records:
+                yield pa.RecordBatch.from_pylist(records, schema=schema)
 
     def _to_json(self, message: object, struct: pa.StructType) -> dict[str, Any]:
         return message

--- a/src/pipeline/base.py
+++ b/src/pipeline/base.py
@@ -11,14 +11,14 @@ from typing import Any
 import boto3
 import botocore
 import duckdb
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from settings import settings
 from src import artifacts
 from src.di import module
-from src.di.types.base_module import BaseModule
-from src.di.types.data_source import resolve
 from src.pipeline import progress, windows
+from src.pipeline.results import RunSummary
+from src.source.context import SourceContext
 
 SECOND = 1
 MINUTE = 60 * SECOND
@@ -70,7 +70,7 @@ class Frequency(BaseModel):
 
     """
 
-    every: int
+    every: int = Field(gt=0, strict=True)
     unit: Unit
 
     def to_seconds(self) -> float:
@@ -87,7 +87,7 @@ class Lookback(BaseModel):
 
     """
 
-    last: int
+    last: int = Field(ge=0, strict=True)
     unit: Unit
 
     def to_seconds(self) -> float:
@@ -120,9 +120,17 @@ class OnEvent(BaseModel):
 
     """
 
-    predicate: str
+    predicate: str = Field(min_length=1)
     debounce: Lookback | None = None
     forward: Lookback | None = None
+
+    @field_validator("debounce", "forward")
+    @classmethod
+    def require_time_unit(cls, value: Lookback | None) -> Lookback | None:
+        """Event delays are elapsed time, not frame counts."""
+        if value is not None and value.unit == Unit.FRAME:
+            raise ValueError("Event debounce and forward windows require a time unit")
+        return value
 
     def min_gap_seconds(self) -> float:
         """Minimum seconds required between consecutive events; 0 if no debounce is set."""
@@ -147,7 +155,7 @@ class Cadence(BaseModel):
 
     """
 
-    topic: str
+    topic: str = Field(min_length=1)
     when: OnceAtEnd | Frequency | OnEvent
 
     @staticmethod
@@ -357,6 +365,38 @@ class ArtifactMixin:
         return path
 
 
+class PipelineConfig(BaseModel):
+    """Validate configuration before operators acquire resources or produce effects."""
+
+    model_config = ConfigDict(extra="forbid")
+    name: str = Field(pattern=r"^[a-z0-9]+(?:_[a-z0-9]+)*$")
+    site: str = Field(pattern=r"^[a-z0-9]+(?:_[a-z0-9]+)*$")
+    asset: str = Field(pattern=r"^[a-z0-9]+(?:_[a-z0-9]+)*$")
+    path: str = Field(min_length=1)
+    allow_failure: bool = Field(strict=True)
+    cadence: dict[str, Any]
+    gates: list[dict[str, Any]] = Field(default_factory=list)
+    tasks: list[dict[str, Any]]
+    source_args: dict[str, Any] = Field(default_factory=dict)
+    report_progress: bool = False
+
+
+def _shared_source_options(config: dict[str, Any]) -> dict[str, Any]:
+    """Normalize legacy setup options and reject conflicting source interpretations."""
+    options = dict(config["source_args"])
+    operators = [*config["gates"], *config["tasks"]]
+    for operator in operators:
+        if "lookback" in operator:
+            Lookback.build(operator["lookback"])
+        for key, value in operator.get("setup", {}).items():
+            if key in options and options[key] != value:
+                raise ValueError(f"Conflicting source option {key!r}; use shared source_args")
+            options[key] = value
+    for operator in operators:
+        operator["setup"] = {**options, **operator.get("setup", {})}
+    return options
+
+
 class Pipeline:
     """A data processing pipeline consisting of gates and tasks.
 
@@ -376,6 +416,7 @@ class Pipeline:
         gates: list[tuple[Gate, Lookback | None]],
         tasks: list[tuple[Task, Lookback | None]],
         report_progress: bool,
+        source_args: dict[str, Any] | None = None,
     ) -> None:
         """Initialize a Pipeline instance.
 
@@ -391,6 +432,7 @@ class Pipeline:
             tasks (list[tuple[Task, Lookback  |  None]]): List of task operators and their
                 lookback windows.
             report_progress (bool): Whether to report progress during artifact uploads.
+            source_args: Shared source decoding and timestamp options.
 
         """
         if not artifacts.is_lower_snake_case(name):
@@ -414,6 +456,8 @@ class Pipeline:
         self._report_progress = report_progress
         self._artifacts = []
         self._produced: list[pathlib.Path] = []
+        self._source_args = source_args or {}
+        self.summary = RunSummary()
 
     @property
     def name(self) -> str:
@@ -436,18 +480,12 @@ class Pipeline:
         return self._cadence
 
     def _asof_timestamps(self) -> Iterator[float]:
-        ds_type = resolve(self._path)
-
-        factory = module.provide(
-            f"{BaseModule.SOURCE_FACTORY.value}.{ds_type.value}", {"path": self._path}
-        )
-        registry = module.provide(f"{BaseModule.TOPIC_REGISTRY.value}.{ds_type.value}", {})
-        dataset = module.provide(f"{BaseModule.MESSAGE_DATASET.value}.{ds_type.value}", {})
+        source = SourceContext.build(self._path, self._source_args)
 
         logging.info("Gathering timestamps for pipeline '%s'...", self.name)
-        relation = dataset.to_duckdb(
-            factory=factory,
-            registry=registry,
+        relation = source.dataset.to_duckdb(
+            factory=source.factory,
+            registry=source.registry,
             topics=[self.cadence.topic],
             start_seconds=None,
             end_seconds=None,
@@ -456,17 +494,18 @@ class Pipeline:
             yield from self._event_timestamps(relation, self.cadence.when)
             return
 
-        rows = relation.project(settings.TIMESTAMP_SECONDS_COLUMN_NAME).fetchall()
-        timestamps = [float(row[0]) for row in rows]
-
-        if not timestamps:
-            return
-
         if isinstance(self.cadence.when, OnceAtEnd):
-            yield timestamps[-1]
+            row = relation.aggregate(f'max("{settings.TIMESTAMP_SECONDS_COLUMN_NAME}")').fetchone()
+            if row and row[0] is not None:
+                yield float(row[0])
         else:
             last_run_at = None
-            for i, timestamp_seconds in enumerate(timestamps):
+            timestamps = windows.relation_rows(
+                relation.project(settings.TIMESTAMP_SECONDS_COLUMN_NAME).order(
+                    settings.TIMESTAMP_SECONDS_COLUMN_NAME
+                )
+            )
+            for i, (timestamp_seconds,) in enumerate(timestamps):
                 match self.cadence.when.unit:
                     case Unit.FRAME:
                         if i % self.cadence.when.every == 0:
@@ -489,8 +528,10 @@ class Pipeline:
         Consecutive events closer together than the debounce window are coalesced.
         """
         ts_column = settings.TIMESTAMP_SECONDS_COLUMN_NAME
-        rows = relation.project(f"{ts_column} AS ts, ({when.predicate}) AS hit").fetchall()
-        yield from windows.rising_edges(rows, when.min_gap_seconds())
+        rows = windows.relation_rows(
+            relation.project(f"{ts_column} AS ts, ({when.predicate}) AS hit").order("ts")
+        )
+        yield from windows.iter_rising_edges(rows, when.min_gap_seconds())
 
     def run_at(self, asof_seconds: float) -> None:
         """Run the pipeline at the given timestamp (in seconds)."""
@@ -502,6 +543,7 @@ class Pipeline:
                         self._produced.extend(produced)
                     if task.upload and produced and self.can_upload_artifacts():
                         self._artifacts.extend(produced)
+                self.summary.succeeded += 1
                 logging.info(
                     "Pipeline '%s' executed when topic '%s' received message at %.4f seconds",
                     self.name,
@@ -509,6 +551,7 @@ class Pipeline:
                     asof_seconds,
                 )
             else:
+                self.summary.skipped += 1
                 logging.info(
                     "Pipeline '%s' skipped when topic '%s' received message at %.4f seconds",
                     self.name,
@@ -516,8 +559,10 @@ class Pipeline:
                     asof_seconds,
                 )
         except Exception as e:
+            self.summary.failed += 1
+            self.summary.errors.append(f"At {asof_seconds}: {type(e).__name__}: {e}")
             if not self._allow_failure:
-                raise e
+                raise
             logging.error(
                 "Pipeline '%s' failed when topic '%s' received message at %.4f seconds: %s",
                 self.name,
@@ -551,6 +596,10 @@ class Pipeline:
         if missing_keys:
             raise MissingRequiredKeyError(", ".join(missing_keys))
 
+        config = PipelineConfig.model_validate(config).model_dump()
+        cadence = Cadence.build(config["cadence"])
+        source_args = _shared_source_options(config)
+
         pipeline = config["name"]
         site = config["site"]
         asset = config["asset"]
@@ -580,10 +629,11 @@ class Pipeline:
             asset=asset,
             path=path,
             allow_failure=config["allow_failure"],
-            cadence=Cadence.build(config["cadence"]),
+            cadence=cadence,
             gates=gates,
             tasks=tasks,
             report_progress=config.get("report_progress", False),
+            source_args=source_args,
         )
 
     def can_upload_artifacts(self) -> bool:

--- a/src/pipeline/batch.py
+++ b/src/pipeline/batch.py
@@ -8,6 +8,7 @@ source does not abort the batch -- failures are reported per path.
 
 import glob
 import logging
+from dataclasses import asdict
 from typing import Any
 
 from src.pipeline import base
@@ -58,7 +59,8 @@ def run_batch(config: dict[str, Any], paths: list[str]) -> list[dict[str, Any]]:
             results.append(
                 {
                     "path": path,
-                    "status": "completed",
+                    "status": pipeline.summary.status,
+                    "runs": asdict(pipeline.summary),
                     "artifacts": [str(artifact) for artifact in produced],
                 }
             )
@@ -72,10 +74,12 @@ def summarize(results: list[dict[str, Any]]) -> dict[str, Any]:
     """Summarize batch results: source counts and total artifacts produced."""
     completed = [result for result in results if result["status"] == "completed"]
     failed = [result for result in results if result["status"] == "failed"]
+    partial = [result for result in results if result["status"] == "partial"]
     return {
         "sources": len(results),
         "completed": len(completed),
         "failed": len(failed),
-        "artifacts": sum(len(result.get("artifacts", [])) for result in completed),
+        "partial": len(partial),
+        "artifacts": sum(len(result.get("artifacts", [])) for result in results),
         "results": results,
     }

--- a/src/pipeline/messages.py
+++ b/src/pipeline/messages.py
@@ -3,12 +3,10 @@
 import duckdb
 
 from settings import settings
-from src.di import module
-from src.di.types.base_module import BaseModule
-from src.di.types.data_source import resolve
 from src.message.base import MessageDataset
 from src.pipeline import base
 from src.source.base import BoundedSourceFactory, SourceFactory
+from src.source.context import SourceContext
 from src.topic.base import TopicRegistry
 
 
@@ -36,15 +34,12 @@ class TopicMessageMixin:
 
     def setup(self, path: str, **kwargs) -> None:  # noqa: ANN003
         """Implement `base.Operator.setup`."""
-        ds_type = resolve(path)
-
-        factory_module = f"{BaseModule.SOURCE_FACTORY.value}.{ds_type.value}"
-        registry_module = f"{BaseModule.TOPIC_REGISTRY.value}.{ds_type.value}"
-        dataset_module = f"{BaseModule.MESSAGE_DATASET.value}.{ds_type.value}"
-
-        self._factory = module.provide(factory_module, {**kwargs, "path": path})
-        self._registry = module.provide(registry_module, {**kwargs})
-        self._dataset = module.provide(dataset_module, {**kwargs})
+        source = SourceContext.build(path, kwargs)
+        self._factory, self._registry, self._dataset = (
+            source.factory,
+            source.registry,
+            source.dataset,
+        )
 
     def to_duckdb(
         self,

--- a/src/pipeline/results.py
+++ b/src/pipeline/results.py
@@ -1,0 +1,21 @@
+"""Structured pipeline execution outcomes, including permitted failures."""
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+
+@dataclass
+class RunSummary:
+    """Count completed, skipped, and failed cadence runs."""
+
+    succeeded: int = 0
+    skipped: int = 0
+    failed: int = 0
+    errors: list[str] = field(default_factory=list)
+
+    @property
+    def status(self) -> Literal["completed", "partial", "failed"]:
+        """Distinguish successful completion from tolerated failures."""
+        if self.failed:
+            return "partial" if self.succeeded else "failed"
+        return "completed"

--- a/src/pipeline/tasks/reduce/base.py
+++ b/src/pipeline/tasks/reduce/base.py
@@ -2,6 +2,7 @@
 
 from settings import settings
 from src.pipeline import windows
+from src.source.context import SourceContext
 
 
 class ReduceMixin:
@@ -20,10 +21,17 @@ class ReduceMixin:
         """
         relation = self.to_duckdb(topics=[self._event_topic], asof_seconds=asof_seconds)
         ts_column = settings.TIMESTAMP_SECONDS_COLUMN_NAME
-        rows = relation.project(f"{ts_column} AS ts, ({self._predicate}) AS hit").fetchall()
-
-        events = windows.rising_edges(rows, self._debounce_seconds)
-        intervals = windows.merge_intervals(
-            windows.event_windows(events, self._pre_seconds, self._post_seconds)
+        rows = windows.relation_rows(
+            relation.project(f"{ts_column} AS ts, ({self._predicate}) AS hit").order("ts")
         )
-        return events, intervals
+        bounds = SourceContext(self.factory, self.registry, self.dataset).bounds()
+        plan = windows.plan_reduction(
+            rows,
+            self._pre_seconds,
+            self._post_seconds,
+            bounds[1] - bounds[0],
+            self._debounce_seconds,
+            bounds=bounds,
+            ordered=True,
+        )
+        return plan["events"], plan["intervals"]

--- a/src/pipeline/windows.py
+++ b/src/pipeline/windows.py
@@ -5,8 +5,38 @@ Pure functions shared by the `OnEvent` cadence, the reduce task, and the
 operates on timestamps and intervals, so it is cheap to unit test.
 """
 
-from collections.abc import Iterable, Sequence
+import math
+from collections.abc import Iterable, Iterator, Sequence
 from typing import Any
+
+import duckdb
+
+
+def relation_rows(relation: duckdb.DuckDBPyRelation) -> Iterator[tuple]:
+    """Consume ordered results in bounded batches without a whole-source row list."""
+    while rows := relation.fetchmany(8192):
+        yield from rows
+
+
+def iter_rising_edges(
+    samples: Iterable[tuple[float, Any]], min_gap_seconds: float = 0.0
+) -> Iterator[float]:
+    """Find edges in an ordered stream using constant state."""
+    if not math.isfinite(min_gap_seconds) or min_gap_seconds < 0:
+        raise ValueError("min_gap_seconds must be finite and non-negative")
+    previous_hit = False
+    last_edge: float | None = None
+    for raw_timestamp, raw_hit in samples:
+        hit = bool(raw_hit)
+        timestamp = float(raw_timestamp)
+        if (
+            hit
+            and not previous_hit
+            and (last_edge is None or timestamp - last_edge >= min_gap_seconds)
+        ):
+            last_edge = timestamp
+            yield timestamp
+        previous_hit = hit
 
 
 def rising_edges(samples: Iterable[tuple[float, Any]], min_gap_seconds: float = 0.0) -> list[float]:
@@ -29,18 +59,7 @@ def rising_edges(samples: Iterable[tuple[float, Any]], min_gap_seconds: float = 
 
     """
     ordered = sorted(samples, key=lambda sample: sample[0])
-    edges: list[float] = []
-    previous_hit = False
-    last_edge_at: float | None = None
-    for raw_timestamp, raw_hit in ordered:
-        hit = bool(raw_hit)
-        if hit and not previous_hit:
-            timestamp_seconds = float(raw_timestamp)
-            if last_edge_at is None or timestamp_seconds - last_edge_at >= min_gap_seconds:
-                last_edge_at = timestamp_seconds
-                edges.append(timestamp_seconds)
-        previous_hit = hit
-    return edges
+    return list(iter_rising_edges(ordered, min_gap_seconds))
 
 
 def event_windows(
@@ -52,8 +71,8 @@ def event_windows(
         ValueError: If ``pre_seconds`` or ``post_seconds`` is negative.
 
     """
-    if pre_seconds < 0 or post_seconds < 0:
-        raise ValueError("pre_seconds and post_seconds must be non-negative.")
+    if any(not math.isfinite(value) or value < 0 for value in (pre_seconds, post_seconds)):
+        raise ValueError("pre_seconds and post_seconds must be finite and non-negative.")
     return [(float(event) - pre_seconds, float(event) + post_seconds) for event in events]
 
 
@@ -82,12 +101,15 @@ def total_duration(intervals: Sequence[tuple[float, float]]) -> float:
     return sum(end - start for start, end in intervals)
 
 
-def plan_reduction(
+def plan_reduction(  # noqa: PLR0913 -- preserve positional API; bounds/order are keyword-only
     samples: Iterable[tuple[float, Any]],
     pre_seconds: float,
     post_seconds: float,
     span_seconds: float,
     min_gap_seconds: float = 0.0,
+    *,
+    bounds: tuple[float, float] | None = None,
+    ordered: bool = False,
 ) -> dict[str, Any]:
     """Compute the full reduction plan from predicate samples.
 
@@ -101,14 +123,26 @@ def plan_reduction(
         post_seconds: Seconds to keep after each event.
         span_seconds: Total time span of the source, used for the kept fraction.
         min_gap_seconds: Debounce window between consecutive events.
+        bounds: Whole-source start/end; clip windows to data that actually exists.
+        ordered: Stream pre-sorted samples without sorting them in Python.
 
     Returns:
         A dict with ``events`` (list of timestamps), ``intervals`` (merged kept
         windows), ``kept_seconds``, ``total_seconds``, and ``kept_fraction``.
 
     """
-    events = rising_edges(samples, min_gap_seconds)
+    events = (
+        list(iter_rising_edges(samples, min_gap_seconds))
+        if ordered
+        else rising_edges(samples, min_gap_seconds)
+    )
     intervals = merge_intervals(event_windows(events, pre_seconds, post_seconds))
+    if bounds is not None:
+        start, end = bounds
+        if not all(math.isfinite(value) for value in bounds) or end < start:
+            raise ValueError("Source bounds must be finite and ordered")
+        intervals = merge_intervals((max(a, start), min(b, end)) for a, b in intervals)
+        span_seconds = end - start
     kept_seconds = total_duration(intervals)
     return {
         "events": events,

--- a/src/sink/buffer.py
+++ b/src/sink/buffer.py
@@ -16,7 +16,7 @@ import yaml
 
 from settings import settings
 from src.pipeline import live
-from src.pipeline.base import Cadence, Frequency, OnEvent, Pipeline, Unit
+from src.pipeline.base import Cadence, Frequency, OnceAtEnd, OnEvent, Pipeline, Unit
 
 
 def _topic_uuid(topic: str) -> str:
@@ -227,6 +227,8 @@ class TopicBufferWriter:
     def _should_run(
         self, cadence: Cadence, message_count: int, last_run_at: float | None, asof_seconds: float
     ) -> bool:
+        if isinstance(cadence.when, OnceAtEnd):
+            return False
         if last_run_at is None:
             return True
 

--- a/src/source/context.py
+++ b/src/source/context.py
@@ -3,9 +3,6 @@
 from dataclasses import dataclass
 from typing import Any, cast
 
-import duckdb
-
-from settings import settings
 from src.di import module
 from src.di.types.base_module import BaseModule
 from src.di.types.data_source import resolve
@@ -47,12 +44,4 @@ class SourceContext:
         """Return whole-source bounds, not just the event topic's observed span."""
         if isinstance(self.factory, BoundedSourceFactory):
             return self.factory.start_seconds, self.factory.end_seconds
-        relation = self.dataset.to_duckdb(self.factory, self.registry)
-        return relation_bounds(relation)
-
-
-def relation_bounds(relation: duckdb.DuckDBPyRelation) -> tuple[float, float]:
-    """Aggregate a relation's timestamp bounds without materializing its rows."""
-    timestamp = settings.TIMESTAMP_SECONDS_COLUMN_NAME
-    row = relation.aggregate(f'min("{timestamp}"), max("{timestamp}")').fetchone()
-    return (float(row[0]), float(row[1])) if row and row[0] is not None else (0.0, 0.0)
+        return self.dataset.bounds(self.factory, self.registry)

--- a/src/source/context.py
+++ b/src/source/context.py
@@ -1,0 +1,58 @@
+"""Construct the same source adapters for tools, cadence discovery, and operators."""
+
+from dataclasses import dataclass
+from typing import Any, cast
+
+import duckdb
+
+from settings import settings
+from src.di import module
+from src.di.types.base_module import BaseModule
+from src.di.types.data_source import resolve
+from src.message.base import MessageDataset
+from src.source.base import BoundedSourceFactory, SourceFactory
+from src.topic.base import TopicRegistry
+
+
+@dataclass
+class SourceContext:
+    """The adapters interpreting one source with one set of decoding options."""
+
+    factory: SourceFactory
+    registry: TopicRegistry
+    dataset: MessageDataset
+
+    @classmethod
+    def build(cls, path: str, args: dict[str, Any] | None = None) -> "SourceContext":
+        """Construct adapters, preserving the explicit source path over any args path."""
+        kind = resolve(path).value
+        options = args or {}
+        return cls(
+            cast(
+                SourceFactory,
+                module.provide(
+                    f"{BaseModule.SOURCE_FACTORY.value}.{kind}", {**options, "path": path}
+                ),
+            ),
+            cast(
+                TopicRegistry, module.provide(f"{BaseModule.TOPIC_REGISTRY.value}.{kind}", options)
+            ),
+            cast(
+                MessageDataset,
+                module.provide(f"{BaseModule.MESSAGE_DATASET.value}.{kind}", options),
+            ),
+        )
+
+    def bounds(self) -> tuple[float, float]:
+        """Return whole-source bounds, not just the event topic's observed span."""
+        if isinstance(self.factory, BoundedSourceFactory):
+            return self.factory.start_seconds, self.factory.end_seconds
+        relation = self.dataset.to_duckdb(self.factory, self.registry)
+        return relation_bounds(relation)
+
+
+def relation_bounds(relation: duckdb.DuckDBPyRelation) -> tuple[float, float]:
+    """Aggregate a relation's timestamp bounds without materializing its rows."""
+    timestamp = settings.TIMESTAMP_SECONDS_COLUMN_NAME
+    row = relation.aggregate(f'min("{timestamp}"), max("{timestamp}")').fetchone()
+    return (float(row[0]), float(row[1])) if row and row[0] is not None else (0.0, 0.0)

--- a/test/pipeline/test_execution_correctness.py
+++ b/test/pipeline/test_execution_correctness.py
@@ -1,0 +1,118 @@
+"""Cadence validation, consistent source time, and truthful outcomes."""
+
+from collections.abc import Iterator
+from unittest.mock import Mock
+
+import pytest
+
+import server
+from src.pipeline import base, windows
+
+
+def _config() -> dict:
+    return {
+        "name": "review",
+        "site": "test",
+        "asset": "robot",
+        "path": "data/sample/pyarrow/csv/flight.csv",
+        "allow_failure": False,
+        "source_args": {"timestamp_column": "t", "timestamp_format": "seconds"},
+        "cadence": {"topic": "message", "when": "once_at_end"},
+        "tasks": [],
+    }
+
+
+@pytest.mark.parametrize("every", [0, -1, True])
+def test_invalid_frequency_is_rejected_before_source_access(every: int) -> None:
+    config = _config()
+    config["path"] = "/missing.csv"
+    config["cadence"]["when"] = {"every": every, "unit": "frame"}
+    with pytest.raises(ValueError):
+        base.Pipeline.build(config)
+
+
+def test_negative_lookback_and_frame_event_delay_are_rejected() -> None:
+    with pytest.raises(ValueError):
+        base.Lookback(last=-1, unit=base.Unit.SECOND)
+    with pytest.raises(ValueError, match="time unit"):
+        base.OnEvent(predicate="TRUE", forward=base.Lookback(last=1, unit=base.Unit.FRAME))
+
+
+def test_cadence_uses_shared_source_timestamp_options() -> None:
+    pipeline = base.Pipeline.build(_config())
+    assert list(pipeline._asof_timestamps()) == [59.5]
+
+
+def test_legacy_setup_is_shared_with_cadence() -> None:
+    config = _config()
+    config["tasks"] = [
+        {
+            "module": "src.pipeline.tasks.write_topics_to_file",
+            "setup": config.pop("source_args"),
+            "args": {"topics": ["message"], "output_format": "csv"},
+        }
+    ]
+    pipeline = base.Pipeline.build(config)
+    assert list(pipeline._asof_timestamps()) == [59.5]
+    assert "setup" in config["tasks"][0]
+
+
+def test_conflicting_source_options_fail_before_operator_import() -> None:
+    config = _config()
+    config["tasks"] = [{"module": "missing.module", "setup": {"timestamp_column": "other"}}]
+    with pytest.raises(ValueError, match="Conflicting source option"):
+        base.Pipeline.build(config)
+
+
+def test_permitted_failures_do_not_report_completed(monkeypatch: pytest.MonkeyPatch) -> None:
+    config = _config()
+    config["allow_failure"] = True
+    pipeline = base.Pipeline.build(config)
+    task = Mock(upload=False)
+    task.execute.side_effect = ValueError("broken task")
+    pipeline._tasks = [(task, None)]
+    monkeypatch.setattr(base.Pipeline, "build", lambda config: pipeline)
+    result = server.run_pipeline(config)
+    assert result["status"] == "failed"
+    assert result["runs"]["failed"] == 1
+    assert "broken task" in result["runs"]["errors"][0]
+    task.execute.side_effect = None
+    task.execute.return_value = None
+    pipeline.run_at(61.0)
+    assert pipeline.summary.status == "partial"
+
+
+def test_gate_skip_is_counted() -> None:
+    pipeline = base.Pipeline.build(_config())
+    gate = Mock()
+    gate.evaluate.return_value = False
+    pipeline._gates = [(gate, None)]
+    pipeline.run_at(60.0)
+    assert pipeline.summary.skipped == 1
+    assert pipeline.summary.failed == pipeline.summary.succeeded == 0
+
+
+def test_retention_is_clipped_to_source_bounds() -> None:
+    plan = windows.plan_reduction([(0.0, True), (10.0, False)], 20, 20, 10, bounds=(0, 10))
+    assert plan["intervals"] == [(0, 10)]
+    assert plan["kept_seconds"] == 10
+    assert plan["kept_fraction"] == 1
+
+
+def test_sorted_event_stream_is_consumed_incrementally() -> None:
+    consumed = []
+
+    def samples() -> Iterator[tuple[float, bool]]:
+        for index in range(100_000):
+            consumed.append(index)
+            yield float(index), index % 2 == 0
+
+    events = windows.iter_rising_edges(samples())
+    assert next(events) == 0
+    assert consumed == [0]
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), -1])
+def test_invalid_window_values_are_rejected(value: float) -> None:
+    with pytest.raises(ValueError):
+        windows.plan_reduction([(0.0, True)], value, 0, 1)

--- a/test/pipeline/test_preview_pipeline.py
+++ b/test/pipeline/test_preview_pipeline.py
@@ -48,7 +48,7 @@ def test_preview_windows_merge_when_overlapping() -> None:
     )
     assert result["event_count"] == 2
     assert len(result["intervals"]) == 1
-    assert result["intervals"][0] == {"start_seconds": 0.0, "end_seconds": 65.0}
+    assert result["intervals"][0] == {"start_seconds": 0.0, "end_seconds": 59.5}
 
 
 def test_preview_no_events_keeps_nothing() -> None:

--- a/test/pipeline/test_streaming_memory.py
+++ b/test/pipeline/test_streaming_memory.py
@@ -1,0 +1,36 @@
+"""Reader memory and ordering regressions over generated CSV data."""
+
+import pathlib
+import tracemalloc
+
+from src.message.pyarrow.csv import MessageDataset
+from src.source.pyarrow.csv import SourceFactory
+
+
+def test_csv_reader_memory_does_not_scale_with_decoded_file(tmp_path: pathlib.Path) -> None:
+    path = tmp_path / "wide.csv"
+    with path.open("w") as stream:
+        stream.write("t,value\n")
+        for index in range(120_000):
+            stream.write(f"{index},{'x' * 500}\n")
+    source = SourceFactory(str(path), timestamp_column="t", timestamp_format="seconds").build()
+    tracemalloc.start()
+    try:
+        count = sum(1 for _ in MessageDataset()._messages(source, ["message"], None, None))
+        _, peak = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+    assert count == 120_000
+    assert peak < 40 * 1024 * 1024, f"decoded Python memory grew to {peak} bytes"
+
+
+def test_streaming_sort_preserves_ties_and_filters_window(tmp_path: pathlib.Path) -> None:
+    path = tmp_path / "unordered.csv"
+    path.write_text("t,value\n3,last\n1,first\n2,a\n2,b\n0,excluded\n")
+    source = SourceFactory(str(path), timestamp_column="t", timestamp_format="seconds").build()
+    messages = list(MessageDataset()._messages(source, ["message"], 1, 2))
+    assert [(timestamp, row["value"]) for _, timestamp, row in messages] == [
+        (1, "first"),
+        (2, "a"),
+        (2, "b"),
+    ]

--- a/test/sink/test_buffer.py
+++ b/test/sink/test_buffer.py
@@ -3,11 +3,14 @@
 import json
 import pathlib
 import threading
+from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pyarrow as pa
 import pytest
 
-from src.pipeline.base import Cadence, Frequency, Lookback, OnEvent, Unit
+from src.pipeline.base import Cadence, Frequency, Lookback, OnceAtEnd, OnEvent, Unit
+from src.sink.base import TopicSink
 from src.sink.buffer import TopicBufferReader, TopicBufferWriter, _artifact_paths
 
 TOPIC = "/imu"
@@ -35,6 +38,7 @@ class PipelineStub:
     """Duck-typed stand-in: the writer only touches `.cadence` and `.run_at`."""
 
     def __init__(self, when: object) -> None:
+        self.name = "stub"
         self.cadence = Cadence(topic=TOPIC, when=when)
         self.ran_at: list[float] = []
 
@@ -159,3 +163,33 @@ def test_concurrent_writers_do_not_corrupt_the_buffer(tmp_path: pathlib.Path) ->
 def test_reader_requires_an_existing_buffer(tmp_path: pathlib.Path) -> None:
     with pytest.raises(FileNotFoundError):
         TopicBufferReader(tmp_path, "/never_written")
+
+
+def test_once_at_end_never_runs_from_append(tmp_path: pathlib.Path) -> None:
+    pipeline = PipelineStub(OnceAtEnd())
+    writer = make_writer(tmp_path, pipeline=pipeline)
+    for timestamp in (1.0, 2.0):
+        writer.append({"x": timestamp, "note": "end-only"})
+    assert pipeline.ran_at == []
+    assert writer.last_timestamp_seconds == 2.0
+
+
+@pytest.mark.parametrize("timestamps", [[], [1.0], [1.0, 2.0]])
+def test_once_at_end_runs_only_once_when_sink_closes(
+    tmp_path: pathlib.Path, timestamps: list[float]
+) -> None:
+    pipeline = PipelineStub(OnceAtEnd())
+    writer = make_writer(tmp_path, pipeline=pipeline)
+    for timestamp in timestamps:
+        writer.append({"x": timestamp, "note": "end-only"})
+    sink = SimpleNamespace(
+        _is_singleton_initialized=True,
+        host="test",
+        port=12345,
+        _buffers={TOPIC: writer},
+        pause=Mock(),
+        _disconnect=Mock(),
+    )
+    TopicSink.close(sink)
+    TopicSink.close(sink)
+    assert pipeline.ran_at == timestamps[-1:]

--- a/test/source/test_influxdb.py
+++ b/test/source/test_influxdb.py
@@ -10,13 +10,19 @@ gated on `BAGEL_INFLUXDB_TEST_URL`, e.g.:
 """
 
 import os
+from datetime import datetime
 
 import pytest
 
 pytest.importorskip("influxdb_client_3")
 
+import pyarrow as pa
+
 from src.di.types import data_source
+from src.message import influxdb as message_influxdb
 from src.source import influxdb
+from src.source.context import SourceContext
+from src.topic.influxdb import TopicRegistry
 
 INFLUX_URL = os.environ.get("BAGEL_INFLUXDB_TEST_URL")
 
@@ -56,6 +62,52 @@ def test_parse_url_requires_database() -> None:
 def test_parse_url_requires_influxdb_scheme() -> None:
     with pytest.raises(ValueError, match="influxdb://"):
         influxdb.parse_url("postgres://h/db")
+
+
+def test_bounds_uses_aggregate_queries_not_full_row_downloads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """bounds() must not download every row of every measurement.
+
+    Regression for PR #237 review (src/source/context.py:50): `SourceContext.bounds()`
+    called `to_duckdb()` with no `topics`, which downloads and struct-packs every row
+    of every measurement (`_topic_arrow`'s `SELECT * FROM ... ORDER BY time`) merely
+    to compute two numbers.
+    """
+    queries: list[str] = []
+
+    class _FakeInfluxClient:
+        def query(self, sql: str) -> pa.Table:
+            queries.append(sql)
+            if "information_schema.tables" in sql:
+                return pa.table({"table_name": ["readings"]})
+            return pa.table(
+                {
+                    "lo": pa.array([datetime(2024, 1, 1, 0, 0, 0)], type=pa.timestamp("us")),
+                    "hi": pa.array([datetime(2024, 1, 1, 0, 2, 0)], type=pa.timestamp("us")),
+                }
+            )
+
+    monkeypatch.setattr(
+        influxdb.InfluxDatabase, "client", property(lambda self: _FakeInfluxClient())
+    )
+    data_source = influxdb.InfluxDatabase(host="http://h:8181", database="telemetry", token="")
+
+    class _StubFactory:
+        def build(self) -> influxdb.InfluxDatabase:
+            return data_source
+
+    context = SourceContext(
+        factory=_StubFactory(),  # not a BoundedSourceFactory, so bounds() must query
+        registry=TopicRegistry(),
+        dataset=message_influxdb.MessageDataset(),
+    )
+
+    start, end = context.bounds()
+
+    assert start == pytest.approx(1704067200.0)  # 2024-01-01T00:00:00Z
+    assert end == pytest.approx(1704067320.0)  # 2024-01-01T00:02:00Z
+    assert not any("SELECT *" in query for query in queries)
 
 
 # -- live database ------------------------------------------------------------------

--- a/test/source/test_postgres.py
+++ b/test/source/test_postgres.py
@@ -13,7 +13,11 @@ import os
 import pytest
 
 from src.di.types import data_source
+from src.message import postgres as message_postgres
+from src.query import connection
 from src.source import postgres
+from src.source.context import SourceContext
+from src.topic.postgres import TopicRegistry
 
 PG_URL = os.environ.get("BAGEL_POSTGRES_TEST_URL")
 
@@ -77,6 +81,46 @@ def test_timestamp_column_missing_raises_actionable_error(
     )
     with pytest.raises(ValueError, match="timestamp_columns"):
         database.timestamp_column("readings")
+
+
+def test_bounds_skips_tables_without_a_detectable_timestamp_column(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A table lacking a timestamp column must not block bounds() on the others.
+
+    Regression for PR #237 review (src/source/context.py:50): `SourceContext.bounds()`
+    called `to_duckdb()` with no `topics`, so it expanded to every table via
+    `_topic_select`, which calls `timestamp_column()` unconditionally -- raising
+    for any unrelated table lacking a detectable timestamp column even though only
+    the eligible tables matter for the source's overall bounds.
+    """
+    monkeypatch.setattr(postgres, "attach", lambda url: "pg_test")
+    monkeypatch.setattr(
+        postgres.PostgresDatabase, "relation_name", lambda self, topic: f'"{topic}"'
+    )
+    monkeypatch.setattr(
+        postgres.PostgresDatabase,
+        "tables",
+        lambda self: [("public", "events"), ("public", "opaque")],
+    )
+
+    connection().execute("CREATE OR REPLACE TABLE events (t TIMESTAMP, v INTEGER)")
+    connection().execute(
+        "INSERT INTO events VALUES "
+        "(TIMESTAMP '2024-01-01 00:00:00', 1), (TIMESTAMP '2024-01-01 00:02:00', 2)"
+    )
+    connection().execute("CREATE OR REPLACE TABLE opaque (v INTEGER)")
+    connection().execute("INSERT INTO opaque VALUES (1), (2)")
+
+    factory = postgres.SourceFactory(path="postgres://h/db")
+    context = SourceContext(
+        factory=factory, registry=TopicRegistry(), dataset=message_postgres.MessageDataset()
+    )
+
+    start, end = context.bounds()
+
+    assert start == pytest.approx(1704067200.0)  # 2024-01-01T00:00:00Z
+    assert end == pytest.approx(1704067320.0)  # 2024-01-01T00:02:00Z
 
 
 # -- live database ------------------------------------------------------------------


### PR DESCRIPTION
Make pipeline execution use one source clock, honor end-only live cadence, and report actual outcomes. Previously a live `once_at_end` task ran on its first message; previews could report 40 seconds retained from a 10-second recording; and tolerated task failures still returned `completed`.

Priorities:

- **P1:** defer live `once_at_end` until shutdown, including empty streams and repeated closes.
- **P2:** clip retention windows to whole-source bounds using the same planning function in previews and reduction tasks.
- **P2:** validate positive cadence/nonnegative lookback values and time-based event delays before constructing operators. Share `source_args` between cadence, gates, and tasks; normalize legacy setup options and reject conflicts.
- **P2:** expose run counts/errors and completed/partial/failed status in tool and batch results.
- **P2:** stream CSV/JSON Arrow batches through DuckDB sorting, preserving timestamp ties; consume cadence/event results in bounded batches instead of whole-source Python lists.
- **P2 maintainability:** extract SourceContext and a typed RunSummary; document contracts in doc/runbooks/quality.md.

Validation: **490 portable tests passed, 5 expected skips**; Ruff lint/format and pre-commit. Regression coverage includes 120,000 wide CSV rows with a 40 MiB ceiling on decoded Python memory, stable sorting/window filtering, first-message/shutdown behavior, source-clock consistency, validation-before-import, source-bound clipping, and permitted failure reporting. One existing third-party MDF destructor warning remains visible; service-bound validation runs in CI.

Compatibility: callers must handle `partial` and `runs` in tool responses. Source bounds change previously overstated preview durations. Existing task setup options remain accepted when they agree; conflicting source interpretations now fail explicitly. Output memory still scales with requested rows/events, and the legacy standalone plan_reduction duration-only form remains available.

Related to #231. Stack part 2/3, based on #232. Review this diff independently and land the integrated stack through the landing PR, per CONTRIBUTING.md.
