### PR TITLE
fix(docker): COPY demo.py into px4/ros2 images (broken main build)

### DIFF
--- a/docker/Dockerfile.px4
+++ b/docker/Dockerfile.px4
@@ -58,6 +58,7 @@ EXPOSE ${JUPYTER_PORT}
 COPY --chown=${USERNAME}:${USERNAME} server.py ./server.py
 COPY --chown=${USERNAME}:${USERNAME} run.py ./run.py
 COPY --chown=${USERNAME}:${USERNAME} settings.py ./settings.py
+COPY --chown=${USERNAME}:${USERNAME} demo.py ./demo.py
 COPY --chown=${USERNAME}:${USERNAME} src ./src
 # MCAP as a first-class format (no ROS required)
 

--- a/docker/Dockerfile.ros2
+++ b/docker/Dockerfile.ros2
@@ -67,6 +67,7 @@ EXPOSE ${JUPYTER_PORT}
 COPY --chown=${USERNAME}:${USERNAME} server.py ./server.py
 COPY --chown=${USERNAME}:${USERNAME} run.py ./run.py
 COPY --chown=${USERNAME}:${USERNAME} settings.py ./settings.py
+COPY --chown=${USERNAME}:${USERNAME} demo.py ./demo.py
 COPY --chown=${USERNAME}:${USERNAME} src ./src
 # MCAP as a first-class format (no ROS required)
 


### PR DESCRIPTION
Hotfix: `docker/Dockerfile.px4` and `.ros2` run a build-time `import demo` check but never `COPY demo.py` — the COPY was dropped in a merge-conflict resolution during today's merge batch, so both image builds fail with `ModuleNotFoundError: No module named 'demo'`. main is currently red on these two images; this restores the missing COPY. No other Dockerfile has the import-demo check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)