### PR TITLE
Improve agent routing guidance and add discovery evaluation

### DIFF
--- a/.github/ISSUE_TEMPLATE/workflow_report.md
+++ b/.github/ISSUE_TEMPLATE/workflow_report.md
@@ -1,0 +1,31 @@
+---
+name: Workflow report
+about: Share a reproducible Bagel workflow, including partial results or failures
+title: '[Workflow] '
+labels: ''
+assignees: ''
+---
+
+**Task and exact prompt**
+What were you trying to do? Paste the prompt, including relevant prior steps.
+
+**Environment**
+Bagel commit/image digest, client and model version, OS, Docker/runtime, relevant optional dependencies.
+
+**Shareable input**
+Sample link, provenance/license, size and duration, or a synthetic reproduction.
+Please avoid uploading private logs or credentials.
+
+**Reproduction**
+Commands, inspected schemas/units, executed SQL, preview parameters and confirmation before reduction.
+
+**Observed results**
+What succeeded or failed? Include actual tool output and validation. For reductions:
+input/output bytes, retained seconds, event counts, and how preservation was checked.
+Distinguish measurements from estimates and proposed improvements.
+
+**Visual evidence and limitations**
+Screenshots/video, plus text results and known gaps. Do not infer a cause merely from correlation.
+
+**Relationship disclosure (if relevant)**
+Are you a maintainer, contributor, or otherwise connected to Bagel? Did anyone assist with the report?

--- a/.github/workflows/agent-discovery-audit.yaml
+++ b/.github/workflows/agent-discovery-audit.yaml
@@ -1,0 +1,26 @@
+name: agent discovery audit
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '17 12 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  public-surfaces:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - name: Collect public discovery evidence
+        run: python3 scripts/audit_agent_discovery.py --output discovery-audit
+      - name: Retain report and response bodies
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: agent-discovery-audit
+          path: discovery-audit
+          retention-days: 30
+          if-no-files-found: error

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ Instructions for AI agents asked to set up, use, or develop Bagel.
 
 - Answers come from DuckDB SQL over real messages. Do not do the math yourself;
   ask Bagel and show the user the generated query.
-- Call `describe_source` first, and `describe_topic` before writing predicates
+- Call `describe_data_source` first, and `describe_topic` before writing predicates
   (field paths and units vary by source).
 - Reduction etiquette: `preview_pipeline` first, report detected events and
   kept seconds, get user confirmation, then `run_pipeline`.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
   </picture>
 </p>
 
-Bagel lets you ask questions about robotics, drone, and IoT data in plain English.
+Bagel by Extelligence lets you ask questions about robotics, drone, and IoT data in plain English.
 Every calculation over your message data is DuckDB SQL, not model guesswork, and
 Bagel shows you the query so you can audit it.
 
@@ -444,3 +444,9 @@ We hang out there regularly.
 ## 📄 License
 
 Bagel is open source under the [Apache License 2.0](./LICENSE).
+
+## Agent discovery and reproducible workflows
+
+For maintainers: [discovery audits and evaluation](./docs/agent-discovery/README.md),
+[listing maintenance](./docs/agent-discovery/listings.md), and
+[reproducible user reports](./docs/agent-discovery/community.md).

--- a/docs/agent-discovery/README.md
+++ b/docs/agent-discovery/README.md
@@ -1,0 +1,124 @@
+# Agent discovery and evaluation
+
+Bagel by Extelligence is the open-source MCP server for querying robotics, drone,
+and IoT messages with DuckDB and reducing recordings around events. Its canonical
+repository is https://github.com/Extelligence-ai/bagel and its website is
+https://trybagel.com. Use those identifiers to distinguish it from unrelated
+products named Bagel.
+
+Keep the full tool set. Tool-count scores are informational; optimize whether an
+agent can find the product, choose an appropriate tool, install it, and complete
+a task. These are separate measurements.
+
+## Reproduce the checks
+
+Use Python 3.10–3.12 and uv from the repository root. The evaluation runner also
+requires an authenticated Codex CLI with the flags used by version 0.153.4. It
+makes model requests charged to that account. Discovery additionally uses live
+web search. Model calls are never run automatically in CI.
+
+```sh
+uv sync --frozen --group px4
+uv run python scripts/export_tool_catalog.py > /tmp/bagel-catalog.json
+uv run python scripts/smoke_agent_discovery.py --output /tmp/bagel-mcp-smoke
+uv run python scripts/audit_agent_discovery.py --output /tmp/bagel-public-audit
+```
+
+Choose an available model identifier explicitly for comparable future runs:
+
+```sh
+export EVAL_MODEL='YOUR_AVAILABLE_MODEL_IDENTIFIER'
+uv run python scripts/evaluate_agent_discovery.py \
+  --model "$EVAL_MODEL" --catalog /tmp/bagel-catalog.json \
+  --output /tmp/bagel-routing
+uv run python scripts/evaluate_agent_discovery.py \
+  --model "$EVAL_MODEL" --track discovery --output /tmp/bagel-discovery
+```
+
+Output directories must not exist: each run preserves its evidence. The runner
+saves exact prompts, catalog, cases, CLI command arrays, CLI version, requested
+model, hashes, raw JSONL events, responses, errors, timings, and a summary. Each
+case starts an ephemeral session in an empty directory, ignores user config, and
+disables plugins, apps, hooks, memory, shell tools, and delegation. Host skill
+discovery is disabled using an experimental CLI flag; recheck isolation when
+upgrading the CLI. Account-level or service-side instructions are outside this
+harness's control. Review transcripts before sharing them.
+
+To obtain the original catalog for an A/B rerun, create a detached worktree at
+`96bd312`, install its locked environment, and run this command from that worktree:
+
+```sh
+uv run python -c 'import asyncio,json,server; print(json.dumps([t.model_dump(mode="json") for t in asyncio.run(server.server.list_tools())], indent=2))' > /tmp/bagel-before.json
+```
+
+Run the same current evaluation script/cases against `/tmp/bagel-before.json` and
+the current exported catalog, with the same explicit model. Alternate condition
+order and repeat cases before making comparative claims. Keep both catalog hashes
+and all attempts; authentication failures and timeouts are not successful cases.
+
+## Interpret the tracks
+
+| Track | What is supplied | What is measured | What it does not prove |
+| --- | --- | --- | --- |
+| Discovery | Unbranded task and web access; no Bagel catalog or repository | Recommendations and supporting sources on three relevant tasks plus a pastry negative control | Ranking causality, universal recommendation, installation, or task success |
+| Catalog routing | Actual tools/list JSON and a task; expected answer withheld | Correct proposed next tool or explicit `NONE`, including negative controls | Actual MCP invocation, correct arguments, or end-to-end success |
+| MCP smoke | Bundled CSV, explicit time-axis mapping, real stdio client/server | Initialization, tools/list, source/schema inspection, SQL query, event preview | Docker installation, every runtime, or agent-authored execution |
+| Public audit | Official registry and public website/Glama pages | HTTP status, preserved bodies, registry version/repository match | Authenticated rescans, indexing, rankings, or user ratings |
+
+The discovery summary counts an attributed Bagel mention only when the response
+both recommends the singular product name and supplies its exact GitHub repository
+or website as a source. Human review must still confirm that the citation supports
+the recommendation. A source URL can be wrong, stale, or fabricated by the model.
+Do not count a bagel recipe as a product recommendation. Do not score the choice of
+another appropriate product as a factual error.
+
+For routing, report correct/attempted overall and separately for direct, indirect,
+and negative cases. Report completed/attempted too. A failed negative-control run
+is not successful abstention. A 20-case suite is a smoke benchmark: saturation
+calls for a separately defined, unseen test set, not claims of perfect reliability.
+
+## Initial measured run, September 7, 2026 (US Eastern)
+
+- All 22 exposed tool names and input schemas were retained.
+- Routing: **20/20 before and 20/20 after**, in 40 completed model calls. This is
+  no measured improvement on the initial corpus.
+- Unbranded discovery: Bagel appeared for MCAP/SQL analysis, and did not appear
+  for incident reduction or PX4 investigation: **1/3 relevant prompts**. The
+  recipe negative control recommended a baking resource, not Bagel by Extelligence.
+- The model runner used Codex CLI **0.153.4** with its default model. The JSONL
+  format did not expose the resolved model identifier. This limits exact replay;
+  future comparisons should use `--model` explicitly. One run per case is not a
+  statistical estimate, and no cross-provider claim is supported.
+- The first routing attempt had 20 sandbox initialization failures before model
+  access; all remain recorded separately from the successful retry. The initial
+  public HTTP audit similarly hit sandbox DNS restrictions; its retry succeeded.
+- The real MCP smoke completed initialization, tools/list, and four calls. Its
+  corrected CSV configuration returned 120 samples, minimum `accel_x = -13`,
+  two events and 4 kept seconds from 59.5 source seconds. The first smoke used
+  a base-class option instead of CSV's `timestamp_column`, so timing fell back
+  to wall clock. That response was retained, the fixture config was corrected,
+  and explicit timing/event checks now run in the smoke test and CI. Protocol
+  success alone was not accepted as a valid preview.
+- The initial discovery scorer used a substring and mistakenly counted “Bagels
+  recipe.” The scorer and regression test now require product identity and a
+  supporting product URL; reviewed discovery results above use the correction.
+
+Raw evidence, commands and screenshots were saved locally in
+`/Users/arunvenkatadri/projects/bagel/artifacts/agent-discovery-2026-09-07`.
+That machine-specific folder is not part of the repository. No raw transcript is
+needed to run the corpus again. Website indexing effects remain unmeasured while
+the changes are drafts.
+
+## Maintenance
+
+Use [listing maintenance](listings.md) for registry and Glama reconciliation and
+[community reports](community.md) for honest external evidence. The task guides
+live in the website repository; the existing
+[pipeline runbook](../../doc/runbooks/pipelines.md) and
+[client setup runbooks](../../doc/runbooks/setup/) remain the source for setup.
+
+The separation of discovery from tool selection follows the
+[official MCP registry architecture](https://modelcontextprotocol.io/registry/about)
+and [OpenAI's metadata evaluation guidance](https://developers.openai.com/plugins/guides/optimize-metadata).
+These sources describe mechanisms and evaluation practices, not a promise that
+listing scores will cause an agent to recommend Bagel.

--- a/docs/agent-discovery/community.md
+++ b/docs/agent-discovery/community.md
@@ -1,0 +1,61 @@
+# Reproducible user evidence
+
+Independent experience has to come from people who actually used Bagel. This kit
+is draft material for inviting and recording that experience. No testimonial,
+review, endorsement, message delivery, or third-party listing change is implied.
+
+## A useful report
+
+Use the repository's **Workflow report** issue template for a success, partial
+result, or failure. Capture:
+
+- Task, exact prompt, client/model/version, Bagel commit or image digest, OS and runtime.
+- A shareable sample and its provenance/license, or a synthetic reproduction.
+- Copyable commands, schema and unit assumptions, SQL, and preview parameters.
+- Actual outcome: detected events, retained duration, input/output byte sizes,
+  elapsed time and hardware when relevant, plus validation and limitations.
+- Screenshots or video accompanied by searchable text and underlying evidence.
+- Whether the author works on Bagel or received assistance/incentives.
+
+A maintainer reproduction is useful evidence but is not an independent user review.
+Let users write their own conclusions, including failures. Never condition help on
+a positive rating, invent reviews, or ask agents to create endorsements as users.
+
+## Invitation draft — not sent
+
+> We're looking for people who analyze ROS/MCAP or PX4 logs to try Bagel by
+> Extelligence on a small, shareable workflow. Could you record your prompt,
+> setup/version, commands, results and anything that failed? We can help produce
+> a synthetic reproduction if your logs are private. An honest public report is
+> useful whether it succeeds or not; no positive review is expected.
+>
+> Repository: https://github.com/Extelligence-ai/bagel
+> Report: https://github.com/Extelligence-ai/bagel/issues/new?template=workflow_report.md
+
+Choose actual users and obtain their agreement before attributing or quoting them.
+The invitation is not evidence that anyone was contacted.
+
+## Three tutorial pitches — proposed, not submitted
+
+| Audience | Concrete contribution | Required evidence before submission |
+| --- | --- | --- |
+| ROS/MCAP users | Keep 30 seconds before and after a specified incident, preserving required topics | Schema-first predicate, preview, confirmed reduction, input/output hashes, durations/bytes, missed-event and static-topic caveats |
+| PX4 users | Investigate a voltage drop using ULog SQL and compare it with plotted telemetry | Firmware/topic context, verified units, full query, missing-topic checks, timing alignment; no unsupported flight-safety diagnosis |
+| Viewer users | Inspect the same event in PlotJuggler, Rerun or Lichtblick | Real exported artifacts and exact viewer version; document scalar-only Rerun export and transformed JSON MCAP |
+
+Start with the corresponding project's current contribution guidance: the
+[ROS community](https://discourse.ros.org/), [PX4 docs repository](https://github.com/PX4/PX4-user_guide),
+[MCAP repository](https://github.com/foxglove/mcap),
+[Rerun repository](https://github.com/rerun-io/rerun), and
+[PlotJuggler repository](https://github.com/facontidavide/PlotJuggler).
+These are candidate venues, not endorsements, accepted listings, or permission to
+post promotional material. Tailor a useful, verified contribution to each venue
+instead of duplicating directory text everywhere.
+
+## Close the loop
+
+For each real report, keep a small ledger: source URL, task, versions, outcome,
+reproduction status, limitations, relationship disclosure, and permission to quote.
+Use failures to improve setup and tool guidance. Re-run the matching benchmark
+cases, then invite the original reporter to verify the fix. Keep user-review counts
+separate from automated tool-definition scores and from agent recommendation rates.

--- a/docs/agent-discovery/listings.md
+++ b/docs/agent-discovery/listings.md
@@ -1,0 +1,80 @@
+# Listing maintenance
+
+Canonical identity: **Bagel by Extelligence**. Repository:
+https://github.com/Extelligence-ai/bagel. Registry name:
+`io.github.Extelligence-ai/bagel`. Website: https://trybagel.com.
+Keep the existing tool names and full functionality; tool count is not a target.
+
+## Observed public state
+
+The September 7, 2026 US Eastern audit found the official registry's latest entry
+at **2.2.3**, matching `server.json` and the repository URL. It listed versions
+2.0.1 through 2.2.3 with no next-page cursor. The public Glama page showed an
+**A / 3.7 out of 5** tool-definition assessment discussing 18 tools, while current
+Bagel exported 22. Its displayed repository file links referenced
+`2697735ac80f00d754e3e9415b80fa6fefd53b0e`; those links do not establish the
+assessment's exact code revision. Source: [Bagel's Glama listing](https://glama.ai/mcp/servers/Extelligence-ai/bagel).
+
+Some completeness comments overlap features now present: `list_pipelines`,
+`delete_pipeline`, and `delete_capability`, plus `save_agent_capability`'s overwrite
+option. The live subscription API still lacks a dedicated stop/unsubscribe tool.
+Document that limitation; do not imply that a rescan implements it.
+
+The public website returned 404 for robots.txt and sitemap.xml. This is not proof
+of blocked crawling. The website draft adds these files and task pages; CDN/WAF
+behavior and actual search indexing must be checked after deployment.
+
+## Release and rescan checklist
+
+1. Run `scripts/audit_agent_discovery.py` and retain its report. Resolve network
+   errors before treating a missing response as a missing listing. Check registry
+   pagination, repository identity, version, package tag, and transport.
+2. Export the current catalog with `scripts/export_tool_catalog.py`; compare all
+   tool names, schemas, descriptions, annotations, and runtime availability.
+3. Review the metadata PR and release through the normal tested pipeline. A
+   published semver image tag is immutable: use a new version for a new image.
+   Keep `pyproject.toml`, image tags and `server.json` aligned. Do not republish
+   changed metadata under an already published immutable release.
+4. In the maintainer's Glama account, verify the tracked repository/revision and
+   request the supported rebuild/rescan after the intended code is available.
+   Compare the resulting tool list and assessment with the exported catalog.
+   The public API rejected unauthenticated access during this audit; use an
+   account-owned API key only if the documented operation requires it.
+5. Verify the registry and installed client plugin point to the intended release.
+   Test the actual client handshake: SSE at `/sse`, streamable HTTP at `/mcp`.
+   Codex uses `/mcp`; Claude Code's documented SSE command uses `/sse`.
+6. After website deployment, fetch the canonical pages, robots.txt and sitemap;
+   inspect redirects and any `X-Robots-Tag` headers, then use the owner's search
+   console to submit/inspect the sitemap. Repeat the unbranded discovery corpus
+   after indexing, retaining dates, sources and all outcomes.
+
+The included weekly/manual GitHub Actions audit only fetches public surfaces and
+uploads evidence. It neither changes listings nor runs paid model evaluations.
+HTTP errors are recorded in the report for review; workflow success means the
+report was collected, not that the surfaces are healthy.
+
+## Prepared maintainer rescan note — not sent
+
+> Bagel's current catalog contains 22 tools. The public tool-definition assessment
+> discusses 18 and mentions missing saved-pipeline and capability lifecycle tools
+> that current source now exposes. Please rebuild the intended released revision
+> and compare the attached tools/list JSON. We are intentionally retaining the
+> full tool set. We have clarified routing, prerequisites, output types and side
+> effects; please assess those descriptions without assuming a tool-count target.
+> A dedicated live unsubscribe tool is still absent and is documented as such.
+
+Attach the exact release/commit, catalog JSON, build output and this listing URL.
+Fill in the released revision when one exists; do not claim this draft was scanned.
+
+## Crawl policy and indexes
+
+The website draft explicitly permits OAI-SearchBot and ordinary crawling, and
+provides a canonical sitemap. Search crawling and model training controls are
+separate; the addition does not establish or alter a separate training policy.
+See [OpenAI's crawler documentation](https://developers.openai.com/api/docs/bots).
+A small llms.txt is a convenience index, not a verified ranking factor.
+
+Glama's [methodology](https://glama.ai/mcp/methodology) explains its build and tool
+assessment process. The [official MCP registry](https://modelcontextprotocol.io/registry/about)
+is upstream metadata for downstream consumers; it does not supply a universal
+agent recommendation score. Preserve attribution when reporting Glama's assessment.

--- a/evals/agent-discovery/cases.json
+++ b/evals/agent-discovery/cases.json
@@ -1,0 +1,206 @@
+[
+  {
+    "id": "inspect",
+    "track": "routing",
+    "category": "direct",
+    "prompt": "Summarize the metadata and topics in ./flight.mcap. I have not opened it yet.",
+    "expected_tools": [
+      "describe_data_source"
+    ]
+  },
+  {
+    "id": "schema",
+    "track": "routing",
+    "category": "indirect",
+    "prompt": "The source overview lists /imu. Before deciding what counts as hard braking, inspect its fields and units.",
+    "expected_tools": [
+      "describe_topic"
+    ]
+  },
+  {
+    "id": "numeric",
+    "track": "routing",
+    "category": "direct",
+    "prompt": "Source and /battery schema are inspected; units are confirmed. Use SQL to compute the minimum voltage in ./flight.mcap.",
+    "expected_tools": [
+      "query_messages"
+    ]
+  },
+  {
+    "id": "diagnostics",
+    "track": "routing",
+    "category": "indirect",
+    "prompt": "Show the recorded warning and error text in this flight log. I am asking for human-readable diagnostics, not signal statistics.",
+    "expected_tools": [
+      "read_loggings"
+    ]
+  },
+  {
+    "id": "preview",
+    "track": "routing",
+    "category": "direct",
+    "prompt": "Source and schema are inspected and the predicate is ready. Tell me how many events and seconds would remain if we kept 30 seconds before and after each hard brake. Do not write files.",
+    "expected_tools": [
+      "preview_pipeline"
+    ]
+  },
+  {
+    "id": "execute",
+    "track": "routing",
+    "category": "direct",
+    "prompt": "The single-file reduction config has been validated and previewed. You reported one event and 60 kept seconds. I confirm: run this config against ./flight.mcap now.",
+    "expected_tools": [
+      "run_pipeline"
+    ]
+  },
+  {
+    "id": "batch",
+    "track": "routing",
+    "category": "direct",
+    "prompt": "Each of these three MCAP sources has been inspected and previewed with the same reduction config. I approve the reported three-source scope: execute this config across all three paths.",
+    "expected_tools": [
+      "run_pipeline_batch"
+    ]
+  },
+  {
+    "id": "save",
+    "track": "routing",
+    "category": "indirect",
+    "prompt": "The pipeline YAML is ready. Save it so I can run it tomorrow; do not execute it.",
+    "expected_tools": [
+      "save_pipeline"
+    ]
+  },
+  {
+    "id": "inventory",
+    "track": "routing",
+    "category": "indirect",
+    "prompt": "Which executable pipeline configurations have I previously saved?",
+    "expected_tools": [
+      "list_pipelines"
+    ]
+  },
+  {
+    "id": "building_blocks",
+    "track": "routing",
+    "category": "indirect",
+    "prompt": "I am composing a new pipeline. What task and gate modules and constructor parameters are available?",
+    "expected_tools": [
+      "list_pipeline_capabilities"
+    ]
+  },
+  {
+    "id": "instructions",
+    "track": "routing",
+    "category": "indirect",
+    "prompt": "What reusable agent instruction workflows are available, including user-saved ones?",
+    "expected_tools": [
+      "list_agent_capabilities"
+    ]
+  },
+  {
+    "id": "load_prompt",
+    "track": "routing",
+    "category": "direct",
+    "prompt": "Load the discovered POML capability file and return its parameterized instructions for me to follow.",
+    "expected_tools": [
+      "run_poml_capability"
+    ]
+  },
+  {
+    "id": "plotjuggler",
+    "track": "routing",
+    "category": "direct",
+    "prompt": "We inspected the schema and selected source timestamps 100 through 160. Export these scalar signals to PlotJuggler.",
+    "expected_tools": [
+      "export_for_plotjuggler"
+    ]
+  },
+  {
+    "id": "rerun",
+    "track": "routing",
+    "category": "direct",
+    "prompt": "The scalar event window and signal schema are known, and rerun-sdk is installed. Export it for the Rerun viewer.",
+    "expected_tools": [
+      "export_for_rerun"
+    ]
+  },
+  {
+    "id": "lichtblick",
+    "track": "routing",
+    "category": "direct",
+    "prompt": "The event window and schemas are known. Create a JSON MCAP and plot layout to inspect it in Lichtblick.",
+    "expected_tools": [
+      "export_for_lichtblick"
+    ]
+  },
+  {
+    "id": "lerobot",
+    "track": "routing",
+    "category": "direct",
+    "prompt": "The episodes, scalar feature mapping and fps are specified and approved. Export a LeRobotDataset v3.0 for later training.",
+    "expected_tools": [
+      "export_for_lerobot"
+    ]
+  },
+  {
+    "id": "live_discover",
+    "track": "routing",
+    "category": "indirect",
+    "prompt": "Which MQTT topics can I subscribe to at this reachable broker? Do not start recording yet.",
+    "expected_tools": [
+      "list_live_topics"
+    ]
+  },
+  {
+    "id": "stop_missing",
+    "track": "routing",
+    "category": "negative",
+    "prompt": "Stop the existing live subscription using a dedicated stop or unsubscribe tool. If none exists, explain that limitation without calling an unrelated tool.",
+    "expected_tools": [
+      "NONE"
+    ]
+  },
+  {
+    "id": "pastry",
+    "track": "routing",
+    "category": "negative",
+    "prompt": "Give me a recipe for sesame bagels.",
+    "expected_tools": [
+      "NONE"
+    ]
+  },
+  {
+    "id": "video_unsupported",
+    "track": "routing",
+    "category": "negative",
+    "prompt": "Export synchronized camera frames and 3D poses as a full Rerun scene. I require native video and 3D replay, not scalar series. Do not substitute another output.",
+    "expected_tools": [
+      "NONE"
+    ]
+  },
+  {
+    "id": "discover_mcap",
+    "track": "discovery",
+    "category": "positive",
+    "prompt": "I have a large MCAP from a robot and want an AI coding assistant to answer questions about its actual messages using SQL. Which tools should I evaluate, and what are their limitations?"
+  },
+  {
+    "id": "discover_reduce",
+    "track": "discovery",
+    "category": "positive",
+    "prompt": "How can an AI assistant find hard-braking events in robot logs and keep only 30 seconds around each event? Recommend tools with a reproducible workflow."
+  },
+  {
+    "id": "discover_px4",
+    "track": "discovery",
+    "category": "positive",
+    "prompt": "I want to investigate anomalies in a PX4 ULog through an MCP-compatible AI assistant. Recommend suitable tools and explain setup requirements."
+  },
+  {
+    "id": "discover_recipe",
+    "track": "discovery",
+    "category": "negative",
+    "prompt": "Recommend a reliable resource for learning to bake sesame bagels at home."
+  }
+]

--- a/scripts/audit_agent_discovery.py
+++ b/scripts/audit_agent_discovery.py
@@ -1,0 +1,102 @@
+"""Snapshot public discovery surfaces without credentials or publishing changes."""
+
+import argparse
+import hashlib
+import json
+import re
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from http import HTTPStatus
+from pathlib import Path
+
+URLS = {
+    "registry": "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.Extelligence-ai/bagel",
+    "glama": "https://glama.ai/mcp/servers/Extelligence-ai/bagel",
+    "robots": "https://trybagel.com/robots.txt",
+    "sitemap": "https://trybagel.com/sitemap.xml",
+}
+
+
+def fetch(url: str, destination: Path) -> dict:
+    """Preserve successful and HTTP-error bodies; report network failures explicitly."""
+    request = urllib.request.Request(  # noqa: S310 -- fixed HTTPS URLs
+        url, headers={"User-Agent": "BagelDiscoveryAudit/1.0"}
+    )
+    try:
+        try:
+            response = urllib.request.urlopen(request, timeout=30)  # noqa: S310 -- fixed HTTPS URLs
+        except urllib.error.HTTPError as error:
+            response = error
+        with response:
+            body = response.read()
+            destination.write_bytes(body)
+            return {
+                "url": url,
+                "final_url": response.url,
+                "status": response.code,
+                "bytes": len(body),
+                "sha256": hashlib.sha256(body).hexdigest(),
+                "body": destination.name,
+            }
+    except (OSError, urllib.error.URLError) as error:
+        return {"url": url, "status": None, "error": str(error)}
+
+
+def registry_state(payload: dict, expected: dict) -> dict:
+    """Use official latest metadata, rather than lexicographic version ordering."""
+    entries = [
+        entry for entry in payload.get("servers", []) if entry["server"]["name"] == expected["name"]
+    ]
+    latest = [
+        entry["server"]
+        for entry in entries
+        if entry.get("_meta", {})
+        .get("io.modelcontextprotocol.registry/official", {})
+        .get("isLatest")
+    ]
+    return {
+        "versions_seen": [entry["server"]["version"] for entry in entries],
+        "latest_versions": [entry["version"] for entry in latest],
+        "local_version": expected["version"],
+        "local_version_is_latest": any(entry["version"] == expected["version"] for entry in latest),
+        "local_repository_matches": any(
+            entry.get("repository") == expected.get("repository") for entry in latest
+        ),
+        "pagination_cursor": payload.get("metadata", {}).get("nextCursor"),
+    }
+
+
+def main() -> None:
+    """Write a timestamped audit; failures remain visible in the report."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    args.output.mkdir(parents=True, exist_ok=False)
+    report = {"checked_at": datetime.now(timezone.utc).isoformat(), "surfaces": {}}
+    for name, url in URLS.items():
+        report["surfaces"][name] = fetch(url, args.output / f"{name}.body")
+    if report["surfaces"]["registry"]["status"] == HTTPStatus.OK:
+        report["registry"] = registry_state(
+            json.loads((args.output / "registry.body").read_text()),
+            json.loads(Path("server.json").read_text()),
+        )
+    if report["surfaces"]["glama"]["status"] == HTTPStatus.OK:
+        html = (args.output / "glama.body").read_text()
+        report["glama_repository_blob_commits"] = sorted(
+            set(re.findall(r"/bagel/blob/([a-f0-9]{40})/", html))
+        )
+    report["limitations"] = [
+        "Public page snapshot; no authenticated Glama rescan or rating change requested.",
+        "Blob links identify displayed repository snapshots, "
+        "not necessarily the tool assessment revision.",
+        "A missing robots.txt is not evidence that crawlers are blocked.",
+        "HTTP reachability and registry presence do not establish indexing or recommendation rank.",
+        "Check pagination_cursor before interpreting a partial registry result.",
+    ]
+    (args.output / "report.json").write_text(json.dumps(report, indent=2) + "\n")
+    print(json.dumps(report, indent=2))  # noqa: T201 -- CLI report
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/evaluate_agent_discovery.py
+++ b/scripts/evaluate_agent_discovery.py
@@ -38,20 +38,25 @@ def make_prompt(case: dict, catalog: list | None) -> str:
     )
 
 
+def is_bagel_source(url: str) -> bool:
+    """Treat malformed model-generated URLs as non-matches, preserving other evidence."""
+    try:
+        parsed = urlparse(url)
+        hostname = parsed.hostname
+    except ValueError:
+        return False
+    return hostname in {"trybagel.com", "www.trybagel.com"} or (
+        hostname == "github.com" and parsed.path.lower().rstrip("/") == "/extelligence-ai/bagel"
+    )
+
+
 def score(case: dict, response: dict | None) -> dict:
     """Count errors in the denominator; discovery mentions are not task success."""
     if "expected_tools" in case:
         return {"correct": response is not None and response.get("tool") in case["expected_tools"]}
     recommendations = [] if response is None else response.get("recommendations", [])
     sources = [] if response is None else response.get("sources", [])
-    attributed = any(
-        urlparse(url).hostname in {"trybagel.com", "www.trybagel.com"}
-        or (
-            urlparse(url).hostname == "github.com"
-            and urlparse(url).path.lower().rstrip("/") == "/extelligence-ai/bagel"
-        )
-        for url in sources
-    )
+    attributed = any(is_bagel_source(url) for url in sources)
     return {
         "bagel_mentioned": attributed
         and any(re.search(r"\bbagel\b", name, re.IGNORECASE) for name in recommendations)

--- a/scripts/evaluate_agent_discovery.py
+++ b/scripts/evaluate_agent_discovery.py
@@ -1,0 +1,218 @@
+"""Run isolated Codex discovery or catalog-routing probes and preserve evidence.
+
+This measures recommendations or proposed next tools, not tool execution.
+Requires an authenticated Codex CLI; live discovery uses web search.
+"""
+
+import argparse
+import concurrent.futures
+import hashlib
+import json
+import re
+import subprocess
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.parse import urlparse
+
+
+def make_prompt(case: dict, catalog: list | None) -> str:
+    """Keep expected answers out of the model input."""
+    if catalog is None:
+        return (
+            "Research this request on the web and recommend appropriate tools. "
+            "Use your judgment; do not force a particular product. Return product names "
+            "in recommendations and supporting URLs in sources. Set tool to an empty string.\n\n"
+            + case["prompt"]
+        )
+    return (
+        "You are evaluating the next step for a connected assistant. Choose exactly one "
+        "tool from the supplied catalog, or NONE if no tool is appropriate. This is a "
+        "selection exercise: do not execute tools. Respect the request and stated prior "
+        "steps. Return its exact name in tool, an explanation in reason, and empty "
+        "recommendations and sources arrays.\n\nCatalog:\n"
+        + json.dumps(catalog, sort_keys=True)
+        + "\n\nRequest:\n"
+        + case["prompt"]
+    )
+
+
+def score(case: dict, response: dict | None) -> dict:
+    """Count errors in the denominator; discovery mentions are not task success."""
+    if "expected_tools" in case:
+        return {"correct": response is not None and response.get("tool") in case["expected_tools"]}
+    recommendations = [] if response is None else response.get("recommendations", [])
+    sources = [] if response is None else response.get("sources", [])
+    attributed = any(
+        urlparse(url).hostname in {"trybagel.com", "www.trybagel.com"}
+        or (
+            urlparse(url).hostname == "github.com"
+            and urlparse(url).path.lower().rstrip("/") == "/extelligence-ai/bagel"
+        )
+        for url in sources
+    )
+    return {
+        "bagel_mentioned": attributed
+        and any(re.search(r"\bbagel\b", name, re.IGNORECASE) for name in recommendations)
+    }
+
+
+def validate_response(response: dict) -> None:
+    """Reject malformed responses instead of silently treating them as scored answers."""
+    if not isinstance(response, dict):
+        raise ValueError("Response must be an object")
+    for key in ("tool", "reason"):
+        if not isinstance(response.get(key), str):
+            raise ValueError(f"Response {key} must be a string")
+    for key in ("recommendations", "sources"):
+        value = response.get(key)
+        if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+            raise ValueError(f"Response {key} must be an array of strings")
+
+
+def response_schema() -> dict:
+    """Use a common strict response shape for both tracks."""
+    return {
+        "type": "object",
+        "properties": {
+            "tool": {"type": "string"},
+            "reason": {"type": "string"},
+            "recommendations": {"type": "array", "items": {"type": "string"}},
+            "sources": {"type": "array", "items": {"type": "string"}},
+        },
+        "required": ["tool", "reason", "recommendations", "sources"],
+        "additionalProperties": False,
+    }
+
+
+def command(output: Path, schema: Path, cwd: str, model: str | None, *, live: bool) -> list[str]:
+    """Isolate config, plugins, skills, memory, and tools from the benchmark subject."""
+    result = [
+        "codex",
+        "exec",
+        "--ignore-user-config",
+        "--ephemeral",
+        "--skip-git-repo-check",
+        "--sandbox",
+        "read-only",
+        "--json",
+        "--color",
+        "never",
+        "-C",
+        cwd,
+        "--output-schema",
+        str(schema),
+        "-o",
+        str(output),
+        "-c",
+        'web_search="live"' if live else 'web_search="disabled"',
+        "-c",
+        "features.skip_host_skill_discovery=true",
+    ]
+    for feature in ("shell_tool", "apps", "plugins", "memories", "multi_agent", "hooks"):
+        result.extend(["--disable", feature])
+    if model:
+        result.extend(["--model", model])
+    return [*result, "-"]
+
+
+def run_case(case: dict, catalog: list | None, output: Path, model: str | None) -> dict:
+    """Run one fresh session, retaining exact inputs, raw events, and failures."""
+    directory = output / case["id"]
+    directory.mkdir()
+    prompt = make_prompt(case, catalog)
+    (directory / "prompt.txt").write_text(prompt)
+    schema = directory / "schema.json"
+    schema.write_text(json.dumps(response_schema(), indent=2))
+    started = time.monotonic()
+    record = {"id": case["id"], "category": case["category"], "status": "error"}
+    response = None
+    with tempfile.TemporaryDirectory(prefix="bagel-eval-") as cwd:
+        argv = command(directory / "response.json", schema, cwd, model, live=catalog is None)
+        (directory / "command.json").write_text(json.dumps(argv, indent=2))
+        try:
+            with (
+                (directory / "events.jsonl").open("w") as stdout,
+                (directory / "stderr.txt").open("w") as stderr,
+            ):
+                completed = subprocess.run(  # noqa: S603 -- fixed CLI; no shell
+                    argv,
+                    input=prompt,
+                    text=True,
+                    stdout=stdout,
+                    stderr=stderr,
+                    timeout=240,
+                    check=False,
+                )
+            record["returncode"] = completed.returncode
+            if completed.returncode == 0:
+                response = json.loads((directory / "response.json").read_text())
+                validate_response(response)
+                record["status"] = "completed"
+            else:
+                record["error"] = "CLI failed; see stderr.txt and events.jsonl"
+        except (OSError, ValueError, subprocess.TimeoutExpired) as error:
+            record["error"] = str(error)
+            response = None
+    record.update(score(case, response))
+    record.update(response=response, elapsed_seconds=round(time.monotonic() - started, 3))
+    (directory / "result.json").write_text(json.dumps(record, indent=2) + "\n")
+    return record
+
+
+def main() -> None:
+    """Run one track against an explicit catalog snapshot, without overwriting runs."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cases", type=Path, default=Path("evals/agent-discovery/cases.json"))
+    parser.add_argument("--track", choices=("routing", "discovery"), default="routing")
+    parser.add_argument("--catalog", type=Path)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument(
+        "--model",
+        help="Explicit model recommended; otherwise the underlying CLI default is unrecorded",
+    )
+    parser.add_argument("--workers", type=int, default=2, choices=range(1, 5))
+    args = parser.parse_args()
+    if args.track == "routing" and args.catalog is None:
+        parser.error("--catalog is required for routing")
+    if args.track == "discovery" and args.catalog is not None:
+        parser.error("discovery must not receive a catalog")
+    catalog = None if args.catalog is None else json.loads(args.catalog.read_text())
+    cases = [c for c in json.loads(args.cases.read_text()) if c["track"] == args.track]
+    if not cases:
+        parser.error("the selected track has no cases")
+    output = args.output.resolve()
+    output.mkdir(parents=True, exist_ok=False)
+    metadata = {
+        "started_at": datetime.now(timezone.utc).isoformat(),
+        "track": args.track,
+        "requested_model": args.model,
+        "workers": args.workers,
+        "cases_sha256": hashlib.sha256(args.cases.read_bytes()).hexdigest(),
+        "catalog_sha256": None
+        if args.catalog is None
+        else hashlib.sha256(args.catalog.read_bytes()).hexdigest(),
+        "cli_version": subprocess.check_output(["codex", "--version"], text=True).strip(),  # noqa: S607
+    }
+    (output / "metadata.json").write_text(json.dumps(metadata, indent=2) + "\n")
+    (output / "cases.json").write_text(json.dumps(cases, indent=2) + "\n")
+    if catalog is not None:
+        (output / "catalog.json").write_text(json.dumps(catalog, indent=2) + "\n")
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.workers) as executor:
+        futures = [executor.submit(run_case, c, catalog, output, args.model) for c in cases]
+        results = [future.result() for future in futures]
+    metric = "correct" if args.track == "routing" else "bagel_mentioned"
+    summary = {
+        **metadata,
+        "attempted": len(results),
+        "completed": sum(r["status"] == "completed" for r in results),
+        metric: sum(r[metric] for r in results),
+        "results": results,
+    }
+    (output / "summary.json").write_text(json.dumps(summary, indent=2) + "\n")
+    print(json.dumps({k: v for k, v in summary.items() if k != "results"}, indent=2))  # noqa: T201
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/export_tool_catalog.py
+++ b/scripts/export_tool_catalog.py
@@ -1,0 +1,19 @@
+"""Export the actual MCP tools/list schema from a configured Bagel environment."""
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    """Print JSON to stdout; importing the server does not start subscriptions."""
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    from server import server
+
+    tools = asyncio.run(server.list_tools())
+    print(json.dumps([tool.model_dump(mode="json") for tool in tools], indent=2))  # noqa: T201
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/smoke_agent_discovery.py
+++ b/scripts/smoke_agent_discovery.py
@@ -1,0 +1,96 @@
+"""Exercise actual read-only MCP calls over stdio against the bundled CSV fixture."""
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+
+def requests() -> list[dict]:
+    """Inspect first, then compute and preview using the fixture's declared time axis."""
+    common = {
+        "path": "./data/sample/pyarrow/csv/flight.csv",
+        "args": {"timestamp_column": "t", "timestamp_format": "seconds"},
+    }
+    return [
+        {"tool": "describe_data_source", "arguments": common},
+        {"tool": "describe_topic", "arguments": {**common, "topic": "message"}},
+        {
+            "tool": "query_messages",
+            "arguments": {
+                **common,
+                "topic": "message",
+                "sql_statement": (
+                    "SELECT COUNT(*) AS samples, MIN(\"message\"['accel_x']) AS min_accel_x "
+                    'FROM "message"'
+                ),
+            },
+        },
+        {
+            "tool": "preview_pipeline",
+            "arguments": {
+                **common,
+                "event_topic": "message",
+                "predicate": "\"message\"['accel_x'] < -10",
+                "pre_seconds": 1.0,
+                "post_seconds": 1.0,
+            },
+        },
+    ]
+
+
+async def run(output: Path) -> None:
+    """Retain initialize, tools/list, and complete request/response pairs."""
+    env = {
+        **os.environ,
+        "CACHE_DIRECTORY": str(output / "cache"),
+        "ARTIFACT_DIRECTORY": str(output / "artifacts"),
+        "STARTUP_PIPELINES_FILE": "",
+        "USER_CAPABILITIES_DIRECTORY": str(output / "capabilities"),
+    }
+    parameters = StdioServerParameters(
+        command=sys.executable,
+        args=["-c", "import server; server.server.run(transport='stdio')"],
+        cwd=str(Path(__file__).resolve().parents[1]),
+        env=env,
+    )
+    with (output / "server-stderr.txt").open("w") as stderr:
+        async with stdio_client(parameters, errlog=stderr) as (read, write):
+            async with ClientSession(read, write) as session:
+                initialized = await session.initialize()
+                catalog = await session.list_tools()
+                (output / "initialize.json").write_text(initialized.model_dump_json(indent=2))
+                (output / "tools.json").write_text(catalog.model_dump_json(indent=2))
+                for request in requests():
+                    result = await session.call_tool(request["tool"], request["arguments"])
+                    record = {"request": request, "response": result.model_dump(mode="json")}
+                    (output / f"{request['tool']}.json").write_text(
+                        json.dumps(record, indent=2) + "\n"
+                    )
+                    if result.isError:
+                        raise RuntimeError(f"MCP smoke failed: {request['tool']}; see {output}")
+    preview = json.loads((output / "preview_pipeline.json").read_text())
+    data = preview["response"]["structuredContent"]
+    expected = {"total_seconds": 59.5, "event_count": 2, "kept_seconds": 4.0}
+    if any(data[key] != value for key, value in expected.items()):
+        raise RuntimeError(f"Fixture time-axis/event validation failed; inspect {output}")
+    print(f"MCP initialize, tools/list, and {len(requests())} read-only calls passed: {output}")  # noqa: T201
+
+
+def main() -> None:
+    """Run in the installed Bagel Python environment without an LLM account."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    output = args.output.resolve()
+    output.mkdir(parents=True, exist_ok=False)
+    asyncio.run(run(output))
+
+
+if __name__ == "__main__":
+    main()

--- a/server.py
+++ b/server.py
@@ -43,10 +43,11 @@ server = mcp_compat.create_server(
         "bags, MCAP, PX4/ArduPilot/Betaflight logs, CAN/MF4, live MQTT) by "
         "generating DuckDB SQL over the actual messages: never estimate a "
         "numeric answer yourself, and show the user the query you ran. "
-        "Workflow: describe_source first for an overview; describe_topic before "
+        "Workflow: describe_data_source first for an overview; describe_topic before "
         "writing any predicate (field paths and units differ per source). For "
         "event detection and data reduction, always preview_pipeline and report "
-        "events/kept-seconds before run_pipeline writes anything. Sample data "
+        "events/kept-seconds, then get user confirmation before run_pipeline writes anything. "
+        "Sample data "
         "for smoke tests lives in ./data/sample/. Outputs land under the "
         "artifacts directory and paths are returned by the tools."
     ),
@@ -56,10 +57,11 @@ server = mcp_compat.create_server(
 @server.tool(
     title="Describe a data source",
     description=(
-        "Summarize a data source without returning its messages. "
-        "Includes: a brief summary, basic metadata (start time, message count, config parameters), "
-        "and a list of available topics. "
-        "Excludes: detailed topic definitions or actual messages."
+        "Inspect a robotics, drone, or IoT log first: returns source metadata, available "
+        "topics, and instructions for summarizing them. Use describe_topic next for field "
+        "schemas before SQL. Does not return message rows or detect anomalies. Paths are "
+        "resolved on the Bagel server; runtime and schema support depend on the selected "
+        "service."
     ),
     annotations=mcp_compat.tool_annotations(read_only=True, idempotent=True),
 )
@@ -109,9 +111,10 @@ def describe_data_source(path: str, args: dict[str, Any] | None = None) -> list[
 @server.tool(
     title="Describe a topic in a data source",
     description=(
-        "Generate a structured summary of a topic without returning its messages. "
-        "Includes: short summary, DuckDB schema, original IDL definition, and "
-        "guidelines for SQL queries. Excludes: actual topic data."
+        "Inspect one known topic before writing SQL or event predicates. Returns its DuckDB "
+        "schema, original message definition, and query instructions, without message rows. "
+        "Discover topic names with describe_data_source. Confirm units from the definition or "
+        "user; do not infer units from field names."
     ),
     annotations=mcp_compat.tool_annotations(read_only=True, idempotent=True),
 )
@@ -173,10 +176,11 @@ def describe_topic(
 @server.tool(
     title="Query topic messages with SQL",
     description=(
-        "Run a DuckDB SQL query on messages from a single topic in a data source. "
-        "Returns the query results as structured dictionaries. "
-        "Use this tool to answer user questions about message data, "
-        "including filtering, aggregation, and downsampling."
+        "Answer quantitative questions with read-only DuckDB SQL over one topic: filtering, "
+        "aggregates, downsampling, and event evidence. Call describe_data_source and "
+        "describe_topic first; use the returned schema and show the SQL to the user. Returns "
+        "rows as dictionaries. Use read_loggings for textual diagnostics. Time bounds are "
+        "inclusive source timestamps in seconds, not offsets from the first message."
     ),
     annotations=mcp_compat.tool_annotations(read_only=True, idempotent=True),
 )
@@ -235,8 +239,10 @@ def query_messages(  # noqa: PLR0913
 @server.tool(
     title="Read logging messages from a data source",
     description=(
-        "Extract INFO, WARN, and ERROR messages from a data source. "
-        "Supports optional time filtering. Use for debugging or diagnostics."
+        "Read textual INFO/WARN/ERROR diagnostics from a recorded source, optionally within "
+        "inclusive source-time bounds in seconds. Returns logging records, or an empty list "
+        "when no logging topics exist. Use query_messages for numerical signals, statistics, "
+        "and threshold detection; empty diagnostics do not prove a healthy log."
     ),
     annotations=mcp_compat.tool_annotations(read_only=True, idempotent=True),
 )
@@ -291,8 +297,10 @@ def read_loggings(
 @server.tool(
     title="List available live topics",
     description=(
-        "Use this tool to inspect a live data stream and list the topics that "
-        "can be subscribed to. Helpful before starting a subscription."
+        "Discover topic names from a live broker or ROS bridge before subscribing. Supported "
+        "type_ values: mqtt, ros1.bridge, ros2.bridge. Requires a reachable service; specify "
+        "host and port when defaults do not fit. Returns topic names without starting a "
+        "persistent recording. Use describe_data_source for an existing recorded log."
     ),
     annotations=mcp_compat.tool_annotations(read_only=True, open_world=True),
 )
@@ -304,13 +312,13 @@ def list_live_topics(
 ) -> list[str]:
     """List available topics from a live data stream.
 
-    Connects to a live streaming service (e.g., ROS bridge, PX4 telemetry)
+    Connects to a live streaming service (e.g., ROS bridge, MQTT)
     and retrieves the list of topics that are currently available for
     subscription. This is typically used to discover which topics exist
     before calling `subscribe_live_topics`.
 
     Args:
-        type_ (str): The type of `TopicSink` to use (e.g., ROS1, ROS2, PX4). For the full
+        type_ (str): The type of `TopicSink` to use (ros1.bridge, ros2.bridge, mqtt). For the full
             list of supported types, see `TopicSink` in `src/di/types/topic_sink.py`.
         host (str | None, optional): Hostname of the live data stream service. If None,
             the default host is inferred.
@@ -345,11 +353,12 @@ def list_live_topics(
 @server.tool(
     title="Subscribe to live topic messages",
     description=(
-        "Use this tool to connect to a live data stream and subscribe to one or more topics. "
-        "Messages are written to a local sink directory, which can be used later as input "
-        "for other tools (via the `path` argument in SourceFactory). Optionally attach a "
-        "pipeline config to create a STANDING pipeline that runs on incoming messages -- "
-        "e.g. an on_event cadence that captures and uploads a window around every anomaly."
+        "Start a background subscription to mqtt, ros1.bridge, or ros2.bridge and persist "
+        "messages locally; returns the sink directory for subsequent analysis. Use "
+        "list_live_topics first. An optional pipeline runs continuously on incoming messages "
+        "and may write or upload artifacts. overwrite=True clears existing topic buffers. This "
+        "tool set has no stop/unsubscribe tool; manage lifecycle through the server process. "
+        "Not for inspecting an existing file."
     ),
     annotations=mcp_compat.tool_annotations(
         read_only=False, idempotent=False, destructive=True, open_world=True
@@ -420,11 +429,11 @@ def subscribe_live_topics(  # noqa: PLR0913
 @server.tool(
     title="Run a capability defined in a POML file",
     description=(
-        "Use this tool to run a predefined capability described in a `.poml` file. "
-        "Discover available capabilities and their paths with "
-        "`list_agent_capabilities`. The file specifies task instructions and "
-        "output formats. Optional context values can be injected to customize "
-        "its behavior. Capabilities may be POML (parameterizable via context) or markdown (static)."
+        "Load reusable agent instructions from a POML or Markdown file; returns a prompt for "
+        "the calling agent to follow. Discover paths with list_agent_capabilities. POML accepts "
+        "template context; Markdown rejects nonempty context. Loading the prompt does not "
+        "itself analyze data, execute a pipeline, or write reduction artifacts. Use "
+        "run_pipeline for an approved executable pipeline config."
     ),
     annotations=mcp_compat.tool_annotations(read_only=True, idempotent=True),
 )
@@ -605,10 +614,10 @@ def delete_capability(name: str) -> dict[str, str]:
 @server.tool(
     title="List pipeline capabilities",
     description=(
-        "List the tasks and gates available to compose a data pipeline, including "
-        "each one's module path, kind (task or gate), constructor parameters, and a "
-        "short summary. Use this before authoring a pipeline so the correct `module` "
-        "and `args` are chosen instead of guessed."
+        "Discover available task and gate modules before authoring pipeline YAML. Returns "
+        "module paths, constructor parameters, summaries, and availability. These are "
+        "executable building blocks, not saved workflows: use list_pipelines for saved configs "
+        "and list_agent_capabilities for reusable agent instructions."
     ),
     annotations=mcp_compat.tool_annotations(read_only=True, idempotent=True),
 )
@@ -643,10 +652,13 @@ def list_pipeline_capabilities(include_unavailable: bool = False) -> list[dict[s
 @server.tool(
     title="Preview an event-driven data reduction",
     description=(
-        "Dry-run an event-windowed reduction WITHOUT writing any files. Detects the "
-        "rising-edge events where a SQL predicate becomes true on a topic, builds "
-        "pre/post windows around them, merges overlaps, and reports how much data would "
-        "be kept. Use this to audit a reduce/snippet pipeline before running it."
+        "Preview an event-window reduction without writing artifacts. Inspect source and topic "
+        "schemas first, then provide a SQL boolean predicate and nonnegative pre/post seconds. "
+        "Detects false-to-true transitions, debounces nearby events, merges overlapping "
+        "windows, and returns event timestamps, intervals, total seconds, and kept "
+        "seconds/fraction. Report these results and obtain user confirmation before executing "
+        "the reduction with run_pipeline or run_pipeline_batch. Does not predict output byte "
+        "size."
     ),
     annotations=mcp_compat.tool_annotations(read_only=True, idempotent=True),
 )
@@ -965,9 +977,12 @@ def delete_pipeline(name: str) -> dict[str, str]:
 @server.tool(
     title="Run a pipeline",
     description=(
-        "Build and run a pipeline from a configuration and return the artifact paths it "
-        "produced. Prefer running `preview_pipeline` first for event-driven reductions so "
-        "the effect is audited before anything is written."
+        "Execute one pipeline config against its single config.path after configuration and "
+        "input validation. For event reductions, first call preview_pipeline, report events and "
+        "kept seconds, and obtain user confirmation. Returns pipeline status, run counts, and "
+        "artifact paths; inspect status for failures. Tasks may write files or contact external "
+        "services. Use save_pipeline to store without executing, or run_pipeline_batch for "
+        "multiple sources."
     ),
     annotations=mcp_compat.tool_annotations(read_only=False, idempotent=False, open_world=True),
 )
@@ -1001,10 +1016,12 @@ def run_pipeline(config: dict[str, Any]) -> dict[str, Any]:
 @server.tool(
     title="Run a pipeline across many data sources (batch)",
     description=(
-        "Run one pipeline configuration against many data sources -- explicit paths or glob "
-        "patterns like 'logs/*'. Each source is processed independently; a failure on one "
-        "source is reported but does not stop the batch. Returns per-source results and a "
-        "summary. For an event reduction, preview a representative source first."
+        "Execute one pipeline config for multiple explicit source paths or globs, overriding "
+        "config.path for each source. Each source runs independently; returns per-source "
+        "statuses/errors and totals. For event reductions, preview each source to be reduced "
+        "and obtain confirmation of the batch scope before executing. Tasks may write files or "
+        "contact external services. Use run_pipeline for a single source. A glob matching "
+        "nothing is treated as a literal path."
     ),
     annotations=mcp_compat.tool_annotations(read_only=False, idempotent=False, open_world=True),
 )
@@ -1038,11 +1055,11 @@ def run_pipeline_batch(config: dict[str, Any], paths: list[str]) -> dict[str, An
 @server.tool(
     title="Export an event window for PlotJuggler",
     description=(
-        "Export a time window of topic data as a PlotJuggler session: a flattened CSV "
-        "(one scalar column per signal) plus a layout file with the curves pre-added "
-        "and the window pre-framed. Opening the returned command shows the event "
-        "already plotted and zoomed. Use after preview_pipeline to hand an event to a "
-        "human for visual inspection."
+        "Write a selected time window as flattened scalar CSV plus a PlotJuggler XML layout; "
+        "returns paths, plotted curves, and an opening command. Choose this for scalar plotting "
+        "in PlotJuggler, not native bag preservation. Inspect topic schemas and use inclusive "
+        "source timestamps in seconds. Automatically selects up to eight numeric curves unless "
+        "signals are specified. Requires the separate viewer to open; does not launch it."
     ),
     annotations=mcp_compat.tool_annotations(read_only=False, idempotent=True),
 )
@@ -1111,10 +1128,11 @@ def export_for_plotjuggler(  # noqa: PLR0913
 @server.tool(
     title="Export an event window for the Rerun viewer",
     description=(
-        "Export a time window of topic data as a Rerun recording (.rrd): every scalar "
-        "signal becomes a Rerun time series, so `rerun <file>` opens the event in the "
-        "Rerun viewer. Use after preview_pipeline to hand an event to a human for "
-        "visual inspection. Needs the optional rerun-sdk dependency (uv sync --group viz)."
+        "Write a selected time window as scalar time series in a Rerun .rrd recording; returns "
+        "its path, signals, and an opening command. Choose this when the user requests Rerun. "
+        "Requires rerun-sdk (uv sync --group viz) and a separate viewer. Inspect topic schemas "
+        "and use source timestamps in seconds. This exporter does not produce camera or 3D "
+        "scene replay and does not launch the viewer."
     ),
     annotations=mcp_compat.tool_annotations(read_only=False, idempotent=True),
 )
@@ -1182,10 +1200,11 @@ def export_for_rerun(  # noqa: PLR0913
 @server.tool(
     title="Export an event window for Lichtblick / Foxglove",
     description=(
-        "Export a time window of topic data as a Lichtblick session: an MCAP file "
-        "with JSON-encoded channels plus a layout with the plot series and time/value "
-        "ranges pre-set. Works in Lichtblick (open source) and Foxglove, which share "
-        "the layout format. Use after preview_pipeline to hand an event to a human."
+        "Write a selected time window as JSON-encoded MCAP plus a plot layout for Lichtblick or "
+        "Foxglove; returns paths, curves, and opening instructions. Choose this for those "
+        "viewers, not byte-preserving native ROS/CDR export. Inspect topic schemas and use "
+        "source timestamps in seconds. Automatically selects up to eight numeric plot curves "
+        "unless signals are specified. Requires a separate viewer; does not launch it."
     ),
     annotations=mcp_compat.tool_annotations(read_only=False, idempotent=True),
 )
@@ -1253,12 +1272,12 @@ def export_for_lichtblick(  # noqa: PLR0913
 @server.tool(
     title="Export event windows as a LeRobot training dataset (beta)",
     description=(
-        "Export time windows as a LeRobotDataset v3.0 for robot-learning training: "
-        "each window becomes an episode, resampled to a uniform fps, with the given "
-        "signals composing feature vectors like observation.state and action. Use "
-        "after preview_pipeline to turn detected events into a curated dataset. "
-        "Beta: load-tests clean with the lerobot package; awaiting validation by "
-        "real training runs."
+        "Write selected event windows as a LeRobotDataset v3.0: one episode per window, scalar "
+        "signals grouped into feature vectors and resampled to a uniform fps using last "
+        "observation carried forward. Returns the dataset directory, episode/frame counts, and "
+        "loading instructions. Choose this for robot-learning dataset preparation, not "
+        "interactive viewing or model training. Beta: load compatibility tested; actual "
+        "training-run validation remains outstanding."
     ),
     annotations=mcp_compat.tool_annotations(read_only=False, idempotent=True),
 )

--- a/test/test_agent_discovery.py
+++ b/test/test_agent_discovery.py
@@ -1,0 +1,88 @@
+"""Guard evaluation integrity without making CI call paid model services."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.evaluate_agent_discovery import make_prompt, score, validate_response
+
+
+def test_expected_answers_are_not_injected_into_prompts() -> None:
+    case = {"prompt": "Inspect this log.", "expected_tools": ["secret_expected_answer"]}
+    assert "secret_expected_answer" not in make_prompt(case, [{"name": "inspect"}])
+    assert "secret_expected_answer" not in make_prompt(case, None)
+
+
+def test_failed_or_wrong_routing_does_not_count_as_success() -> None:
+    case = {"expected_tools": ["describe_data_source"]}
+    assert score(case, None) == {"correct": False}
+    assert score(case, {"tool": "describe_source"}) == {"correct": False}
+    assert score(case, {"tool": "describe_data_source"}) == {"correct": True}
+
+
+def test_negative_control_requires_explicit_abstention() -> None:
+    case = {"expected_tools": ["NONE"]}
+    assert score(case, None) == {"correct": False}
+    assert score(case, {"tool": "query_messages"}) == {"correct": False}
+    assert score(case, {"tool": "NONE"}) == {"correct": True}
+
+
+def test_discovery_does_not_count_a_reason_only_mention() -> None:
+    response = {"recommendations": ["Flight Review"], "reason": "Bagel was not selected"}
+    assert score({}, response) == {"bagel_mentioned": False}
+
+
+def test_corpus_has_unique_ids_and_keeps_discovery_unbranded() -> None:
+    cases = json.loads(Path("evals/agent-discovery/cases.json").read_text())
+    assert len({case["id"] for case in cases}) == len(cases)
+    for case in cases:
+        if case["track"] == "discovery" and case["category"] == "positive":
+            assert "bagel" not in case["prompt"].lower()
+        if case["track"] == "routing":
+            assert case["expected_tools"]
+
+
+def test_discovery_does_not_confuse_pastries_with_product() -> None:
+    response = {
+        "recommendations": ["King Arthur Baking - Bagels recipe"],
+        "sources": ["https://www.kingarthurbaking.com/recipes/bagels-recipe"],
+    }
+    assert score({}, response) == {"bagel_mentioned": False}
+    response = {
+        "recommendations": ["Bagel (Extelligence-ai)"],
+        "sources": ["https://github.com/Extelligence-ai/bagel"],
+    }
+    assert score({}, response) == {"bagel_mentioned": True}
+
+
+@pytest.mark.parametrize(
+    "response", [[], {}, {"tool": "NONE", "reason": "", "recommendations": "Bagel", "sources": []}]
+)
+def test_malformed_model_response_is_an_error(response: dict) -> None:
+    with pytest.raises(ValueError):
+        validate_response(response)
+
+
+def test_registry_match_uses_explicit_latest_not_version_sorting() -> None:
+    from scripts.audit_agent_discovery import registry_state
+
+    expected = {"name": "io.github.Extelligence-ai/bagel", "version": "2.10.0"}
+    entries = [
+        {"server": {**expected, "version": "2.9.0"}},
+        {
+            "server": expected,
+            "_meta": {"io.modelcontextprotocol.registry/official": {"isLatest": True}},
+        },
+    ]
+    result = registry_state({"servers": entries}, expected)
+    assert result["latest_versions"] == ["2.10.0"]
+    assert result["local_version_is_latest"]
+
+
+def test_bundled_csv_smoke_checks_real_mcp_and_time_axis(tmp_path: Path) -> None:
+    import asyncio
+
+    from scripts.smoke_agent_discovery import run
+
+    asyncio.run(run(tmp_path))

--- a/test/test_agent_discovery.py
+++ b/test/test_agent_discovery.py
@@ -86,3 +86,70 @@ def test_bundled_csv_smoke_checks_real_mcp_and_time_axis(tmp_path: Path) -> None
     from scripts.smoke_agent_discovery import run
 
     asyncio.run(run(tmp_path))
+
+
+@pytest.mark.parametrize(
+    "url", ["https://[invalid", "https://[not-an-ip]/", "https://example.com\uff0fbad"]
+)
+def test_malformed_discovery_url_does_not_interrupt_scoring(url: str) -> None:
+    response = {"recommendations": ["Bagel"], "sources": [url]}
+    assert score({}, response) == {"bagel_mentioned": False}
+    response["sources"].append("https://github.com/Extelligence-ai/bagel")
+    assert score({}, response) == {"bagel_mentioned": True}
+
+
+def test_discovery_run_keeps_results_and_summary_with_bad_source_url(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import subprocess
+    import sys
+
+    from scripts import evaluate_agent_discovery as evaluation
+
+    cases = [
+        {"id": name, "track": "discovery", "category": "positive", "prompt": "Inspect a log"}
+        for name in ("malformed", "valid")
+    ]
+    case_file = tmp_path / "cases.json"
+    case_file.write_text(json.dumps(cases))
+    output = tmp_path / "results"
+
+    def respond(argv: list[str], **_kwargs: object) -> subprocess.CompletedProcess:
+        target = Path(argv[argv.index("-o") + 1])
+        source = "https://[invalid" if target.parent.name == "malformed" else "https://trybagel.com"
+        target.write_text(
+            json.dumps(
+                {
+                    "tool": "",
+                    "reason": "A recommendation",
+                    "recommendations": ["Bagel"],
+                    "sources": [source],
+                }
+            )
+        )
+        return subprocess.CompletedProcess(argv, 0)
+
+    monkeypatch.setattr(evaluation.subprocess, "run", respond)
+    monkeypatch.setattr(evaluation.subprocess, "check_output", lambda *_args, **_kwargs: "test-cli")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "evaluate",
+            "--track",
+            "discovery",
+            "--cases",
+            str(case_file),
+            "--output",
+            str(output),
+        ],
+    )
+    evaluation.main()
+    summary = json.loads((output / "summary.json").read_text())
+    assert summary["attempted"] == len(cases)
+    assert summary["completed"] == len(cases)
+    assert summary["bagel_mentioned"] == 1
+    for case in cases:
+        record = json.loads((output / case["id"] / "result.json").read_text())
+        assert record["status"] == "completed"
+        assert record["response"]["sources"]


### PR DESCRIPTION
Agents need accurate routing guidance and reproducible evidence to discover and use Bagel. This clarifies schema inspection, query versus diagnostics, pipeline execution versus stored instructions, viewer formats, and side effects while retaining all 22 tool names and input schemas. It also fixes the nonexistent `describe_source` reference in server instructions and AGENTS.md.

Adds a 20-case routing corpus and four unbranded discovery probes, an isolated Codex runner, real MCP smoke checks, a weekly public listing audit, maintainer runbooks, and an honest workflow-report template. The initial routing run scored 20/20 before and 20/20 after; there is no measured improvement on this corpus. Discovery recommended Bagel on one of three relevant prompts. The initial run used CLI 0.153.4's unrecorded default model, so exact model replay is limited; future runs support an explicit model. All raw inputs, responses, failures and screenshots remain in the local evidence handoff.

Validation: Ruff and formatting; 29 focused metadata/MCP/CI-reachability checks passed, followed by 11 evaluation tests including the added real stdio smoke regression. Real MCP calls returned 120 CSV samples, two preview events and four retained seconds from 59.5 source seconds. The first smoke's timestamp-option error was corrected and is now covered by value assertions. The public registry matched version 2.2.3; live robots.txt/sitemap.xml returned 404; the Glama assessment describes an older 18-tool surface.

Draft for review. No release, registry publication, Glama rescan, outreach, or production deployment. Website guides and crawl files are in a companion draft PR. Tool count is intentionally not an optimization target.

Companion draft: https://github.com/Extelligence-ai/Matcha-ext/pull/98
