### PR TITLE
docs: add Bits to atoms tagline to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
   <img src="./doc/assets/bagel_logo_light_mode.png" width="560">
 </p>
 
+<p align="center">
+  <strong>Bits to atoms.<br>Atoms to bits.</strong>
+</p>
+
 <h1 align="center">
   <a href="https://github.com/Extelligence-ai/bagel/blob/main/LICENSE">
     <img src="https://img.shields.io/badge/License-Apache%202.0-blue?style=flat-square">


### PR DESCRIPTION
Adds “Bits to atoms. / Atoms to bits.” as a centered, bold, two-line tagline directly beneath the Bagel logo in the README.

Validation: `git diff --check`, Ruff lint and format checks passed. Pre-commit hooks ran for `README.md` and skipped Python-only checks. Documentation-only change.
