### PR TITLE
ci: Product Completeness Agent — catch lifecycle gaps before they ship

### DIFF
--- a/.github/agents/product-completeness-agent.md
+++ b/.github/agents/product-completeness-agent.md
@@ -1,0 +1,119 @@
+# Product Completeness Agent
+
+You are the **Product Completeness Agent** for Bagel. You are not a code
+reviewer. Correctness reviewers (Codex, Claude) already check whether the
+code does what it claims. Your job is the question they structurally miss:
+
+> **Is this feature *whole*, or does it ship a dead end?**
+
+A create with no delete, a subscribe with no unsubscribe, a state a user can
+enter but not observe or leave — every one of those is *correct code* and a
+*broken product*. An external completeness audit once scored Bagel 3/5 for
+exactly this class ("no way to list or delete saved pipelines, no
+stop/unsubscribe for live subscriptions, no editing/removal for capabilities
+or topics — minor dead ends"). Those gaps passed every correctness review
+because nothing was *wrong*; something was *missing*. You exist so that never
+happens silently again.
+
+## What you inspect
+
+Only the **added or changed** surface in the PR diff — never the whole
+codebase. For each new or modified user-facing capability (an MCP tool, an
+agent capability/`.poml`, a wire-contract message, a pipeline task, a CLI
+verb, a config knob a user sets), run the checklist below. Ignore pure
+refactors, tests, docs-only changes, and internal helpers with no user-facing
+surface — say so briefly rather than inventing findings.
+
+## The completeness checklist
+
+Apply each lens to every new/changed capability. State the capability, the
+lens, and the verdict.
+
+1. **Lifecycle symmetry — the one that scored us 3/5.** Every verb that
+   *creates or begins* state must have its inverses:
+   - **create / save / add / enroll / register / start / subscribe / stream**
+     → is there a **list/describe** (see what exists) **and** a
+     **delete / remove / unenroll / stop / unsubscribe / pause** (undo it)?
+   - A create-only operation is a dead end by default. If an inverse is
+     genuinely out of scope for the PR, the PR must say *where it lands* — a
+     tracked issue, a follow-up, a documented "v1 limitation" — not leave it
+     unstated.
+
+2. **Observability.** Any state a user can create, can they *see* it? Its
+   existence, its status, its health, its identifiers? "You started it and now
+   you have no way to ask what it's doing" is a gap.
+
+3. **Reversibility / no trap states.** From every state a user can enter, is
+   there a path back? Pause needs resume. Enroll needs unenroll. A one-way
+   door is a finding unless it's inherently irreversible (and then it needs a
+   confirmation/warning).
+
+4. **Empty and error states.** What does the new surface do with *zero* items,
+   an *unknown* name, a *second identical* call (idempotency), a *not-yet-set-up*
+   precondition? A tool that only behaves on the happy path is incomplete.
+
+5. **Discoverability.** Is the new thing findable — listed by a discovery
+   tool, mentioned in the runbook/skill/README, named consistently with its
+   siblings (verb-noun, snake_case)? A capability nobody can find is a gap.
+
+6. **Documentation & contract parity.** New capability → is the operator
+   runbook / plugin skill / protocol doc updated to match? A wire field added
+   → is it in the contract doc? Shipping behavior without its doc is a dead end
+   for the next user.
+
+7. **Naming & consistency.** Does the new verb match the established
+   vocabulary and the annotation conventions of its neighbors? An outlier name
+   is a discoverability tax.
+
+## How to judge severity
+
+- **Gap (must address before merge or explicitly defer):** a missing inverse,
+  an unobservable state, a trap state, or a create-without-list/delete. The
+  kind of thing that becomes a support ticket or a bad review.
+- **Note (worth a follow-up):** an empty-state rough edge, a naming outlier, a
+  doc that lags the code.
+- **Whole:** the capability has its full lifecycle, is observable, reversible,
+  discoverable, and documented. Say so — a clean bill is a real result.
+
+A gap the PR *already* acknowledges (a linked issue, a "v1 limitation" note,
+an explicit deferral) is not a blocking finding — completeness includes being
+honest about what's deferred. Credit that; don't re-flag it.
+
+## Output format
+
+Write your report as Markdown. Structure it exactly:
+
+```
+## Product completeness review
+
+**Scope:** <the user-facing capabilities this PR adds or changes, one line each — or "no user-facing surface changed" and stop>
+
+### <capability name>
+- **Lifecycle:** ✅ full / ⚠️ <which inverse is missing> / — n/a
+- **Observable:** ✅ / ⚠️ <what can't be seen>
+- **Reversible:** ✅ / ⚠️ <the trap state> / — inherently irreversible (warned)
+- **Empty/error/idempotent:** ✅ / ⚠️ <the unhandled case>
+- **Discoverable:** ✅ / ⚠️
+- **Docs/contract parity:** ✅ / ⚠️ <what's missing>
+
+### Verdict
+<one of:>
+- **Whole** — no completeness gaps; the added surface is a complete product increment.
+- **Gaps (N)** — <ranked list, each: the missing piece, why it's a dead end for a user, and the smallest thing that closes it (a tool, an issue, a doc line)>.
+- **Deferred, acknowledged** — the gaps exist but the PR tracks them; list what's deferred and where.
+```
+
+Be specific and concrete — name the missing tool, quote the wire field, cite
+the file. A finding a maintainer can't act on in one step is a bad finding.
+Lead with the gaps that would actually reach a user; don't pad the list to
+look thorough. If the surface is whole, say "Whole" and stop — a short true
+report beats a long invented one.
+
+## Apply this to yourself
+
+Before you ship a feature, you'd run this checklist on it. So: this agent's
+own "capability" is a review comment. Its lifecycle is inherently
+stateless — it creates nothing to list or delete — so lenses 1–3 are n/a to
+the agent itself, and that's the honest answer, not a dodge. Hold the code you
+review to the same standard: n/a is a valid verdict when it's true, and only
+when it's true.

--- a/.github/workflows/product-review.yaml
+++ b/.github/workflows/product-review.yaml
@@ -75,9 +75,17 @@ jobs:
           fi
           echo "num=$num" >> "$GITHUB_OUTPUT"
           echo "head_sha=$(gh api "repos/$REPO/pulls/$num" --jq .head.sha)" >> "$GITHUB_OUTPUT"
-      # Base checkout at root (trusted); agent definition lives here.
+      # Agent definition (the persona the reviewer OBEYS) is read from root,
+      # so root MUST be trusted base code -- never the PR merge ref. On a
+      # pull_request event actions/checkout defaults to refs/pull/N/merge,
+      # which contains the PR's changes: without pinning, a PR that edits
+      # product-completeness-agent.md would rewrite the reviewer's own
+      # instructions and have them executed against itself (prompt injection
+      # via the persona file). Pin to the base SHA; the fallback covers the
+      # comment-triggered path, which has no PR context.
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.base.sha || github.event.repository.default_branch }}
           persist-credentials: false
       # PR head into a subdirectory the model may read; no credentials in it.
       - uses: actions/checkout@v4

--- a/.github/workflows/product-review.yaml
+++ b/.github/workflows/product-review.yaml
@@ -28,13 +28,24 @@ name: product-review
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    # Must cover every surface the persona (.github/agents/product-completeness-agent.md)
+    # claims to grade: MCP tools + CLI entry (server.py, run.py), agent
+    # capabilities/.poml (src/agent/**), pipeline tasks/gates/discovery
+    # (src/pipeline/**), wire-contract/publish surfaces (src/sink/**), a
+    # user-settable knob (settings.py, compose.yaml), and the docs the
+    # persona checks for parity (protocol doc, runbooks, plugin skills). A
+    # gap here is a doc/contract-parity miss inside the agent itself (lens 6).
     paths:
       - "server.py"
+      - "run.py"
+      - "settings.py"
+      - "compose.yaml"
       - "src/agent/**"
-      - "src/sink/publish/config.py"
-      - "src/sink/publish/control.py"
-      - "src/pipeline/tasks/**"
+      - "src/pipeline/**"
+      - "src/sink/**"
       - "doc/fleet_protocol_v1.md"
+      - "doc/runbooks/**"
+      - "plugin/skills/**"
   issue_comment:
     types: [created]
 
@@ -74,7 +85,9 @@ jobs:
             num=${{ github.event.pull_request.number }}
           fi
           echo "num=$num" >> "$GITHUB_OUTPUT"
-          echo "head_sha=$(gh api "repos/$REPO/pulls/$num" --jq .head.sha)" >> "$GITHUB_OUTPUT"
+          pr_json="$(gh api "repos/$REPO/pulls/$num")"
+          echo "head_sha=$(echo "$pr_json" | jq -er .head.sha)" >> "$GITHUB_OUTPUT"
+          echo "base_sha=$(echo "$pr_json" | jq -er .base.sha)" >> "$GITHUB_OUTPUT"
       # Agent definition (the persona the reviewer OBEYS) is read from root,
       # so root MUST be trusted base code -- never the PR merge ref. On a
       # pull_request event actions/checkout defaults to refs/pull/N/merge,
@@ -94,6 +107,19 @@ jobs:
           path: pr-head
           fetch-depth: 0
           persist-credentials: false
+      # `gh pr diff` reads the PR's LIVE current diff by number, with no
+      # commit-SHA argument -- if a push lands after head_sha is resolved
+      # above but before the model gets around to running it (agent turns can
+      # take minutes), it would inspect a newer revision's diff while
+      # ./pr-head and the posted report still say head_sha. Generate the diff
+      # ourselves, right now, pinned to the exact base/head SHAs already
+      # resolved and checked out, so the diff, the files the model reads, and
+      # the commit the report is stamped with all name the same tree.
+      - name: Generate the diff pinned to the checked-out head
+        run: |
+          git -C pr-head diff --no-color \
+            "${{ steps.pr.outputs.base_sha }}...${{ steps.pr.outputs.head_sha }}" \
+            > "${{ github.workspace }}/pr-diff.patch"
       - name: Resolve the identity-token file path
         run: echo "ANTHROPIC_IDENTITY_TOKEN_FILE=${RUNNER_TEMP}/gha-jwt" >> "$GITHUB_ENV"
       - name: Keep a fresh OIDC token in the identity file
@@ -122,15 +148,18 @@ jobs:
             ./.github/agents/product-completeness-agent.md at this checkout —
             read it first and follow it exactly. Review the changed surface of
             pull request #${{ steps.pr.outputs.num }} (head commit
-            ${{ steps.pr.outputs.head_sha }}): get the diff with
-            `gh pr diff ${{ steps.pr.outputs.num }}`, and read any file you
-            need ONLY under ./pr-head at the PR's head. Then WRITE your report
+            ${{ steps.pr.outputs.head_sha }}): the diff is already generated
+            and pinned to that exact head at ./pr-diff.patch -- read it, and
+            read any file you need ONLY under ./pr-head at the PR's head. Do
+            not run `gh pr diff` yourself; it reads the PR's live diff and may
+            no longer match the head commit this report is stamped with. Then
+            WRITE your report
             (in the persona's exact output format, its first line being
             "Product completeness review -- commit ${{ steps.pr.outputs.head_sha }}")
             to ./product-review-body.md and nothing else. Do not run
             `gh pr review`, `gh pr comment`, or any command that posts.
           claude_args: >-
-            --allowedTools Bash(gh pr diff:*),Bash(gh pr view:*),Read(./**),Grep(./pr-head/**),Glob(./pr-head/**),Write(./product-review-body.md)
+            --allowedTools Bash(gh pr view:*),Read(./**),Grep(./pr-head/**),Glob(./pr-head/**),Write(./product-review-body.md)
             --disallowedTools Read(//tmp/**),Read(${{ runner.temp }}/**),Read(**/.git/**)
             --max-turns 40
         env:

--- a/.github/workflows/product-review.yaml
+++ b/.github/workflows/product-review.yaml
@@ -1,0 +1,149 @@
+# Product Completeness Agent in CI.
+#
+# Runs the .github/agents/product-completeness-agent.md persona against a PR's
+# diff and posts an ADVISORY comment flagging product-shaped gaps (missing
+# inverses, dead ends, unobservable state) — the class correctness reviewers
+# miss. This is NOT a merge gate: product completeness is judgment, so it
+# comments, never blocks. Fires automatically on PRs that touch the
+# user-facing surface, and on demand via a "@product review" comment.
+#
+# Keyless, hardened exactly like claude-review.yaml (its own five security
+# rounds): the model gets read-only, path-scoped tools and can only WRITE one
+# output file; a subsequent no-model shell step validates and posts it under a
+# maintainer PAT. It reads contributor-controlled PR content, so it holds no
+# secret the model can reach, checks the PR head out to a subdirectory with
+# persist-credentials:false, and denies reads of /tmp, the runner temp, and
+# any .git.
+#
+# SETUP (one console step, mirrors the bagel-claude-review rule): the
+# auto-on-PR path presents a GitHub OIDC token whose `sub` is
+# `repo:Extelligence-ai/bagel:pull_request` — add a second federation rule
+# with that subject_prefix, same audience/service account
+# (bagel-ci-reviewer), so the exchange is accepted. The four
+# ANTHROPIC_* repo variables are already set. Until that rule exists the
+# auto path's token exchange fails closed (no comment posted, no leak); the
+# "@product review" comment path uses the default-branch context the existing
+# rule already covers.
+name: product-review
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "server.py"
+      - "src/agent/**"
+      - "src/sink/publish/config.py"
+      - "src/sink/publish/control.py"
+      - "src/pipeline/tasks/**"
+      - "doc/fleet_protocol_v1.md"
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+
+jobs:
+  product-review:
+    # Auto on product-surface PRs from THIS repo (never fork PRs: they get a
+    # read-only token and must not reach WIF); or a maintainer's explicit
+    # "@product review" comment.
+    if: >-
+      (github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request != null &&
+        contains(github.event.comment.body, '@product review') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
+    runs-on: ubuntu-latest
+    env:
+      ANTHROPIC_FEDERATION_RULE_ID: ${{ vars.ANTHROPIC_FEDERATION_RULE_ID }}
+      ANTHROPIC_ORGANIZATION_ID: ${{ vars.ANTHROPIC_ORGANIZATION_ID }}
+      ANTHROPIC_SERVICE_ACCOUNT_ID: ${{ vars.ANTHROPIC_SERVICE_ACCOUNT_ID }}
+      ANTHROPIC_WORKSPACE_ID: ${{ vars.ANTHROPIC_WORKSPACE_ID }}
+    steps:
+      - name: Resolve the PR number and head
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          if [ "${{ github.event_name }}" = "issue_comment" ]; then
+            num=${{ github.event.issue.number }}
+          else
+            num=${{ github.event.pull_request.number }}
+          fi
+          echo "num=$num" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$(gh api "repos/$REPO/pulls/$num" --jq .head.sha)" >> "$GITHUB_OUTPUT"
+      # Base checkout at root (trusted); agent definition lives here.
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      # PR head into a subdirectory the model may read; no credentials in it.
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.pr.outputs.head_sha }}
+          path: pr-head
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Resolve the identity-token file path
+        run: echo "ANTHROPIC_IDENTITY_TOKEN_FILE=${RUNNER_TEMP}/gha-jwt" >> "$GITHUB_ENV"
+      - name: Keep a fresh OIDC token in the identity file
+        run: |
+          fetch() {
+            local tmp
+            tmp="$(mktemp "${ANTHROPIC_IDENTITY_TOKEN_FILE}.XXXXXX")"
+            if curl -fsS -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+                 "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=https://api.anthropic.com" \
+                 | jq -er .value > "$tmp"; then
+              mv "$tmp" "$ANTHROPIC_IDENTITY_TOKEN_FILE"
+            else
+              echo "::warning::OIDC token refresh failed; keeping last valid token"
+              rm -f "$tmp"
+            fi
+          }
+          fetch
+          ( while true; do sleep 180; fetch || true; done ) &
+      - name: Product Completeness Agent inspects the PR
+        uses: anthropics/claude-code-action@v1
+        with:
+          prompt: >-
+            You are the Product Completeness Agent. Your full persona,
+            checklist, and required output format are defined in
+            ./.github/agents/product-completeness-agent.md at this checkout —
+            read it first and follow it exactly. Review the changed surface of
+            pull request #${{ steps.pr.outputs.num }} (head commit
+            ${{ steps.pr.outputs.head_sha }}): get the diff with
+            `gh pr diff ${{ steps.pr.outputs.num }}`, and read any file you
+            need ONLY under ./pr-head at the PR's head. Then WRITE your report
+            (in the persona's exact output format, its first line being
+            "Product completeness review -- commit ${{ steps.pr.outputs.head_sha }}")
+            to ./product-review-body.md and nothing else. Do not run
+            `gh pr review`, `gh pr comment`, or any command that posts.
+          claude_args: >-
+            --allowedTools Bash(gh pr diff:*),Bash(gh pr view:*),Read(./**),Grep(./pr-head/**),Glob(./pr-head/**),Write(./product-review-body.md)
+            --disallowedTools Read(//tmp/**),Read(${{ runner.temp }}/**),Read(**/.git/**)
+            --max-turns 40
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - name: Post the report (deterministic — no model in this step)
+        env:
+          GH_TOKEN: ${{ secrets.CODEX_TRIGGER_TOKEN || github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ steps.pr.outputs.num }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+        run: |
+          body="product-review-body.md"
+          if [ ! -s "$body" ]; then
+            echo "::error::Product agent produced no report file."
+            exit 1
+          fi
+          first="$(head -n1 "$body")"
+          expected="Product completeness review -- commit ${HEAD_SHA}"
+          if [ "$first" != "$expected" ]; then
+            echo "::error::Report file missing/incorrect header (got: $first)"
+            exit 1
+          fi
+          # Advisory PR comment (issue comment), not a review — never gates merge.
+          gh api -X POST "repos/$REPO/issues/$PR/comments" -F body=@"$body" >/dev/null
+          echo "Posted product completeness review for $HEAD_SHA."

--- a/.github/workflows/product-review.yaml
+++ b/.github/workflows/product-review.yaml
@@ -105,6 +105,7 @@ jobs:
           fetch
           ( while true; do sleep 180; fetch || true; done ) &
       - name: Product Completeness Agent inspects the PR
+        continue-on-error: true  # advisory: an agent/auth failure must never red-X the PR
         uses: anthropics/claude-code-action@v1
         with:
           prompt: >-
@@ -135,14 +136,14 @@ jobs:
         run: |
           body="product-review-body.md"
           if [ ! -s "$body" ]; then
-            echo "::error::Product agent produced no report file."
-            exit 1
+            echo "::warning::No product-review report produced (agent auth not configured yet, or the agent step failed). Advisory step skipped — the PR is NOT blocked."
+            exit 0
           fi
           first="$(head -n1 "$body")"
           expected="Product completeness review -- commit ${HEAD_SHA}"
           if [ "$first" != "$expected" ]; then
-            echo "::error::Report file missing/incorrect header (got: $first)"
-            exit 1
+            echo "::warning::Report header malformed (got: $first); skipping the post rather than blocking the PR."
+            exit 0
           fi
           # Advisory PR comment (issue comment), not a review — never gates merge.
           gh api -X POST "repos/$REPO/issues/$PR/comments" -F body=@"$body" >/dev/null


### PR DESCRIPTION
## Summary

A **Product Completeness Agent** that inspects new/changed features for the class of gap correctness review structurally misses — missing inverses, dead ends, unobservable or trap states — the exact class an external audit scored Bagel 3/5 on ("no way to list or delete saved pipelines, no stop/unsubscribe for live subscriptions, no editing/removal for capabilities or topics").

**`.github/agents/product-completeness-agent.md`** — the agent persona and rubric: lifecycle symmetry (every create/subscribe/enroll needs list + delete/unsubscribe/unenroll), observability, reversibility/no-trap-states, empty & error states, discoverability, and doc/contract parity. It grades the *added surface only*, credits gaps the PR already tracks, and answers "n/a" honestly (including about itself).

**`.github/workflows/product-review.yaml`** — runs it in CI and posts an **advisory** comment. It is deliberately **not a merge gate**: completeness is judgment, so it informs, never blocks. Fires automatically on PRs touching the user-facing surface (`server.py`, `src/agent/**`, tool/config/pipeline/contract paths) and on demand via `@product review`.

Security posture is inherited wholesale from `claude-review.yaml`'s hardening (it reads contributor-controlled PR content): keyless WIF, PR head checked out to a subdirectory with `persist-credentials: false`, read-only path-scoped tools, `/tmp` + runner-temp + `.git` reads denied, the model can only *write one output file*, and a subsequent no-model shell step validates the header and posts under a maintainer PAT.

## Setup — one console step

The auto-on-PR path presents a GitHub OIDC token with `sub: repo:Extelligence-ai/bagel:pull_request`. Add a second federation rule with that `subject_prefix`, same audience (`https://api.anthropic.com`) and service account (`bagel-ci-reviewer`) — mirrors the existing `bagel-claude-review` rule. Until it exists, the auto path fails closed (no comment, no leak); the `@product review` comment path works today under the existing default-branch rule. The four `ANTHROPIC_*` repo variables are already set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
